### PR TITLE
Add result filtering via :filters option (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- **NEW:** Result filtering via `:filters` option on `Lotus.run_query/2` and `Lotus.run_sql/3`
+  - Pass a list of `Lotus.Query.Filter` structs to apply WHERE conditions on top of any query
+  - Filters are applied by wrapping the original query in a CTE, so they work safely with any SQL complexity (joins, subqueries, unions, etc.)
+  - Supports operators: `=`, `!=`, `>`, `<`, `>=`, `<=`, `LIKE`, `IS NULL`, `IS NOT NULL`
+  - Source-aware: each database adapter (PostgreSQL, MySQL, SQLite) handles its own identifier quoting via new `quote_identifier/1` and `apply_filters/2` callbacks on `Lotus.Source`
+  - New `Lotus.Query.Filter` struct for source-agnostic filter representation
+  - New `Lotus.SQL.FilterInjector` shared helper for SQL-based sources
+- **FIX:** `Lotus.Source.param_placeholder/4` and `Lotus.Source.limit_offset_placeholders/3` no longer hardcode a fallback to PostgreSQL when the repo is `nil` — they now resolve via the configured default data repo
 - **NEW:** Optional variables with [[ ]] syntax
 - **NEW:** Column-level statistics for query results (`Lotus.Result.Statistics`)
   - Computes per-column statistics from in-memory result sets without additional database queries

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ For the complete setup guide (caching, multiple databases, visibility controls),
 - **Multi-database support** — PostgreSQL, MySQL, and SQLite with per-query repo selection
 - **Result caching** — TTL-based caching with ETS backend, cache profiles, and tag-based invalidation
 - **CSV export** — download query results with streaming support for large datasets
+- **Result filters** — apply column-level filters on query results via `Lotus.Query.Filter`; multiple filters stack with AND and wrap the original query in a CTE for safe application
 - **Schema explorer** — browse tables, columns, and statistics interactively
 - **AI query generation** — ask your database questions in plain English; schema-aware, multi-turn conversations using OpenAI, Anthropic, or Gemini (BYOK)
 - **AI query explanation** — get plain-language explanations of what a query does, including selected fragments; understands Lotus `{{variable}}` and `[[optional]]` syntax

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -60,7 +60,8 @@ defmodule Lotus do
           repo: binary() | nil,
           vars: map(),
           cache: [cache_opt] | :bypass | :refresh | nil,
-          window: window_opts
+          window: window_opts,
+          filters: [Lotus.Query.Filter.t()]
         ]
 
   alias Lotus.Cache.Key
@@ -443,6 +444,9 @@ defmodule Lotus do
     search_path = Keyword.get(opts, :search_path) || q.search_path
     final_opts = prepare_final_opts(opts, search_path)
 
