### PR TITLE
Integrate Telemetry for observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **NEW:** Telemetry integration for observability
+  - Query execution events: `[:lotus, :query, :start]`, `[:lotus, :query, :stop]`, `[:lotus, :query, :exception]`
+  - Cache operation events: `[:lotus, :cache, :hit]`, `[:lotus, :cache, :miss]`, `[:lotus, :cache, :put]`
+  - Schema introspection events: `[:lotus, :schema, :introspection, :start]`, `[:lotus, :schema, :introspection, :stop]`
+  - New `Lotus.Telemetry` module with event reference documentation
+  - Telemetry guide with setup instructions and LiveDashboard integration example
 - **NEW:** `read_only: false` option for `run_sql` — disables the application-level deny list, allowing write queries (INSERT, UPDATE, DELETE, DDL). Single-statement validation and visibility rules still apply.
 - **NEW:** AI-generated query variable configurations alongside SQL
   - LLM can now produce `{{variable}}` placeholders with full variable metadata (type, widget, label, default, list, static_options, options_query)

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -1,0 +1,138 @@
+# Telemetry
+
+Lotus emits [`:telemetry`](https://hex.pm/packages/telemetry) events for query
+execution, cache operations, and schema introspection. These events integrate
+with monitoring tools like Phoenix LiveDashboard, AppSignal, Datadog, and others.
+
+## Events
+
+### Query Execution
+
+| Event                         | Measurements                   | Metadata                                      |
+|-------------------------------|--------------------------------|-----------------------------------------------|
+| `[:lotus, :query, :start]`    | `system_time`                  | `repo`, `sql`, `params`                       |
+| `[:lotus, :query, :stop]`     | `duration`, `row_count`        | `repo`, `sql`, `params`, `result`             |
+| `[:lotus, :query, :exception]`| `duration`                     | `repo`, `sql`, `params`, `kind`, `reason`, `stacktrace` |
+
+Duration is measured in native time units. Use `System.convert_time_unit/3` to
+convert to milliseconds or microseconds.
+
+### Cache Operations
+
+| Event                      | Measurements | Metadata       |
+|----------------------------|--------------|----------------|
+| `[:lotus, :cache, :hit]`   | `count`      | `key`          |
+| `[:lotus, :cache, :miss]`  | `count`      | `key`          |
+| `[:lotus, :cache, :put]`   | `count`      | `key`, `ttl_ms`|
+
+### Schema Introspection
+
+| Event                                       | Measurements  | Metadata                    |
+|---------------------------------------------|---------------|-----------------------------|
+| `[:lotus, :schema, :introspection, :start]` | `system_time` | `operation`, `repo`         |
+| `[:lotus, :schema, :introspection, :stop]`  | `duration`    | `operation`, `repo`, `result` |
+
+The `operation` field is one of: `:list_schemas`, `:list_tables`,
+`:get_table_schema`, `:get_table_stats`, or `:list_relations`.
+
+## Setup
+
+Attach handlers in your application's `start/2` callback:
+
+```elixir
+# lib/my_app/application.ex
+def start(_type, _args) do
+  :telemetry.attach_many(
+    "lotus-telemetry",
+    [
+      [:lotus, :query, :stop],
+      [:lotus, :query, :exception],
+      [:lotus, :cache, :hit],
+      [:lotus, :cache, :miss]
+    ],
+    &MyApp.LotusInstrumentation.handle_event/4,
+    nil
+  )
+
+  children = [
+    # ...
+  ]
+
+  Supervisor.start_link(children, strategy: :one_for_one)
+end
+```
+
+## Example Handler
+
+```elixir
+defmodule MyApp.LotusInstrumentation do
+  require Logger
+
+  def handle_event([:lotus, :query, :stop], measurements, metadata, _config) do
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+
+    Logger.info(
+      "Lotus query completed",
+      duration_ms: duration_ms,
+      row_count: measurements.row_count,
+      repo: inspect(metadata.repo)
+    )
+  end
+
+  def handle_event([:lotus, :query, :exception], measurements, metadata, _config) do
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+
+    Logger.error(
+      "Lotus query failed",
+      duration_ms: duration_ms,
+      reason: inspect(metadata.reason),
+      repo: inspect(metadata.repo)
+    )
+  end
+
+  def handle_event([:lotus, :cache, :hit], _measurements, metadata, _config) do
+    Logger.debug("Lotus cache hit", key: metadata.key)
+  end
+
+  def handle_event([:lotus, :cache, :miss], _measurements, metadata, _config) do
+    Logger.debug("Lotus cache miss", key: metadata.key)
+  end
+end
+```
+
+## Phoenix LiveDashboard Integration
+
+If you use [Phoenix LiveDashboard](https://hex.pm/packages/phoenix_live_dashboard),
+you can add Lotus metrics to your telemetry supervisor:
+
+```elixir
+# lib/my_app_web/telemetry.ex
+defp metrics do
+  [
+    # Lotus query metrics
+    summary("lotus.query.stop.duration",
+      unit: {:native, :millisecond},
+      description: "Lotus query execution time"
+    ),
+    counter("lotus.query.stop.duration",
+      description: "Total Lotus queries executed"
+    ),
+    counter("lotus.query.exception.duration",
+      description: "Total Lotus query failures"
+    ),
+
+    # Cache metrics
+    counter("lotus.cache.hit.count",
+      description: "Lotus cache hits"
+    ),
+    counter("lotus.cache.miss.count",
+      description: "Lotus cache misses"
+    )
+  ]
+end
+```
+
+## Event Reference
+
+For the complete list of events, measurements, and metadata fields, see
+`Lotus.Telemetry`.

--- a/lib/lotus/cache.ex
+++ b/lib/lotus/cache.ex
@@ -3,28 +3,59 @@ defmodule Lotus.Cache do
   Lotus cache facade. If no adapter configured, acts as a no-op pass-through.
   """
 
-  alias Lotus.Config
+  alias Lotus.{Config, Telemetry}
 
   def enabled?, do: match?({:ok, _}, adapter())
 
   def get(key) do
     case adapter() do
-      {:ok, adapter} -> adapter.get(ns(key))
-      _ -> :miss
+      {:ok, adapter} ->
+        case adapter.get(ns(key)) do
+          {:ok, _} = hit ->
+            Telemetry.cache_hit(key)
+            hit
+
+          :miss ->
+            Telemetry.cache_miss(key)
+            :miss
+        end
+
+      _ ->
+        :miss
     end
   end
 
   def get_or_store(key, ttl_ms, fun, opts \\ []) do
     case adapter() do
-      {:ok, adapter} -> adapter.get_or_store(ns(key), ttl_ms, fun, opts)
-      _ -> {:ok, fun.(), :miss}
+      {:ok, adapter} ->
+        case adapter.get_or_store(ns(key), ttl_ms, fun, opts) do
+          {:ok, _val, :hit} = result ->
+            Telemetry.cache_hit(key)
+            result
+
+          {:ok, _val, _miss_or_other} = result ->
+            Telemetry.cache_miss(key)
+            Telemetry.cache_put(key, ttl_ms)
+            result
+
+          other ->
+            other
+        end
+
+      _ ->
+        {:ok, fun.(), :miss}
     end
   end
 
   def put(key, value, ttl_ms, opts \\ []) do
     case adapter() do
-      {:ok, adapter} -> adapter.put(ns(key), value, ttl_ms, opts)
-      _ -> :ok
+      {:ok, adapter} ->
+        result = adapter.put(ns(key), value, ttl_ms, opts)
+        Telemetry.cache_put(key, ttl_ms)
+        result
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -7,7 +7,7 @@ defmodule Lotus.Runner do
   `read_only: false` to allow write operations.
   """
 
-  alias Lotus.{Preflight, Result, Source, Sources, Visibility}
+  alias Lotus.{Preflight, Result, Source, Sources, Telemetry, Visibility}
   alias Lotus.Preflight.Relations
   alias Lotus.Visibility.Policy
 
@@ -30,12 +30,29 @@ defmodule Lotus.Runner do
   @spec run_sql(repo(), sql(), params(), opts()) ::
           {:ok, query_result()} | {:error, term()}
   def run_sql(repo, sql, params \\ [], opts \\ []) when is_binary(sql) and is_list(params) do
+    telemetry_meta = %{repo: repo, sql: sql, params: params}
+    start_time = Telemetry.query_start(telemetry_meta)
     read_only = Keyword.get(opts, :read_only, true)
 
-    with :ok <- assert_single_statement(sql),
-         :ok <- assert_not_denied(sql, read_only),
-         :ok <- preflight_visibility(repo, sql, params, opts) do
-      exec_read_only(repo, sql, params, opts)
+    result =
+      with :ok <- assert_single_statement(sql),
+           :ok <- assert_not_denied(sql, read_only),
+           :ok <- preflight_visibility(repo, sql, params, opts) do
+        exec_read_only(repo, sql, params, opts)
+      end
+
+    case result do
+      {:ok, %Result{} = res} ->
+        Telemetry.query_stop(
+          start_time,
+          Map.merge(telemetry_meta, %{row_count: res.num_rows, result: res})
+        )
+
+        {:ok, res}
+
+      {:error, _} = error ->
+        Telemetry.query_exception(start_time, :error, error, [], telemetry_meta)
+        error
     end
   end
 

--- a/lib/lotus/schema.ex
+++ b/lib/lotus/schema.ex
@@ -24,7 +24,7 @@ defmodule Lotus.Schema do
   - **SQLite**: Returns table names as strings (schema-less)
   """
 
-  alias Lotus.{Config, Source, Sources, Visibility}
+  alias Lotus.{Config, Source, Sources, Telemetry, Visibility}
   alias Lotus.Visibility.Policy
 
   @doc """
@@ -55,6 +55,7 @@ defmodule Lotus.Schema do
           {:ok, [String.t()]} | {:error, term()}
   def list_schemas(repo_or_name, opts \\ []) do
     {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    start_time = Telemetry.schema_introspection_start(:list_schemas, repo_name)
 
     key = schema_key(:list_schemas, repo_name)
     tags = ["repo:#{repo_name}", "schema:list_schemas"]
@@ -66,15 +67,25 @@ defmodule Lotus.Schema do
         :schema
       end
 
-    exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      try do
-        raw_schemas = Source.list_schemas(repo)
-        filtered_schemas = Visibility.filter_schemas(raw_schemas, repo_name)
-        {:ok, filtered_schemas}
-      rescue
-        e -> {:error, Exception.message(e)}
-      end
-    end)
+    result =
+      exec_with_cache(opts[:cache], profile, key, tags, fn ->
+        try do
+          raw_schemas = Source.list_schemas(repo)
+          filtered_schemas = Visibility.filter_schemas(raw_schemas, repo_name)
+          {:ok, filtered_schemas}
+        rescue
+          e -> {:error, Exception.message(e)}
+        end
+      end)
+
+    Telemetry.schema_introspection_stop(
+      start_time,
+      :list_schemas,
+      repo_name,
+      result_status(result)
+    )
+
+    result
   end
 
   @doc """
@@ -114,56 +125,65 @@ defmodule Lotus.Schema do
           {:ok, [{String.t(), String.t()}] | [String.t()]} | {:error, term()}
   def list_tables(repo_or_name, opts \\ []) do
     {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    start_time = Telemetry.schema_introspection_start(:list_tables, repo_name)
     schemas = effective_schemas(repo, opts)
     include_views? = Keyword.get(opts, :include_views, false)
 
-    case Visibility.validate_schemas(schemas, repo_name) do
-      :ok ->
-        search_path = Keyword.get(opts, :search_path)
+    result =
+      case Visibility.validate_schemas(schemas, repo_name) do
+        :ok ->
+          search_path = Keyword.get(opts, :search_path)
 
-        key =
-          schema_key(
-            :list_tables,
-            repo_name,
-            search_path || Enum.join(schemas, ","),
-            include_views?
-          )
+          key =
+            schema_key(
+              :list_tables,
+              repo_name,
+              search_path || Enum.join(schemas, ","),
+              include_views?
+            )
 
-        tags = ["repo:#{repo_name}", "schema:list_tables"]
+          tags = ["repo:#{repo_name}", "schema:list_tables"]
 
-        profile =
-          if is_list(opts[:cache]) do
-            Keyword.get(opts[:cache], :profile, :schema)
-          else
-            :schema
-          end
+          profile =
+            if is_list(opts[:cache]) do
+              Keyword.get(opts[:cache], :profile, :schema)
+            else
+              :schema
+            end
 
-        exec_with_cache(opts[:cache], profile, key, tags, fn ->
-          try do
-            raw_relations = Source.list_tables(repo, schemas, include_views?)
+          exec_with_cache(opts[:cache], profile, key, tags, fn ->
+            try do
+              raw_relations = Source.list_tables(repo, schemas, include_views?)
 
-            filtered =
-              raw_relations
-              |> Enum.filter(&Visibility.allowed_relation?(repo_name, &1))
+              filtered =
+                raw_relations
+                |> Enum.filter(&Visibility.allowed_relation?(repo_name, &1))
 
-            result =
-              if Enum.all?(filtered, fn {schema, _table} -> is_nil(schema) end) do
-                # Schema-less database - return just table names
-                Enum.map(filtered, fn {nil, table} -> table end)
-              else
-                # Schema-aware database - return {schema, table} tuples
-                filtered
-              end
+              tables =
+                if Enum.all?(filtered, fn {schema, _table} -> is_nil(schema) end) do
+                  Enum.map(filtered, fn {nil, table} -> table end)
+                else
+                  filtered
+                end
 
-            {:ok, result}
-          rescue
-            e -> {:error, Exception.message(e)}
-          end
-        end)
+              {:ok, tables}
+            rescue
+              e -> {:error, Exception.message(e)}
+            end
+          end)
 
-      {:error, :schema_not_visible, denied: denied} ->
-        {:error, "Schema(s) not visible: #{Enum.join(denied, ", ")}"}
-    end
+        {:error, :schema_not_visible, denied: denied} ->
+          {:error, "Schema(s) not visible: #{Enum.join(denied, ", ")}"}
+      end
+
+    Telemetry.schema_introspection_stop(
+      start_time,
+      :list_tables,
+      repo_name,
+      result_status(result)
+    )
+
+    result
   end
 
   @doc """
@@ -193,26 +213,37 @@ defmodule Lotus.Schema do
           {:ok, [map()]} | {:error, term()}
   def get_table_schema(repo_or_name, table_name, opts \\ []) do
     {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    start_time = Telemetry.schema_introspection_start(:get_table_schema, repo_name)
     schemas = effective_schemas(repo, opts)
 
-    case resolve_table_schema_with_cache(
-           repo,
-           repo_name,
-           table_name,
-           schemas,
-           opts[:cache],
-           :schema
-         ) do
-      nil when schemas == [] ->
-        # Schema-less database (SQLite) - nil is expected, proceed with nil schema
-        get_table_schema_cached(repo, repo_name, table_name, nil, opts)
+    result =
+      case resolve_table_schema_with_cache(
+             repo,
+             repo_name,
+             table_name,
+             schemas,
+             opts[:cache],
+             :schema
+           ) do
+        nil when schemas == [] ->
+          # Schema-less database (SQLite) - nil is expected, proceed with nil schema
+          get_table_schema_cached(repo, repo_name, table_name, nil, opts)
 
-      nil ->
-        {:error, "Table '#{table_name}' not found in schemas: #{Enum.join(schemas, ", ")}"}
+        nil ->
+          {:error, "Table '#{table_name}' not found in schemas: #{Enum.join(schemas, ", ")}"}
 
-      resolved_schema ->
-        get_table_schema_cached(repo, repo_name, table_name, resolved_schema, opts)
-    end
+        resolved_schema ->
+          get_table_schema_cached(repo, repo_name, table_name, resolved_schema, opts)
+      end
+
+    Telemetry.schema_introspection_stop(
+      start_time,
+      :get_table_schema,
+      repo_name,
+      result_status(result)
+    )
+
+    result
   end
 
   defp get_table_schema_cached(repo, repo_name, table_name, resolved_schema, opts) do
@@ -289,26 +320,36 @@ defmodule Lotus.Schema do
           {:ok, %{row_count: non_neg_integer()}} | {:error, binary()}
   def get_table_stats(repo_or_name, table_name, opts \\ []) do
     {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    start_time = Telemetry.schema_introspection_start(:get_table_stats, repo_name)
     schemas = effective_schemas(repo, opts)
 
-    case resolve_table_schema_with_cache(
-           repo,
-           repo_name,
-           table_name,
-           schemas,
-           opts[:cache],
-           :results
-         ) do
-      nil when schemas == [] ->
-        # Schema-less database (SQLite) - nil is expected, proceed with nil schema
-        get_table_stats_cached(repo, repo_name, table_name, nil, opts)
+    result =
+      case resolve_table_schema_with_cache(
+             repo,
+             repo_name,
+             table_name,
+             schemas,
+             opts[:cache],
+             :results
+           ) do
+        nil when schemas == [] ->
+          get_table_stats_cached(repo, repo_name, table_name, nil, opts)
 
-      nil ->
-        {:error, "Table '#{table_name}' not found in schemas: #{Enum.join(schemas, ", ")}"}
+        nil ->
+          {:error, "Table '#{table_name}' not found in schemas: #{Enum.join(schemas, ", ")}"}
 
-      resolved_schema ->
-        get_table_stats_cached(repo, repo_name, table_name, resolved_schema, opts)
-    end
+        resolved_schema ->
+          get_table_stats_cached(repo, repo_name, table_name, resolved_schema, opts)
+      end
+
+    Telemetry.schema_introspection_stop(
+      start_time,
+      :get_table_stats,
+      repo_name,
+      result_status(result)
+    )
+
+    result
   end
 
   defp get_table_stats_cached(repo, repo_name, table_name, resolved_schema, opts) do
@@ -374,6 +415,7 @@ defmodule Lotus.Schema do
           {:ok, [{String.t() | nil, String.t()}]} | {:error, term()}
   def list_relations(repo_or_name, opts \\ []) do
     {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    start_time = Telemetry.schema_introspection_start(:list_relations, repo_name)
     schemas = effective_schemas(repo, opts)
     include_views? = Keyword.get(opts, :include_views, false)
 
@@ -396,17 +438,27 @@ defmodule Lotus.Schema do
         :schema
       end
 
-    exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      try do
-        raw_relations = Source.list_tables(repo, schemas, include_views?)
+    result =
+      exec_with_cache(opts[:cache], profile, key, tags, fn ->
+        try do
+          raw_relations = Source.list_tables(repo, schemas, include_views?)
 
-        {:ok,
-         raw_relations
-         |> Enum.filter(&Visibility.allowed_relation?(repo_name, &1))}
-      rescue
-        e -> {:error, Exception.message(e)}
-      end
-    end)
+          {:ok,
+           raw_relations
+           |> Enum.filter(&Visibility.allowed_relation?(repo_name, &1))}
+        rescue
+          e -> {:error, Exception.message(e)}
+        end
+      end)
+
+    Telemetry.schema_introspection_stop(
+      start_time,
+      :list_relations,
+      repo_name,
+      result_status(result)
+    )
+
+    result
   end
 
   defp effective_schemas(repo, opts) do
@@ -654,4 +706,7 @@ defmodule Lotus.Schema do
       _ -> {"\"", "\""}
     end
   end
+
+  defp result_status({:ok, _}), do: :ok
+  defp result_status({:error, _}), do: :error
 end

--- a/lib/lotus/telemetry.ex
+++ b/lib/lotus/telemetry.ex
@@ -1,0 +1,259 @@
+defmodule Lotus.Telemetry do
+  @moduledoc """
+  Telemetry events emitted by Lotus.
+
+  Lotus uses `:telemetry` to emit events for query execution, cache operations,
+  and schema introspection. You can attach handlers to these events for monitoring,
+  logging, or integration with tools like Phoenix LiveDashboard or AppSignal.
+
+  ## Query Events
+
+  ### `[:lotus, :query, :start]`
+
+  Emitted when a query begins execution.
+
+  **Measurements:**
+
+    * `:system_time` - The system time at the start of the query (in native units)
+
+  **Metadata:**
+
+    * `:repo` - The Ecto repo module
+    * `:sql` - The SQL statement being executed
+    * `:params` - The query parameters
+
+  ### `[:lotus, :query, :stop]`
+
+  Emitted when a query completes successfully.
+
+  **Measurements:**
+
+    * `:duration` - The query duration (in native time units)
+    * `:row_count` - The number of rows returned
+
+  **Metadata:**
+
+    * `:repo` - The Ecto repo module
+    * `:sql` - The SQL statement that was executed
+    * `:params` - The query parameters
+    * `:result` - The `Lotus.Result` struct
+
+  ### `[:lotus, :query, :exception]`
+
+  Emitted when a query fails with an exception.
+
+  **Measurements:**
+
+    * `:duration` - The time elapsed before the failure (in native time units)
+
+  **Metadata:**
+
+    * `:repo` - The Ecto repo module
+    * `:sql` - The SQL statement that was executed
+    * `:params` - The query parameters
+    * `:kind` - The kind of exception (`:error`, `:exit`, or `:throw`)
+    * `:reason` - The exception or error reason
+    * `:stacktrace` - The stacktrace
+
+  ## Cache Events
+
+  ### `[:lotus, :cache, :hit]`
+
+  Emitted when a cache lookup finds an existing entry.
+
+  **Measurements:**
+
+    * `:count` - Always `1`
+
+  **Metadata:**
+
+    * `:key` - The cache key
+
+  ### `[:lotus, :cache, :miss]`
+
+  Emitted when a cache lookup does not find an entry.
+
+  **Measurements:**
+
+    * `:count` - Always `1`
+
+  **Metadata:**
+
+    * `:key` - The cache key
+
+  ### `[:lotus, :cache, :put]`
+
+  Emitted when a value is stored in the cache.
+
+  **Measurements:**
+
+    * `:count` - Always `1`
+
+  **Metadata:**
+
+    * `:key` - The cache key
+    * `:ttl_ms` - The TTL in milliseconds
+
+  ## Schema Introspection Events
+
+  ### `[:lotus, :schema, :introspection, :start]`
+
+  Emitted when a schema introspection operation begins.
+
+  **Measurements:**
+
+    * `:system_time` - The system time at the start (in native units)
+
+  **Metadata:**
+
+    * `:operation` - The introspection operation (e.g., `:list_schemas`, `:list_tables`,
+      `:get_table_schema`, `:get_table_stats`, `:list_relations`)
+    * `:repo` - The repo name
+
+  ### `[:lotus, :schema, :introspection, :stop]`
+
+  Emitted when a schema introspection operation completes.
+
+  **Measurements:**
+
+    * `:duration` - The operation duration (in native time units)
+
+  **Metadata:**
+
+    * `:operation` - The introspection operation
+    * `:repo` - The repo name
+    * `:result` - `:ok` or `:error`
+
+  ## Example
+
+  Attach a handler in your application's `start/2` callback:
+
+      :telemetry.attach_many(
+        "lotus-logger",
+        [
+          [:lotus, :query, :stop],
+          [:lotus, :query, :exception],
+          [:lotus, :cache, :hit],
+          [:lotus, :cache, :miss]
+        ],
+        &MyApp.TelemetryHandler.handle_event/4,
+        nil
+      )
+
+  A simple logging handler:
+
+      defmodule MyApp.TelemetryHandler do
+        require Logger
+
+        def handle_event([:lotus, :query, :stop], measurements, metadata, _config) do
+          duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+          Logger.info("Lotus query completed in \#{duration_ms}ms, rows: \#{measurements.row_count}")
+        end
+
+        def handle_event([:lotus, :query, :exception], measurements, metadata, _config) do
+          duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+          Logger.error("Lotus query failed after \#{duration_ms}ms: \#{inspect(metadata.reason)}")
+        end
+
+        def handle_event([:lotus, :cache, :hit], _measurements, metadata, _config) do
+          Logger.debug("Lotus cache hit: \#{metadata.key}")
+        end
+
+        def handle_event([:lotus, :cache, :miss], _measurements, metadata, _config) do
+          Logger.debug("Lotus cache miss: \#{metadata.key}")
+        end
+      end
+  """
+
+  @query_start [:lotus, :query, :start]
+  @query_stop [:lotus, :query, :stop]
+  @query_exception [:lotus, :query, :exception]
+
+  @cache_hit [:lotus, :cache, :hit]
+  @cache_miss [:lotus, :cache, :miss]
+  @cache_put [:lotus, :cache, :put]
+
+  @schema_start [:lotus, :schema, :introspection, :start]
+  @schema_stop [:lotus, :schema, :introspection, :stop]
+
+  @doc false
+  def events do
+    [
+      @query_start,
+      @query_stop,
+      @query_exception,
+      @cache_hit,
+      @cache_miss,
+      @cache_put,
+      @schema_start,
+      @schema_stop
+    ]
+  end
+
+  @doc false
+  def query_start(metadata) do
+    start_time = System.monotonic_time()
+    :telemetry.execute(@query_start, %{system_time: System.system_time()}, metadata)
+    start_time
+  end
+
+  @doc false
+  def query_stop(start_time, metadata) do
+    duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(
+      @query_stop,
+      %{duration: duration, row_count: metadata[:row_count] || 0},
+      metadata
+    )
+  end
+
+  @doc false
+  def query_exception(start_time, kind, reason, stacktrace, metadata) do
+    duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(
+      @query_exception,
+      %{duration: duration},
+      Map.merge(metadata, %{kind: kind, reason: reason, stacktrace: stacktrace})
+    )
+  end
+
+  @doc false
+  def cache_hit(key) do
+    :telemetry.execute(@cache_hit, %{count: 1}, %{key: key})
+  end
+
+  @doc false
+  def cache_miss(key) do
+    :telemetry.execute(@cache_miss, %{count: 1}, %{key: key})
+  end
+
+  @doc false
+  def cache_put(key, ttl_ms) do
+    :telemetry.execute(@cache_put, %{count: 1}, %{key: key, ttl_ms: ttl_ms})
+  end
+
+  @doc false
+  def schema_introspection_start(operation, repo) do
+    start_time = System.monotonic_time()
+
+    :telemetry.execute(@schema_start, %{system_time: System.system_time()}, %{
+      operation: operation,
+      repo: repo
+    })
+
+    start_time
+  end
+
+  @doc false
+  def schema_introspection_stop(start_time, operation, repo, result_status) do
+    duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(@schema_stop, %{duration: duration}, %{
+      operation: operation,
+      repo: repo,
+      result: result_status
+    })
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Lotus.MixProject do
       {:nimble_csv, "~> 1.2"},
       {:nimble_options, "~> 1.0"},
       {:postgrex, "~> 0.20", optional: true},
+      {:telemetry, "~> 1.0"},
 
       # AI/LLM Integration
       {:req_llm, "~> 1.6"},
@@ -101,6 +102,7 @@ defmodule Lotus.MixProject do
         "Data Export": [Lotus.Export, ~r/Lotus\.Export\..+/],
         "Data Sources": [Lotus.Source, Lotus.Sources, ~r/Lotus\.Sources\..+/],
         "Schema Introspection": [Lotus.Schema, Lotus.Visibility],
+        Telemetry: [Lotus.Telemetry],
         Caching: [Lotus.Cache, ~r/Lotus\.Cache\..+/],
         "Database Migrations": [Lotus.Migration, Lotus.Migrations, ~r/Lotus\.Migrations\..+/],
         "OTP Application": [Lotus.Application, Lotus.Supervisor],
@@ -122,6 +124,7 @@ defmodule Lotus.MixProject do
       "guides/configuration.md",
       "guides/visibility.md",
       "guides/caching.md",
+      "guides/telemetry.md",
       "guides/contributing.md"
     ]
   end

--- a/test/lotus/cache_telemetry_test.exs
+++ b/test/lotus/cache_telemetry_test.exs
@@ -1,0 +1,113 @@
+defmodule Lotus.CacheTelemetryTest do
+  use Lotus.CacheCase
+  use Mimic
+
+  alias Lotus.Cache
+  alias Lotus.Config
+
+  setup do
+    Mimic.copy(Lotus.Config)
+    :ok
+  end
+
+  setup :verify_on_exit!
+
+  setup do
+    Config
+    |> stub(:cache_adapter, fn -> {:ok, Lotus.Cache.ETS} end)
+    |> stub(:cache_namespace, fn -> "test_telemetry" end)
+
+    :ok
+  end
+
+  describe "cache telemetry events" do
+    test "emits hit event on cache hit" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach(
+        "#{inspect(ref)}",
+        [:lotus, :cache, :hit],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      Cache.put("hit_key", "value", 5000)
+      Cache.get("hit_key")
+
+      assert_received {:telemetry, [:lotus, :cache, :hit], %{count: 1}, %{key: "hit_key"}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    test "emits miss event on cache miss" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach(
+        "#{inspect(ref)}",
+        [:lotus, :cache, :miss],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      Cache.get("missing_key")
+
+      assert_received {:telemetry, [:lotus, :cache, :miss], %{count: 1}, %{key: "missing_key"}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    test "emits put event on cache put" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach(
+        "#{inspect(ref)}",
+        [:lotus, :cache, :put],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      Cache.put("put_key", "value", 5000)
+
+      assert_received {:telemetry, [:lotus, :cache, :put], %{count: 1},
+                       %{key: "put_key", ttl_ms: 5000}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    test "emits hit event on get_or_store cache hit" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [[:lotus, :cache, :hit], [:lotus, :cache, :miss], [:lotus, :cache, :put]],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # First call - miss + put
+      Cache.get_or_store("gos_key", 5000, fn -> "computed" end)
+
+      assert_received {:telemetry, [:lotus, :cache, :miss], _, %{key: "gos_key"}}
+      assert_received {:telemetry, [:lotus, :cache, :put], _, %{key: "gos_key"}}
+
+      # Second call - hit
+      Cache.get_or_store("gos_key", 5000, fn -> "computed" end)
+
+      assert_received {:telemetry, [:lotus, :cache, :hit], _, %{key: "gos_key"}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+  end
+end

--- a/test/lotus/telemetry_test.exs
+++ b/test/lotus/telemetry_test.exs
@@ -1,0 +1,158 @@
+defmodule Lotus.TelemetryTest do
+  use Lotus.Case, async: true
+
+  alias Lotus.Fixtures
+  alias Lotus.Runner
+  alias Lotus.Test.Repo
+
+  setup do
+    fixtures = Fixtures.setup_test_data()
+    {:ok, fixtures}
+  end
+
+  describe "query telemetry events" do
+    test "emits start and stop events on successful query" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [[:lotus, :query, :start], [:lotus, :query, :stop]],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:ok, _result} = Runner.run_sql(Repo, "SELECT 1 AS num")
+
+      assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
+                       %{repo: Repo, sql: "SELECT 1 AS num"}}
+
+      assert_received {:telemetry, [:lotus, :query, :stop], measurements,
+                       %{repo: Repo, sql: "SELECT 1 AS num", result: %Lotus.Result{}}}
+
+      assert is_integer(measurements.duration)
+      assert measurements.duration >= 0
+      assert measurements.row_count >= 0
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    test "emits start and exception events on failed query" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [[:lotus, :query, :start], [:lotus, :query, :exception]],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:error, _} = Runner.run_sql(Repo, "DROP TABLE test_users")
+
+      assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
+                       %{repo: Repo, sql: "DROP TABLE test_users"}}
+
+      assert_received {:telemetry, [:lotus, :query, :exception], measurements,
+                       %{kind: :error, repo: Repo, sql: "DROP TABLE test_users"}}
+
+      assert is_integer(measurements.duration)
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+  end
+
+  describe "schema introspection telemetry events" do
+    @tag :sqlite
+    test "emits start and stop events for list_tables" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [
+          [:lotus, :schema, :introspection, :start],
+          [:lotus, :schema, :introspection, :stop]
+        ],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:ok, _tables} = Lotus.Schema.list_tables("sqlite")
+
+      assert_received {:telemetry, [:lotus, :schema, :introspection, :start], %{system_time: _},
+                       %{operation: :list_tables, repo: "sqlite"}}
+
+      assert_received {:telemetry, [:lotus, :schema, :introspection, :stop],
+                       %{duration: duration},
+                       %{operation: :list_tables, repo: "sqlite", result: :ok}}
+
+      assert is_integer(duration)
+      assert duration >= 0
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    @tag :sqlite
+    test "emits start and stop events for get_table_schema" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [
+          [:lotus, :schema, :introspection, :start],
+          [:lotus, :schema, :introspection, :stop]
+        ],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:ok, _schema} = Lotus.Schema.get_table_schema("sqlite", "products")
+
+      assert_received {:telemetry, [:lotus, :schema, :introspection, :start], _,
+                       %{operation: :get_table_schema, repo: "sqlite"}}
+
+      assert_received {:telemetry, [:lotus, :schema, :introspection, :stop], %{duration: _},
+                       %{operation: :get_table_schema, repo: "sqlite", result: :ok}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    @tag :sqlite
+    test "emits start and stop events for list_schemas" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [
+          [:lotus, :schema, :introspection, :start],
+          [:lotus, :schema, :introspection, :stop]
+        ],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:ok, _schemas} = Lotus.Schema.list_schemas("sqlite")
+
+      assert_received {:telemetry, [:lotus, :schema, :introspection, :start], _,
+                       %{operation: :list_schemas, repo: "sqlite"}}
+
+      assert_received {:telemetry, [:lotus, :schema, :introspection, :stop], %{duration: _},
+                       %{operation: :list_schemas, result: :ok}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+  end
+end


### PR DESCRIPTION
Emit telemetry events for query execution, cache operations, and schema introspection to enable monitoring with LiveDashboard, AppSignal, etc.