### PR TITLE
Add column-level statistics for query results

### DIFF
--- a/lib/lotus/result/statistics.ex
+++ b/lib/lotus/result/statistics.ex
@@ -1,0 +1,258 @@
+defmodule Lotus.Result.Statistics do
+  @moduledoc """
+  Computes column-level statistics from in-memory query results.
+
+  Operates entirely on the data already present in a `%Lotus.Result{}` struct,
+  requiring no additional database queries. Statistics are computed per-column
+  and vary based on the detected column type (numeric, string, or temporal).
+  """
+
+  alias Lotus.Result
+
+  @type column_type :: :numeric | :string | :temporal | :unknown
+  @type column_stats :: map()
+
+  @doc """
+  Computes statistics for a single column in the result set.
+
+  Returns a map with `:type` and type-specific statistics keys.
+  Returns `{:error, reason}` if the column is not found.
+  """
+  @spec compute(Result.t(), String.t()) :: {:ok, column_stats()} | {:error, String.t()}
+  def compute(%Result{} = result, column_name) when is_binary(column_name) do
+    case column_index(result.columns, column_name) do
+      nil ->
+        {:error, "column '#{column_name}' not found"}
+
+      idx ->
+        values = extract_column(result.rows, idx)
+        type = detect_type(values)
+        stats = compute_stats(type, values)
+        {:ok, Map.put(stats, :type, type)}
+    end
+  end
+
+  @doc """
+  Computes statistics for all columns in the result set.
+
+  Returns a map of `%{column_name => stats_map}`.
+  """
+  @spec compute_all(Result.t()) :: %{String.t() => column_stats()}
+  def compute_all(%Result{columns: columns} = result) do
+    Map.new(columns, fn col ->
+      {:ok, stats} = compute(result, col)
+      {col, stats}
+    end)
+  end
+
+  @doc """
+  Detects the column type from its values.
+
+  Inspects non-nil values and returns `:numeric`, `:string`, `:temporal`, or `:unknown`.
+  """
+  @spec detect_column_type(Result.t(), String.t()) :: column_type() | {:error, String.t()}
+  def detect_column_type(%Result{} = result, column_name) do
+    case column_index(result.columns, column_name) do
+      nil -> {:error, "column '#{column_name}' not found"}
+      idx -> result.rows |> extract_column(idx) |> detect_type()
+    end
+  end
+
+  # --- Column extraction ---
+
+  defp column_index(columns, name) do
+    Enum.find_index(columns, &(&1 == name))
+  end
+
+  defp extract_column(rows, idx) do
+    Enum.map(rows, &Enum.at(&1, idx))
+  end
+
+  # --- Type detection ---
+
+  defp detect_type(values) do
+    values
+    |> Enum.find(&(not is_nil(&1)))
+    |> type_of()
+  end
+
+  defp type_of(nil), do: :unknown
+  defp type_of(v) when is_number(v), do: :numeric
+  defp type_of(%Decimal{}), do: :numeric
+  defp type_of(v) when is_binary(v), do: :string
+  defp type_of(v) when is_atom(v), do: :string
+  defp type_of(%Date{}), do: :temporal
+  defp type_of(%Time{}), do: :temporal
+  defp type_of(%DateTime{}), do: :temporal
+  defp type_of(%NaiveDateTime{}), do: :temporal
+  defp type_of(_), do: :unknown
+
+  # --- Stats computation by type ---
+
+  defp compute_stats(:numeric, values), do: numeric_stats(values)
+  defp compute_stats(:string, values), do: string_stats(values)
+  defp compute_stats(:temporal, values), do: temporal_stats(values)
+  defp compute_stats(:unknown, values), do: base_stats(values)
+
+  # --- Base stats (shared across all types) ---
+
+  defp base_stats(values) do
+    total = length(values)
+    {non_nil, nil_count} = partition_nil(values)
+    distinct = non_nil |> Enum.uniq() |> length()
+
+    %{
+      count: total,
+      null_count: nil_count,
+      null_percentage: if(total > 0, do: Float.round(nil_count / total * 100, 2), else: 0.0),
+      distinct_count: distinct
+    }
+  end
+
+  # --- Numeric statistics ---
+
+  defp numeric_stats(values) do
+    base = base_stats(values)
+    {non_nil, _} = partition_nil(values)
+    numbers = Enum.map(non_nil, &to_float/1)
+
+    if numbers == [] do
+      Map.merge(base, %{min: nil, max: nil, avg: nil, median: nil, sum: nil, histogram: []})
+    else
+      sorted = Enum.sort(numbers)
+
+      Map.merge(base, %{
+        min: List.first(sorted),
+        max: List.last(sorted),
+        avg: Float.round(Enum.sum(sorted) / length(sorted), 4),
+        median: compute_median(sorted),
+        sum: Float.round(Enum.sum(sorted), 4),
+        histogram: compute_histogram(sorted)
+      })
+    end
+  end
+
+  defp compute_median(sorted) do
+    n = length(sorted)
+    mid = div(n, 2)
+
+    if rem(n, 2) == 0 do
+      Float.round((Enum.at(sorted, mid - 1) + Enum.at(sorted, mid)) / 2, 4)
+    else
+      Enum.at(sorted, mid) |> Float.round(4)
+    end
+  end
+
+  @histogram_bins 10
+  defp compute_histogram(sorted) do
+    min_val = List.first(sorted)
+    max_val = List.last(sorted)
+
+    if min_val == max_val do
+      [%{bin_start: min_val, bin_end: max_val, count: length(sorted)}]
+    else
+      bin_width = (max_val - min_val) / @histogram_bins
+
+      bins =
+        for i <- 0..(@histogram_bins - 1) do
+          bin_start = Float.round(min_val + i * bin_width, 4)
+          bin_end = Float.round(min_val + (i + 1) * bin_width, 4)
+          %{bin_start: bin_start, bin_end: bin_end, count: 0}
+        end
+
+      sorted
+      |> Enum.reduce(bins, fn val, acc ->
+        bin_idx = floor((val - min_val) / bin_width)
+        bin_idx = min(bin_idx, @histogram_bins - 1)
+
+        List.update_at(acc, bin_idx, fn bin ->
+          %{bin | count: bin.count + 1}
+        end)
+      end)
+    end
+  end
+
+  # --- String statistics ---
+
+  defp string_stats(values) do
+    base = base_stats(values)
+    {non_nil, _} = partition_nil(values)
+    strings = Enum.map(non_nil, &to_string/1)
+
+    if strings == [] do
+      Map.merge(base, %{min_length: nil, max_length: nil, top_values: []})
+    else
+      lengths = Enum.map(strings, &String.length/1)
+
+      top_values =
+        strings
+        |> Enum.frequencies()
+        |> Enum.sort_by(fn {_val, count} -> count end, :desc)
+        |> Enum.take(10)
+        |> Enum.map(fn {val, count} -> %{value: val, count: count} end)
+
+      Map.merge(base, %{
+        min_length: Enum.min(lengths),
+        max_length: Enum.max(lengths),
+        top_values: top_values
+      })
+    end
+  end
+
+  # --- Temporal statistics ---
+
+  defp temporal_stats(values) do
+    base = base_stats(values)
+    {non_nil, _} = partition_nil(values)
+
+    if non_nil == [] do
+      Map.merge(base, %{earliest: nil, latest: nil, distribution: []})
+    else
+      sorted = Enum.sort(non_nil, &temporal_lte?/2)
+
+      Map.merge(base, %{
+        earliest: List.first(sorted),
+        latest: List.last(sorted),
+        distribution: compute_temporal_distribution(sorted)
+      })
+    end
+  end
+
+  defp temporal_lte?(a, b) do
+    case {a, b} do
+      {%DateTime{}, %DateTime{}} -> DateTime.compare(a, b) != :gt
+      {%NaiveDateTime{}, %NaiveDateTime{}} -> NaiveDateTime.compare(a, b) != :gt
+      {%Date{}, %Date{}} -> Date.compare(a, b) != :gt
+      {%Time{}, %Time{}} -> Time.compare(a, b) != :gt
+      _ -> to_string(a) <= to_string(b)
+    end
+  end
+
+  defp compute_temporal_distribution(sorted) do
+    sorted
+    |> Enum.map(&temporal_bucket/1)
+    |> Enum.frequencies()
+    |> Enum.sort()
+    |> Enum.map(fn {bucket, count} -> %{bucket: bucket, count: count} end)
+  end
+
+  defp temporal_bucket(%Date{} = d), do: "#{d.year}-#{pad(d.month)}"
+  defp temporal_bucket(%DateTime{} = dt), do: "#{dt.year}-#{pad(dt.month)}"
+  defp temporal_bucket(%NaiveDateTime{} = dt), do: "#{dt.year}-#{pad(dt.month)}"
+  defp temporal_bucket(%Time{} = t), do: "#{pad(t.hour)}:00"
+  defp temporal_bucket(other), do: to_string(other)
+
+  defp pad(n) when n < 10, do: "0#{n}"
+  defp pad(n), do: "#{n}"
+
+  # --- Helpers ---
+
+  defp partition_nil(values) do
+    {non_nil, nils} = Enum.split_with(values, &(not is_nil(&1)))
+    {non_nil, length(nils)}
+  end
+
+  defp to_float(%Decimal{} = d), do: Decimal.to_float(d)
+  defp to_float(n) when is_integer(n), do: n / 1
+  defp to_float(n) when is_float(n), do: n
+end