+    filters = Keyword.get(opts, :filters, [])
+    sql = Lotus.Source.apply_filters(repo_mod, sql, filters)
+
     {sql, params, window_meta, cache_bound} =
       maybe_apply_window(
         sql,
@@ -588,6 +592,9 @@ defmodule Lotus do
       |> Keyword.put_new_lazy(:read_only, &Config.read_only?/0)
 
     search_path = Keyword.get(runner_opts, :search_path)
+
+    filters = Keyword.get(opts, :filters, [])
+    sql = Lotus.Source.apply_filters(repo_mod, sql, filters)
 
     {sql, params, window_meta, cache_bound} =
       maybe_apply_window(

--- a/lib/lotus/query/filter.ex
+++ b/lib/lotus/query/filter.ex
@@ -1,0 +1,57 @@
+defmodule Lotus.Query.Filter do
+  @moduledoc """
+  Represents a filter condition to apply on query results.
+
+  Filters are source-agnostic data structures that describe a column-level
+  predicate. Each source adapter knows how to translate filters into its
+  native query language (e.g., SQL WHERE clauses via CTE wrapping).
+
+  ## Examples
+
+      %Filter{column: "region", op: :eq, value: "US"}
+      %Filter{column: "price", op: :gt, value: 100}
+      %Filter{column: "deleted_at", op: :is_null}
+  """
+
+  @type operator ::
+          :eq | :neq | :gt | :lt | :gte | :lte | :like | :is_null | :is_not_null
+
+  @type t :: %__MODULE__{
+          column: String.t(),
+          op: operator(),
+          value: term()
+        }
+
+  @enforce_keys [:column, :op]
+  defstruct [:column, :op, :value]
+
+  @operators ~w(eq neq gt lt gte lte like is_null is_not_null)a
+
+  @doc """
+  Creates a new filter, validating the operator.
+  """
+  @spec new(String.t(), operator(), term()) :: t()
+  def new(column, op, value \\ nil) when op in @operators do
+    %__MODULE__{column: column, op: op, value: value}
+  end
+
+  @doc """
+  Returns the list of valid operator atoms.
+  """
+  @spec operators() :: [operator(), ...]
+  def operators, do: @operators
+
+  @doc """
+  Returns a human-readable label for the given operator.
+  """
+  @spec operator_label(operator()) :: String.t()
+  def operator_label(:eq), do: "="
+  def operator_label(:neq), do: "≠"
+  def operator_label(:gt), do: ">"
+  def operator_label(:lt), do: "<"
+  def operator_label(:gte), do: "≥"
+  def operator_label(:lte), do: "≤"
+  def operator_label(:like), do: "LIKE"
+  def operator_label(:is_null), do: "IS NULL"
+  def operator_label(:is_not_null), do: "IS NOT NULL"
+end

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -13,6 +13,26 @@ defmodule Lotus.Source do
   @callback format_error(any()) :: String.t()
 
   @doc """
+  Quotes an identifier (column name, table name) using source-specific syntax.
+
+  Examples:
+    * PostgreSQL → `"column_name"`
+    * MySQL      → `` `column_name` ``
+    * SQLite     → `"column_name"`
+  """
+  @callback quote_identifier(String.t()) :: String.t()
+
+  @doc """
+  Applies a list of filters to an existing query, returning a new query string.
+
+  For SQL sources, this typically wraps the original query in a CTE and appends
+  WHERE clauses. Non-SQL sources may implement entirely different strategies.
+
+  Returns the original query unchanged when filters is empty.
+  """
+  @callback apply_filters(sql :: String.t(), filters :: [Lotus.Query.Filter.t()]) :: String.t()
+
+  @doc """
   Return the list of built-in deny rules for system tables and metadata relations
   that should be hidden from the schema browser for this source.
 
@@ -272,15 +292,12 @@ defmodule Lotus.Source do
   - `index` is 1-based (for drivers like Postgres that need `$1`, `$2`, …).
   - `var` and `type` are available to sources if they need special handling.
 
-  If the repo cannot be resolved, we default to Postgres-style placeholders.
+  Falls back to the configured default data repo when `nil` is given.
   """
   @spec param_placeholder(repo | String.t() | nil, pos_integer(), String.t(), atom() | nil) ::
           String.t()
   def param_placeholder(repo_or_name, index, var, type) when is_integer(index) and index > 0 do
-    case resolve_repo_safe(repo_or_name) do
-      nil -> Lotus.Sources.Postgres.param_placeholder(index, var, type)
-      repo -> impl_for(repo).param_placeholder(index, var, type)
-    end
+    impl_for(resolve_repo!(repo_or_name)).param_placeholder(index, var, type)
   end
 
   @doc """
@@ -289,26 +306,25 @@ defmodule Lotus.Source do
   - `repo_or_name` can be the Repo module or a data-repo name string.
   - `limit_index` and `offset_index` are 1-based indexes for the parameters.
 
-  If the repo cannot be resolved, we default to Postgres-style placeholders.
+  Falls back to the configured default data repo when `nil` is given.
   """
   @spec limit_offset_placeholders(repo | String.t() | nil, pos_integer(), pos_integer()) ::
           {String.t(), String.t()}
   def limit_offset_placeholders(repo_or_name, limit_index, offset_index)
       when is_integer(limit_index) and limit_index > 0 and is_integer(offset_index) and
              offset_index > 0 do
-    case resolve_repo_safe(repo_or_name) do
-      nil -> Lotus.Sources.Postgres.limit_offset_placeholders(limit_index, offset_index)
-      repo -> impl_for(repo).limit_offset_placeholders(limit_index, offset_index)
-    end
+    impl_for(resolve_repo!(repo_or_name)).limit_offset_placeholders(limit_index, offset_index)
   end
 
-  defp resolve_repo_safe(nil), do: nil
-  defp resolve_repo_safe(repo) when is_atom(repo), do: repo
+  defp resolve_repo!(repo) when is_atom(repo) and not is_nil(repo), do: repo
 
-  defp resolve_repo_safe(repo_name) when is_binary(repo_name) do
+  defp resolve_repo!(repo_name) when is_binary(repo_name) do
     Lotus.Config.get_data_repo!(repo_name)
-  rescue
-    _ -> nil
+  end
+
+  defp resolve_repo!(nil) do
+    {_name, mod} = Lotus.Config.default_data_repo()
+    mod
   end
 
   defp impl_for(repo) do
@@ -392,5 +408,26 @@ defmodule Lotus.Source do
           {:ok, String.t()} | {:error, term()}
   def explain_plan(repo, sql, params \\ [], opts \\ []) do
     impl_for(repo).explain_plan(repo, sql, params, opts)
+  end
+
+  @doc """
+  Quotes an identifier (column name, table name) using source-specific syntax.
+  """
+  @spec quote_identifier(repo | String.t() | nil, String.t()) :: String.t()
+  def quote_identifier(repo_or_name, identifier) do
+    impl_for(resolve_repo!(repo_or_name)).quote_identifier(identifier)
+  end
+
+  @doc """
+  Applies filters to a query using the source-specific implementation.
+
+  Returns the original query unchanged when filters is empty.
+  """
+  @spec apply_filters(repo | String.t() | nil, String.t(), [Lotus.Query.Filter.t()]) ::
+          String.t()
+  def apply_filters(_repo_or_name, sql, []), do: sql
+
+  def apply_filters(repo_or_name, sql, filters) do
+    impl_for(resolve_repo!(repo_or_name)).apply_filters(sql, filters)
   end
 end

--- a/lib/lotus/sources/default.ex
+++ b/lib/lotus/sources/default.ex
@@ -8,6 +8,8 @@ defmodule Lotus.Sources.Default do
 
   @behaviour Lotus.Source
 
+  alias Lotus.SQL.FilterInjector
+
   @impl true
   @doc "Simple transaction wrapper for unsupported sources."
   def execute_in_transaction(repo, fun, opts) do
@@ -143,5 +145,18 @@ defmodule Lotus.Sources.Default do
   """
   def resolve_table_schema(_repo, _table, _schemas) do
     nil
+  end
+
+  @impl true
+  @doc "Double-quotes identifiers as a safe default for unknown SQL sources."
+  def quote_identifier(identifier) do
+    escaped = String.replace(identifier, "\"", "\"\"")
+    ~s("#{escaped}")
+  end
+
+  @impl true
+  @doc "Applies filters using standard SQL CTE wrapping with double-quoted identifiers."
+  def apply_filters(sql, filters) do
+    FilterInjector.apply(sql, filters, &quote_identifier/1)
   end
 end

--- a/lib/lotus/sources/mysql.ex
+++ b/lib/lotus/sources/mysql.ex
@@ -5,6 +5,7 @@ defmodule Lotus.Sources.MySQL do
   require Logger
 
   alias Lotus.Sources.Default
+  alias Lotus.SQL.FilterInjector
 
   @myxql_error Module.concat([:MyXQL, :Error])
 
@@ -313,6 +314,17 @@ defmodule Lotus.Sources.MySQL do
       {:ok, %{rows: [[schema]]}} -> schema
       _ -> nil
     end
+  end
+
+  @impl true
+  def quote_identifier(identifier) do
+    escaped = String.replace(identifier, "`", "``")
+    "`#{escaped}`"
+  end
+
+  @impl true
+  def apply_filters(sql, filters) do
+    FilterInjector.apply(sql, filters, &quote_identifier/1)
   end
 
   defp format_mysql_type("varchar", char_len, _, _) when not is_nil(char_len),

--- a/lib/lotus/sources/postgres.ex
+++ b/lib/lotus/sources/postgres.ex
@@ -4,6 +4,7 @@ defmodule Lotus.Sources.Postgres do
   @behaviour Lotus.Source
 
   alias Lotus.Sources.Default
+  alias Lotus.SQL.FilterInjector
 
   @postgrex_error Module.concat([:Postgrex, :Error])
 
@@ -226,6 +227,17 @@ defmodule Lotus.Sources.Postgres do
       {:ok, %{rows: [[schema]]}} -> schema
       _ -> nil
     end
+  end
+
+  @impl true
+  def quote_identifier(identifier) do
+    escaped = String.replace(identifier, "\"", "\"\"")
+    ~s("#{escaped}")
+  end
+
+  @impl true
+  def apply_filters(sql, filters) do
+    FilterInjector.apply(sql, filters, &quote_identifier/1)
   end
 
   defp format_postgres_type("character varying", char_len, _, _) when not is_nil(char_len),

--- a/lib/lotus/sources/sqlite.ex
+++ b/lib/lotus/sources/sqlite.ex
@@ -6,6 +6,7 @@ defmodule Lotus.Sources.SQLite3 do
   require Logger
 
   alias Lotus.Sources.Default
+  alias Lotus.SQL.FilterInjector
 
   @exlite_error Module.concat([:Exqlite, :Error])
 
@@ -182,5 +183,16 @@ defmodule Lotus.Sources.SQLite3 do
   def resolve_table_schema(_repo, _table, _schemas) do
     # SQLite doesn't have schemas, always return nil
     nil
+  end
+
+  @impl true
+  def quote_identifier(identifier) do
+    escaped = String.replace(identifier, "\"", "\"\"")
+    ~s("#{escaped}")
+  end
+
+  @impl true
+  def apply_filters(sql, filters) do
+    FilterInjector.apply(sql, filters, &quote_identifier/1)
   end
 end

--- a/lib/lotus/sql/filter_injector.ex
+++ b/lib/lotus/sql/filter_injector.ex
@@ -1,0 +1,72 @@
+defmodule Lotus.SQL.FilterInjector do
+  @moduledoc ~S"""
+  Shared helpers for SQL-based sources to inject filter conditions into queries.
+
+  Wraps the original query in a CTE and appends WHERE clauses. Each SQL source
+  calls this with its own `quote_fn` for identifier quoting.
+
+  ## Example
+
+      quote_fn = fn id -> ~s("#{id}") end
+      Lotus.SQL.FilterInjector.apply("SELECT * FROM users", [
+        %Lotus.Query.Filter{column: "region", op: :eq, value: "US"}
+      ], quote_fn)
+      #=> ~s(WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US')
+  """
+
+  alias Lotus.Query.Filter
+
+  @doc """
+  Wraps the given SQL in a CTE and appends WHERE clauses for each filter.
+
+  `quote_fn` is a 1-arity function that quotes an identifier for the target database.
+
+  Returns the original SQL unchanged if filters is empty.
+  """
+  @spec apply(String.t(), [Filter.t()], (String.t() -> String.t())) :: String.t()
+  def apply(sql, [], _quote_fn), do: sql
+
+  def apply(sql, filters, quote_fn) when is_list(filters) and is_function(quote_fn, 1) do
+    conditions = Enum.map_join(filters, " AND ", &build_condition(&1, quote_fn))
+    "WITH _base AS (#{sql}) SELECT * FROM _base WHERE #{conditions}"
+  end
+
+  defp build_condition(%Filter{column: column, op: :is_null}, quote_fn) do
+    "#{quote_fn.(column)} IS NULL"
+  end
+
+  defp build_condition(%Filter{column: column, op: :is_not_null}, quote_fn) do
+    "#{quote_fn.(column)} IS NOT NULL"
+  end
+
+  defp build_condition(%Filter{column: column, op: op, value: value}, quote_fn) do
+    "#{quote_fn.(column)} #{op_to_sql(op)} #{quote_value(value)}"
+  end
+
+  defp op_to_sql(:eq), do: "="
+  defp op_to_sql(:neq), do: "!="
+  defp op_to_sql(:gt), do: ">"
+  defp op_to_sql(:lt), do: "<"
+  defp op_to_sql(:gte), do: ">="
+  defp op_to_sql(:lte), do: "<="
+  defp op_to_sql(:like), do: "LIKE"
+
+  @doc """
+  Quotes a value as a SQL literal, handling type-appropriate formatting.
+  """
+  @spec quote_value(term()) :: String.t()
+  def quote_value(nil), do: "NULL"
+  def quote_value(value) when is_integer(value), do: Integer.to_string(value)
+  def quote_value(value) when is_float(value), do: Float.to_string(value)
+  def quote_value(true), do: "TRUE"
+  def quote_value(false), do: "FALSE"
+
+  def quote_value(%Decimal{} = value), do: Decimal.to_string(value)
+
+  def quote_value(value) when is_binary(value) do
+    escaped = String.replace(value, "'", "''")
+    "'#{escaped}'"
+  end
+
+  def quote_value(value), do: quote_value(to_string(value))
+end

--- a/test/lotus/query/filter_test.exs
+++ b/test/lotus/query/filter_test.exs
@@ -1,0 +1,52 @@
+defmodule Lotus.Query.FilterTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Query.Filter
+
+  describe "new/3" do
+    test "creates a filter with column, op, and value" do
+      filter = Filter.new("region", :eq, "US")
+      assert %Filter{column: "region", op: :eq, value: "US"} = filter
+    end
+
+    test "creates a filter without value for nullary operators" do
+      filter = Filter.new("deleted_at", :is_null)
+      assert %Filter{column: "deleted_at", op: :is_null, value: nil} = filter
+    end
+
+    test "raises for invalid operator" do
+      assert_raise FunctionClauseError, fn ->
+        Filter.new("col", :invalid, "val")
+      end
+    end
+  end
+
+  describe "operators/0" do
+    test "returns all valid operators" do
+      ops = Filter.operators()
+      assert :eq in ops
+      assert :neq in ops
+      assert :gt in ops
+      assert :lt in ops
+      assert :gte in ops
+      assert :lte in ops
+      assert :like in ops
+      assert :is_null in ops
+      assert :is_not_null in ops
+    end
+  end
+
+  describe "operator_label/1" do
+    test "returns display labels for operators" do
+      assert Filter.operator_label(:eq) == "="
+      assert Filter.operator_label(:neq) == "≠"
+      assert Filter.operator_label(:gt) == ">"
+      assert Filter.operator_label(:lt) == "<"
+      assert Filter.operator_label(:gte) == "≥"
+      assert Filter.operator_label(:lte) == "≤"
+      assert Filter.operator_label(:like) == "LIKE"
+      assert Filter.operator_label(:is_null) == "IS NULL"
+      assert Filter.operator_label(:is_not_null) == "IS NOT NULL"
+    end
+  end
+end

--- a/test/lotus/source_test.exs
+++ b/test/lotus/source_test.exs
@@ -172,8 +172,24 @@ defmodule Lotus.SourceTest do
                "CAST(? AS SIGNED)"
     end
 
-    test "defaults to Postgres when repo is nil" do
-      assert Source.param_placeholder(nil, 1, "id", :integer) == "$1::integer"
+    test "defaults to configured default repo when repo is nil" do
+      {_name, default_mod} = Lotus.Config.default_data_repo()
+      result = Source.param_placeholder(nil, 1, "id", :integer)
+
+      expected =
+        default_mod.__adapter__()
+        |> then(
+          &Map.get(
+            %{
+              Ecto.Adapters.Postgres => "$1::integer",
+              Ecto.Adapters.MyXQL => "CAST(? AS SIGNED)",
+              Ecto.Adapters.SQLite3 => "?"
+            },
+            &1
+          )
+        )
+
+      assert result == expected
     end
   end
 end

--- a/test/lotus/sql/filter_injector_test.exs
+++ b/test/lotus/sql/filter_injector_test.exs
@@ -1,0 +1,122 @@
+defmodule Lotus.SQL.FilterInjectorTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Query.Filter
+  alias Lotus.SQL.FilterInjector
+
+  defp double_quote(id), do: ~s("#{id}")
+  defp backtick_quote(id), do: "`#{id}`"
+
+  describe "apply/3" do
+    test "returns original SQL when filters is empty" do
+      sql = "SELECT * FROM users"
+      assert FilterInjector.apply(sql, [], &double_quote/1) == sql
+    end
+
+    test "wraps SQL in CTE with single eq filter" do
+      sql = "SELECT * FROM users"
+      filters = [Filter.new("region", :eq, "US")]
+
+      result = FilterInjector.apply(sql, filters, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+    end
+
+    test "handles multiple filters with AND" do
+      sql = "SELECT * FROM orders"
+
+      filters = [
+        Filter.new("region", :eq, "US"),
+        Filter.new("status", :neq, "cancelled")
+      ]
+
+      result = FilterInjector.apply(sql, filters, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _base AS (SELECT * FROM orders) SELECT * FROM _base WHERE "region" = 'US' AND "status" != 'cancelled']
+    end
+
+    test "handles numeric values without quotes" do
+      filters = [Filter.new("price", :gt, 100)]
+      result = FilterInjector.apply("SELECT * FROM products", filters, &double_quote/1)
+      assert result =~ ~s("price" > 100)
+    end
+
+    test "handles float values" do
+      filters = [Filter.new("rating", :gte, 4.5)]
+      result = FilterInjector.apply("SELECT * FROM reviews", filters, &double_quote/1)
+      assert result =~ ~s("rating" >= 4.5)
+    end
+
+    test "handles IS NULL operator" do
+      filters = [Filter.new("deleted_at", :is_null)]
+      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
+      assert result =~ ~s("deleted_at" IS NULL)
+    end
+
+    test "handles IS NOT NULL operator" do
+      filters = [Filter.new("email", :is_not_null)]
+      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
+      assert result =~ ~s("email" IS NOT NULL)
+    end
+
+    test "handles LIKE operator" do
+      filters = [Filter.new("name", :like, "%John%")]
+      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
+      assert result =~ ~s("name" LIKE '%John%')
+    end
+
+    test "escapes single quotes in string values" do
+      filters = [Filter.new("name", :eq, "O'Brien")]
+      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
+      assert result =~ ~s("name" = 'O''Brien')
+    end
+
+    test "handles boolean values" do
+      filters = [Filter.new("active", :eq, true)]
+      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
+      assert result =~ ~s("active" = TRUE)
+    end
+
+    test "works with backtick quoting (MySQL style)" do
+      filters = [Filter.new("region", :eq, "US")]
+      result = FilterInjector.apply("SELECT * FROM users", filters, &backtick_quote/1)
+
+      assert result ==
+               "WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE `region` = 'US'"
+    end
+
+    test "escapes double quotes in column names" do
+      quote_fn = fn id ->
+        escaped = String.replace(id, "\"", "\"\"")
+        ~s("#{escaped}")
+      end
+
+      filters = [Filter.new(~s(col"name), :eq, "val")]
+      result = FilterInjector.apply("SELECT * FROM t", filters, quote_fn)
+      assert result =~ ~s("col""name" = 'val')
+    end
+
+    test "handles all comparison operators" do
+      ops = [eq: "=", neq: "!=", gt: ">", lt: "<", gte: ">=", lte: "<=", like: "LIKE"]
+
+      for {op, sql_op} <- ops do
+        filters = [Filter.new("col", op, "val")]
+        result = FilterInjector.apply("SELECT 1", filters, &double_quote/1)
+        assert result =~ ~s("col" #{sql_op} 'val'), "Failed for op: #{op}"
+      end
+    end
+
+    test "wraps complex queries safely" do
+      sql =
+        "SELECT a.*, b.name FROM a JOIN b ON a.id = b.a_id WHERE a.active = true UNION SELECT c.*, d.name FROM c JOIN d ON c.id = d.c_id"
+
+      filters = [Filter.new("name", :eq, "test")]
+
+      result = FilterInjector.apply(sql, filters, &double_quote/1)
+      assert result =~ "WITH _base AS (#{sql})"
+      assert result =~ ~s(SELECT * FROM _base WHERE "name" = 'test')
+    end
+  end
+end


### PR DESCRIPTION
Introduce source-aware query filtering that wraps the original SQL in a CTE with WHERE clauses. Each database adapter handles its own identifier quoting via new quote_identifier/1 and apply_filters/2 callbacks on the Source behaviour.

- Add Lotus.Query.Filter struct for source-agnostic filter representation
- Add Lotus.SQL.FilterInjector shared helper for CTE-based filter injection
- Add :filters option to run_query/2 and run_sql/3
- Fix param_placeholder/4 and limit_offset_placeholders/3 to resolve via the configured default data repo instead of hardcoding Postgres fallback

Closes https://github.com/typhoonworks/lotus/issues/116