--- a/test/lotus/result/statistics_test.exs
+++ b/test/lotus/result/statistics_test.exs
@@ -1,0 +1,324 @@
+defmodule Lotus.Result.StatisticsTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Result
+  alias Lotus.Result.Statistics
+
+  # --- Helpers ---
+
+  defp result(columns, rows) do
+    Result.new(columns, rows)
+  end
+
+  # --- compute/2 ---
+
+  describe "compute/2" do
+    test "returns error for unknown column" do
+      r = result(["a"], [[1]])
+      assert {:error, "column 'missing' not found"} = Statistics.compute(r, "missing")
+    end
+
+    test "computes numeric stats" do
+      r = result(["val"], [[10], [20], [30], [nil], [40]])
+      assert {:ok, stats} = Statistics.compute(r, "val")
+
+      assert stats.type == :numeric
+      assert stats.count == 5
+      assert stats.null_count == 1
+      assert stats.null_percentage == 20.0
+      assert stats.distinct_count == 4
+      assert stats.min == 10.0
+      assert stats.max == 40.0
+      assert stats.avg == 25.0
+      assert stats.median == 25.0
+      assert stats.sum == 100.0
+      assert is_list(stats.histogram)
+    end
+
+    test "computes string stats" do
+      r = result(["name"], [["Alice"], ["Bob"], ["Alice"], [nil], ["Charlie"]])
+      assert {:ok, stats} = Statistics.compute(r, "name")
+
+      assert stats.type == :string
+      assert stats.count == 5
+      assert stats.null_count == 1
+      assert stats.distinct_count == 3
+      assert stats.min_length == 3
+      assert stats.max_length == 7
+
+      top = stats.top_values
+      assert length(top) == 3
+      assert %{value: "Alice", count: 2} = hd(top)
+    end
+
+    test "computes temporal stats" do
+      dates = [~D[2024-01-15], ~D[2024-03-10], ~D[2024-01-20], nil]
+      r = result(["date"], Enum.map(dates, &[&1]))
+      assert {:ok, stats} = Statistics.compute(r, "date")
+
+      assert stats.type == :temporal
+      assert stats.earliest == ~D[2024-01-15]
+      assert stats.latest == ~D[2024-03-10]
+      assert stats.null_count == 1
+      assert is_list(stats.distribution)
+    end
+
+    test "handles all-nil column" do
+      r = result(["x"], [[nil], [nil]])
+      assert {:ok, stats} = Statistics.compute(r, "x")
+
+      assert stats.type == :unknown
+      assert stats.null_count == 2
+      assert stats.distinct_count == 0
+    end
+  end
+
+  # --- compute_all/1 ---
+
+  describe "compute_all/1" do
+    test "computes stats for every column" do
+      r = result(["id", "name"], [[1, "Alice"], [2, "Bob"]])
+      all = Statistics.compute_all(r)
+
+      assert Map.has_key?(all, "id")
+      assert Map.has_key?(all, "name")
+      assert all["id"].type == :numeric
+      assert all["name"].type == :string
+    end
+
+    test "returns empty map for empty columns" do
+      r = result([], [])
+      assert %{} == Statistics.compute_all(r)
+    end
+  end
+
+  # --- detect_column_type/2 ---
+
+  describe "detect_column_type/2" do
+    test "detects numeric" do
+      r = result(["a"], [[42]])
+      assert :numeric == Statistics.detect_column_type(r, "a")
+    end
+
+    test "detects string" do
+      r = result(["a"], [["hello"]])
+      assert :string == Statistics.detect_column_type(r, "a")
+    end
+
+    test "detects temporal from Date" do
+      r = result(["a"], [[~D[2024-01-01]]])
+      assert :temporal == Statistics.detect_column_type(r, "a")
+    end
+
+    test "detects temporal from DateTime" do
+      r = result(["a"], [[~U[2024-01-01 00:00:00Z]]])
+      assert :temporal == Statistics.detect_column_type(r, "a")
+    end
+
+    test "detects temporal from NaiveDateTime" do
+      r = result(["a"], [[~N[2024-01-01 00:00:00]]])
+      assert :temporal == Statistics.detect_column_type(r, "a")
+    end
+
+    test "detects numeric from Decimal" do
+      r = result(["a"], [[Decimal.new("3.14")]])
+      assert :numeric == Statistics.detect_column_type(r, "a")
+    end
+
+    test "skips leading nils" do
+      r = result(["a"], [[nil], [nil], [42]])
+      assert :numeric == Statistics.detect_column_type(r, "a")
+    end
+
+    test "returns unknown for all nils" do
+      r = result(["a"], [[nil], [nil]])
+      assert :unknown == Statistics.detect_column_type(r, "a")
+    end
+
+    test "returns error for missing column" do
+      r = result(["a"], [[1]])
+      assert {:error, _} = Statistics.detect_column_type(r, "missing")
+    end
+  end
+
+  # --- Numeric edge cases ---
+
+  describe "numeric statistics" do
+    test "single value" do
+      r = result(["v"], [[42]])
+      {:ok, stats} = Statistics.compute(r, "v")
+
+      assert stats.min == 42.0
+      assert stats.max == 42.0
+      assert stats.avg == 42.0
+      assert stats.median == 42.0
+      assert length(stats.histogram) == 1
+    end
+
+    test "even count median" do
+      r = result(["v"], [[1], [2], [3], [4]])
+      {:ok, stats} = Statistics.compute(r, "v")
+
+      assert stats.median == 2.5
+    end
+
+    test "odd count median" do
+      r = result(["v"], [[1], [3], [5]])
+      {:ok, stats} = Statistics.compute(r, "v")
+
+      assert stats.median == 3.0
+    end
+
+    test "handles Decimal values" do
+      r = result(["v"], [[Decimal.new("1.5")], [Decimal.new("2.5")]])
+      {:ok, stats} = Statistics.compute(r, "v")
+
+      assert stats.type == :numeric
+      assert stats.avg == 2.0
+      assert stats.min == 1.5
+      assert stats.max == 2.5
+    end
+
+    test "histogram distributes values into bins" do
+      rows = for i <- 1..100, do: [i]
+      r = result(["v"], rows)
+      {:ok, stats} = Statistics.compute(r, "v")
+
+      assert length(stats.histogram) == 10
+      assert Enum.sum(Enum.map(stats.histogram, & &1.count)) == 100
+    end
+
+    test "all-nil numeric returns nil fields" do
+      r = result(["v"], [[nil], [nil]])
+      {:ok, stats} = Statistics.compute(r, "v")
+
+      assert stats.type == :unknown
+      assert stats.null_count == 2
+    end
+  end
+
+  # --- String edge cases ---
+
+  describe "string statistics" do
+    test "empty strings" do
+      r = result(["s"], [[""], ["a"]])
+      {:ok, stats} = Statistics.compute(r, "s")
+
+      assert stats.min_length == 0
+      assert stats.max_length == 1
+    end
+
+    test "top_values limited to 10" do
+      rows = for i <- 1..20, do: ["val_#{i}"]
+      r = result(["s"], rows)
+      {:ok, stats} = Statistics.compute(r, "s")
+
+      assert length(stats.top_values) == 10
+    end
+
+    test "top_values sorted by frequency descending" do
+      rows = [["a"], ["b"], ["a"], ["c"], ["b"], ["a"]]
+      r = result(["s"], rows)
+      {:ok, stats} = Statistics.compute(r, "s")
+
+      [first, second, third] = stats.top_values
+      assert first.value == "a" and first.count == 3
+      assert second.value == "b" and second.count == 2
+      assert third.value == "c" and third.count == 1
+    end
+
+    test "all-nil returns nil fields" do
+      r = result(["s"], [[nil]])
+      {:ok, stats} = Statistics.compute(r, "s")
+
+      assert stats.type == :unknown
+    end
+
+    test "detects atoms as strings" do
+      r = result(["s"], [[:active], [:inactive], [:active]])
+      {:ok, stats} = Statistics.compute(r, "s")
+
+      assert stats.type == :string
+      assert stats.distinct_count == 2
+    end
+  end
+
+  # --- Temporal edge cases ---
+
+  describe "temporal statistics" do
+    test "DateTime values" do
+      rows = [
+        [~U[2024-01-15 10:00:00Z]],
+        [~U[2024-06-20 12:00:00Z]],
+        [~U[2024-01-25 08:00:00Z]]
+      ]
+
+      r = result(["ts"], rows)
+      {:ok, stats} = Statistics.compute(r, "ts")
+
+      assert stats.earliest == ~U[2024-01-15 10:00:00Z]
+      assert stats.latest == ~U[2024-06-20 12:00:00Z]
+    end
+
+    test "NaiveDateTime values" do
+      rows = [[~N[2024-03-01 09:00:00]], [~N[2024-01-01 09:00:00]]]
+      r = result(["ts"], rows)
+      {:ok, stats} = Statistics.compute(r, "ts")
+
+      assert stats.earliest == ~N[2024-01-01 09:00:00]
+      assert stats.latest == ~N[2024-03-01 09:00:00]
+    end
+
+    test "distribution groups by year-month" do
+      rows = [
+        [~D[2024-01-01]],
+        [~D[2024-01-15]],
+        [~D[2024-02-10]],
+        [~D[2024-02-20]],
+        [~D[2024-02-28]]
+      ]
+
+      r = result(["d"], rows)
+      {:ok, stats} = Statistics.compute(r, "d")
+
+      assert [
+               %{bucket: "2024-01", count: 2},
+               %{bucket: "2024-02", count: 3}
+             ] = stats.distribution
+    end
+
+    test "Time distribution groups by hour" do
+      rows = [[~T[09:15:00]], [~T[09:45:00]], [~T[14:30:00]]]
+      r = result(["t"], rows)
+      {:ok, stats} = Statistics.compute(r, "t")
+
+      assert stats.earliest == ~T[09:15:00]
+      assert stats.latest == ~T[14:30:00]
+
+      assert [
+               %{bucket: "09:00", count: 2},
+               %{bucket: "14:00", count: 1}
+             ] = stats.distribution
+    end
+
+    test "all-nil returns nil fields" do
+      r = result(["d"], [[nil]])
+      {:ok, stats} = Statistics.compute(r, "d")
+
+      assert stats.type == :unknown
+    end
+  end
+
+  # --- Empty result ---
+
+  describe "empty result" do
+    test "handles zero rows" do
+      r = result(["a", "b"], [])
+      {:ok, stats} = Statistics.compute(r, "a")
+
+      assert stats.type == :unknown
+      assert stats.count == 0
+      assert stats.null_count == 0
+    end
+  end
+end


### PR DESCRIPTION
Implement Lotus.Result.Statistics module that computes per-column statistics from in-memory result sets without additional DB queries.

Supports numeric (min/max/avg/median/histogram), string (top values, min/max length), and temporal (earliest/latest, distribution) columns.

Closes #115