### PR TITLE
Fix AI SQL generation treating conversational responses as queries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   - Source-aware: each database adapter (PostgreSQL, MySQL, SQLite) handles its own identifier quoting via new `quote_identifier/1` and `apply_filters/2` callbacks on `Lotus.Source`
   - New `Lotus.Query.Filter` struct for source-agnostic filter representation
   - New `Lotus.SQL.FilterInjector` shared helper for SQL-based sources
+- **FIX:** AI SQL generation now validates plain SQL responses (without `` ```sql `` code blocks) against the database using EXPLAIN before rejecting them — valid SQL is accepted, conversational text is still rejected as `{:error, {:unable_to_generate, content}}` ([#127](https://github.com/typhoonworks/lotus/issues/127))
+- **NEW:** `Lotus.SQL.Validator` — validates SQL syntax against the database without executing, using EXPLAIN. Neutralizes `{{var}}` and `[[...]]` template syntax before validation
+- **NEW:** `Lotus.AI.Actions.ValidateSQL` — AI tool action that lets the LLM validate its SQL against the database before returning it
+- **NEW:** `Lotus.Variables` — universal utilities for `{{variable}}` template syntax: `regex/0`, `extract_names/1`, `neutralize/2`. Consolidates the variable regex previously duplicated across `OptionalClause`, `Query`, and `QueryOptimizer`
+- **NEW:** `Lotus.SQL.OptionalClause.strip_brackets/1` — strips `[[` / `]]` brackets unconditionally, keeping inner content. Used by `Validator` and `QueryOptimizer` for preparing SQL for EXPLAIN
 - **FIX:** `Lotus.Source.param_placeholder/4` and `Lotus.Source.limit_offset_placeholders/3` no longer hardcode a fallback to PostgreSQL when the repo is `nil` — they now resolve via the configured default data repo
 - **NEW:** Optional variables with [[ ]] syntax
 - **NEW:** Column-level statistics for query results (`Lotus.Result.Statistics`)

--- a/lib/lotus/ai/actions/validate_sql.ex
+++ b/lib/lotus/ai/actions/validate_sql.ex
@@ -1,0 +1,45 @@
+defmodule Lotus.AI.Actions.ValidateSQL do
+  @moduledoc """
+  Validates SQL syntax against the database without executing.
+
+  Uses EXPLAIN to parse the query server-side, catching syntax errors
+  and missing table/column references before the query is run.
+  """
+
+  @behaviour Lotus.AI.Action
+
+  alias Lotus.SQL.Validator
+
+  @impl true
+  def name, do: "validate_sql"
+
+  @impl true
+  def description,
+    do:
+      "Validate SQL syntax against the database without executing it. " <>
+        "Use this to check your query for syntax errors before returning it. " <>
+        "Variables ({{var}}) and optional clauses ([[...]]) are handled automatically."
+
+  @impl true
+  def schema do
+    [
+      sql: [type: :string, required: true, doc: "The SQL query to validate"],
+      data_source: [
+        type: :string,
+        required: true,
+        doc: "Name of the data source to validate against"
+      ]
+    ]
+  end
+
+  @impl true
+  def run(params, _context) do
+    case Validator.validate(params.sql, params.data_source) do
+      :ok ->
+        {:ok, %{valid: true}}
+
+      {:error, reason} ->
+        {:ok, %{valid: false, error: reason}}
+    end
+  end
+end

--- a/lib/lotus/ai/prompts/sql_generation.ex
+++ b/lib/lotus/ai/prompts/sql_generation.ex
@@ -54,13 +54,16 @@ defmodule Lotus.AI.Prompts.SQLGeneration do
     - `list_tables()` - Get full table list with schema names
     - `get_table_schema(table_name)` - Get columns for a table (use schema-qualified name if available)
     - `get_column_values(table_name, column_name)` - Get distinct values for a column (e.g., status codes, categories)
+    - `validate_sql(sql)` - Check SQL syntax against the database without executing it
 
     ## Workflow:
     1. Identify relevant tables for the question
     2. Use `get_table_schema()` for those tables (with schema-qualified names)
     3. **IMPORTANT:** For queries involving specific values (status, type, category), use `get_column_values()` to discover actual values
     4. Validate required data exists
-    5. Generate SQL or respond UNABLE_TO_GENERATE
+    5. Generate SQL and use `validate_sql()` to verify syntax before returning
+    6. If invalid, fix errors and re-validate
+    7. If the question cannot be answered with SQL, respond UNABLE_TO_GENERATE
 
     ## Best Practices:
     - When query mentions terms like "outstanding", "active", "pending" - use `get_column_values()` to find actual status values
@@ -121,13 +124,13 @@ defmodule Lotus.AI.Prompts.SQLGeneration do
       reason = String.replace_prefix(content, "UNABLE_TO_GENERATE: ", "")
       {:error, {:unable_to_generate, reason}}
     else
-      sql =
-        case Regex.run(~r/```sql\s*\n(.*?)\n```/s, content) do
-          [_, sql] -> String.trim(sql)
-          nil -> String.trim(content)
-        end
+      case Regex.run(~r/```sql\s*\n(.*?)\n```/s, content) do
+        [_, sql] ->
+          {:ok, String.trim(sql)}
 
-      {:ok, sql}
+        nil ->
+          {:error, {:unable_to_generate, content}}
+      end
     end
   end
 

--- a/lib/lotus/ai/query_optimizer.ex
+++ b/lib/lotus/ai/query_optimizer.ex
@@ -9,6 +9,8 @@ defmodule Lotus.AI.QueryOptimizer do
   alias Lotus.AI.Actions
   alias Lotus.AI.Prompts.Optimization
   alias Lotus.AI.Tool
+  alias Lotus.SQL.OptionalClause
+  alias Lotus.Variables
 
   @doc """
   Generate optimization suggestions for a SQL query.
@@ -30,7 +32,18 @@ defmodule Lotus.AI.QueryOptimizer do
   - `{:ok, result}` - Map with `:suggestions`, `:model`, and `:usage`
   - `{:error, term}` - Error tuple
   """
-  @spec suggest_optimizations(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  @type optimization_response :: %{
+          suggestions: [map()],
+          model: String.t(),
+          usage: %{
+            prompt_tokens: non_neg_integer(),
+            completion_tokens: non_neg_integer(),
+            total_tokens: non_neg_integer()
+          }
+        }
+
+  @spec suggest_optimizations(String.t(), keyword()) ::
+          {:ok, optimization_response()} | {:error, term()}
   def suggest_optimizations(model_string, opts) do
     data_source = Keyword.fetch!(opts, :data_source)
     sql = Keyword.fetch!(opts, :sql)
@@ -70,8 +83,8 @@ defmodule Lotus.AI.QueryOptimizer do
   # Note: nested [[ ]] is not part of Lotus syntax and is not supported.
   defp prepare_sql_for_explain(sql) do
     sql
-    |> String.replace(~r/\[\[(.*?)\]\]/s, "\\1")
-    |> String.replace(~r/\{\{[A-Za-z_][A-Za-z0-9_]*\}\}/, "NULL")
+    |> OptionalClause.strip_brackets()
+    |> Variables.neutralize("NULL")
   end
 
   defp build_tools(data_source) do

--- a/lib/lotus/ai/sql_generator.ex
+++ b/lib/lotus/ai/sql_generator.ex
@@ -11,6 +11,7 @@ defmodule Lotus.AI.SQLGenerator do
   alias Lotus.AI.Conversation
   alias Lotus.AI.Prompts.SQLGeneration
   alias Lotus.AI.Tool
+  alias Lotus.SQL.Validator
 
   @doc """
   Validate that a config contains a non-empty API key string.
@@ -40,7 +41,18 @@ defmodule Lotus.AI.SQLGenerator do
   - `:read_only` - Whether to restrict to read-only SQL (default: true)
   - `:temperature` - LLM temperature (default: 0.1)
   """
-  @spec generate_sql(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  @type sql_response :: %{
+          content: String.t(),
+          model: String.t(),
+          variables: [map()],
+          usage: %{
+            prompt_tokens: non_neg_integer(),
+            completion_tokens: non_neg_integer(),
+            total_tokens: non_neg_integer()
+          }
+        }
+
+  @spec generate_sql(String.t(), keyword()) :: {:ok, sql_response()} | {:error, term()}
   def generate_sql(model_string, opts) do
     data_source = Keyword.fetch!(opts, :data_source)
     prompt = Keyword.fetch!(opts, :prompt)
@@ -63,22 +75,29 @@ defmodule Lotus.AI.SQLGenerator do
     context = build_context(messages)
 
     Tool.run(model_string, context, tools, api_key: api_key, temperature: temperature)
-    |> handle_response(model_string)
+    |> handle_response(model_string, data_source)
   end
 
-  defp handle_response({:ok, response}, model_string) do
+  defp handle_response({:ok, response}, model_string, data_source) do
     content = ReqLLM.Response.text(response)
 
     case SQLGeneration.extract_response(content) do
       {:ok, %{sql: sql, variables: variables}} ->
         {:ok, build_success_response(response, model_string, sql, variables)}
 
-      {:error, {:unable_to_generate, reason}} ->
-        {:error, {:unable_to_generate, reason}}
+      {:error, {:unable_to_generate, candidate}} ->
+        case Validator.validate(candidate, data_source) do
+          :ok ->
+            variables = SQLGeneration.extract_variables(candidate)
+            {:ok, build_success_response(response, model_string, candidate, variables)}
+
+          {:error, _reason} ->
+            {:error, {:unable_to_generate, candidate}}
+        end
     end
   end
 
-  defp handle_response({:error, error}, _model_string), do: {:error, error}
+  defp handle_response({:error, error}, _model_string, _data_source), do: {:error, error}
 
   defp build_success_response(response, model_string, sql, variables) do
     %{
@@ -98,7 +117,8 @@ defmodule Lotus.AI.SQLGenerator do
       Tool.from_action(Actions.ListSchemas, bind: bind),
       Tool.from_action(Actions.ListTables, bind: bind),
       Tool.from_action(Actions.GetTableSchema, bind: bind),
-      Tool.from_action(Actions.GetColumnValues, bind: bind)
+      Tool.from_action(Actions.GetColumnValues, bind: bind),
+      Tool.from_action(Actions.ValidateSQL, bind: bind)
     ]
   end
 

--- a/lib/lotus/sql/optional_clause.ex
+++ b/lib/lotus/sql/optional_clause.ex
@@ -18,7 +18,6 @@ defmodule Lotus.SQL.OptionalClause do
   """
 
   @optional_clause_regex ~r/\[\[(.*?)\]\]/s
-  @variable_regex ~r/\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}/
 
   @doc """
   Processes optional clauses in SQL. Removes `[[...]]` blocks where any
@@ -32,8 +31,8 @@ defmodule Lotus.SQL.OptionalClause do
   def process(sql, supplied_vars) do
     Regex.replace(@optional_clause_regex, sql, fn _full, content ->
       vars_in_block =
-        Regex.scan(@variable_regex, content)
-        |> Enum.map(fn [_, name] -> name end)
+        content
+        |> Lotus.Variables.extract_names()
         |> Enum.uniq()
 
       if Enum.all?(vars_in_block, &has_value?(supplied_vars, &1)) do
@@ -51,10 +50,26 @@ defmodule Lotus.SQL.OptionalClause do
   def extract_optional_variable_names(sql) do
     Regex.scan(@optional_clause_regex, sql)
     |> Enum.flat_map(fn [_, content] ->
-      Regex.scan(@variable_regex, content)
-      |> Enum.map(fn [_, name] -> name end)
+      Lotus.Variables.extract_names(content)
     end)
     |> MapSet.new()
+  end
+
+  @doc """
+  Strips `[[` and `]]` brackets from the string, keeping the inner content.
+
+  Unlike `process/2`, this does not evaluate variables — it unconditionally
+  removes all bracket pairs. Useful for preparing SQL for validation where
+  all optional clauses should be included.
+
+  ## Examples
+
+      iex> Lotus.SQL.OptionalClause.strip_brackets("WHERE 1=1 [[AND status = 'active']]")
+      "WHERE 1=1 AND status = 'active'"
+  """
+  @spec strip_brackets(String.t()) :: String.t()
+  def strip_brackets(content) do
+    Regex.replace(@optional_clause_regex, content, "\\1")
   end
 
   defp has_value?(supplied_vars, name) do

--- a/lib/lotus/sql/validator.ex
+++ b/lib/lotus/sql/validator.ex
@@ -1,0 +1,46 @@
+defmodule Lotus.SQL.Validator do
+  @moduledoc """
+  Validates SQL syntax by preparing it against the database without executing.
+
+  Uses EXPLAIN to parse the query server-side. Before validation, `{{var}}`
+  placeholders are replaced with NULL and `[[...]]` optional brackets are
+  stripped so the raw template can be checked.
+  """
+
+  alias Lotus.SQL.OptionalClause
+  alias Lotus.Variables
+
+  @doc """
+  Validates SQL syntax against the given data source.
+
+  Neutralizes Lotus template syntax (`{{var}}` → `NULL`, `[[...]]` → inner
+  content) and runs EXPLAIN to check whether the database can parse the
+  statement.
+
+  Returns `:ok` if the SQL is valid, or `{:error, reason}` with the
+  database error message if it is not.
+
+  ## Examples
+
+      iex> Lotus.SQL.Validator.validate("SELECT 1", "postgres")
+      :ok
+
+      iex> Lotus.SQL.Validator.validate("NOT VALID SQL", "postgres")
+      {:error, "SQL syntax error: ..."}
+  """
+  @spec validate(String.t(), String.t()) :: :ok | {:error, String.t()}
+  def validate(sql, data_source) do
+    neutralized =
+      sql
+      |> OptionalClause.strip_brackets()
+      |> Variables.neutralize("NULL")
+
+    repo = Lotus.Config.get_data_repo!(data_source)
+
+    case Lotus.Source.explain_plan(repo, neutralized) do
+      {:ok, _plan} -> :ok
+      {:error, reason} when is_binary(reason) -> {:error, reason}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+end

--- a/lib/lotus/storage/query.ex
+++ b/lib/lotus/storage/query.ex
@@ -91,11 +91,7 @@ defmodule Lotus.Storage.Query do
     transformed_sql = Transformer.transform(processed_sql, source_type)
 
     # Extract variables from SQL
-    regex = ~r/\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}/
-
-    vars_in_order =
-      Regex.scan(regex, transformed_sql)
-      |> Enum.map(fn [_, var] -> var end)
+    vars_in_order = Lotus.Variables.extract_names(transformed_sql)
 
     variable_bindings = VariableResolver.resolve_variables(transformed_sql)
 

--- a/lib/lotus/variables.ex
+++ b/lib/lotus/variables.ex
@@ -1,0 +1,62 @@
+defmodule Lotus.Variables do
+  @moduledoc """
+  Utilities for Lotus `{{variable}}` template syntax.
+
+  Variables use the `{{name}}` placeholder format and can appear in SQL
+  queries, templates, or any other Lotus content type.
+  """
+
+  @variable_regex ~r/\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}/
+
+  @doc """
+  Returns the compiled regex for matching `{{variable}}` placeholders.
+
+  Captures the variable name (without braces) in group 1.
+
+  ## Examples
+
+      iex> Regex.scan(Lotus.Variables.regex(), "WHERE id = {{user_id}}")
+      [["{{user_id}}", "user_id"]]
+  """
+  @spec regex() :: Regex.t()
+  def regex, do: @variable_regex
+
+  @doc """
+  Extracts variable names from a string containing `{{variable}}` placeholders.
+
+  Returns names in the order they appear, with duplicates preserved.
+
+  ## Examples
+
+      iex> Lotus.Variables.extract_names("WHERE id = {{user_id}} AND status = {{status}}")
+      ["user_id", "status"]
+
+      iex> Lotus.Variables.extract_names("no variables here")
+      []
+  """
+  @spec extract_names(String.t()) :: [String.t()]
+  def extract_names(content) do
+    Regex.scan(@variable_regex, content)
+    |> Enum.map(fn [_, name] -> name end)
+  end
+
+  @doc """
+  Replaces all `{{variable}}` placeholders with the given replacement value.
+
+  Useful for neutralizing variables before validation (e.g. replacing with
+  `"NULL"` for SQL syntax checking) or for any context where placeholders
+  need to be substituted with a static value.
+
+  ## Examples
+
+      iex> Lotus.Variables.neutralize("SELECT * FROM users WHERE id = {{user_id}}", "NULL")
+      "SELECT * FROM users WHERE id = NULL"
+
+      iex> Lotus.Variables.neutralize("Hello {{name}}", "")
+      "Hello "
+  """
+  @spec neutralize(String.t(), String.t()) :: String.t()
+  def neutralize(content, replacement) do
+    Regex.replace(@variable_regex, content, replacement)
+  end
+end

--- a/test/lotus/ai/actions/validate_sql_test.exs
+++ b/test/lotus/ai/actions/validate_sql_test.exs
@@ -1,0 +1,37 @@
+defmodule Lotus.AI.Actions.ValidateSQLTest do
+  use Lotus.AICase, async: true
+
+  alias Lotus.AI.Actions.ValidateSQL
+
+  describe "run/2" do
+    test "returns valid: true when validation succeeds" do
+      expect(Lotus.SQL.Validator, :validate, fn "SELECT 1", "postgres" -> :ok end)
+
+      assert {:ok, %{valid: true}} =
+               ValidateSQL.run(%{sql: "SELECT 1", data_source: "postgres"}, %{})
+    end
+
+    test "returns valid: false with error when validation fails" do
+      expect(Lotus.SQL.Validator, :validate, fn _sql, "postgres" ->
+        {:error, "SQL syntax error: unexpected token"}
+      end)
+
+      assert {:ok, %{valid: false, error: error}} =
+               ValidateSQL.run(
+                 %{sql: "This is not SQL", data_source: "postgres"},
+                 %{}
+               )
+
+      assert error =~ "syntax error"
+    end
+  end
+
+  describe "tool metadata" do
+    test "exposes name, description, and schema" do
+      assert ValidateSQL.name() == "validate_sql"
+      assert ValidateSQL.description() =~ "Validate"
+      assert Keyword.has_key?(ValidateSQL.schema(), :sql)
+      assert Keyword.has_key?(ValidateSQL.schema(), :data_source)
+    end
+  end
+end

--- a/test/lotus/ai/prompts/sql_generation_test.exs
+++ b/test/lotus/ai/prompts/sql_generation_test.exs
@@ -128,11 +128,10 @@ defmodule Lotus.AI.Prompts.SQLGenerationTest do
       assert sql == "SELECT * FROM users\nWHERE created_at >= NOW() - INTERVAL '30 days'"
     end
 
-    test "extracts plain SQL without markdown" do
+    test "returns error for plain SQL without markdown code block" do
       content = "SELECT COUNT(*) FROM users"
 
-      assert {:ok, sql} = SQLGeneration.extract_sql(content)
-      assert sql == "SELECT COUNT(*) FROM users"
+      assert {:error, {:unable_to_generate, _}} = SQLGeneration.extract_sql(content)
     end
 
     test "trims whitespace from SQL" do
@@ -190,6 +189,21 @@ defmodule Lotus.AI.Prompts.SQLGenerationTest do
 
       assert {:error, {:unable_to_generate, reason}} = SQLGeneration.extract_sql(content)
       assert reason == "Some reason"
+    end
+
+    test "returns error for conversational text without SQL code block" do
+      content =
+        "To generate a query for a heatmap, I'll need some more information. What data points would you like to visualize?"
+
+      assert {:error, {:unable_to_generate, reason}} = SQLGeneration.extract_sql(content)
+      assert reason =~ "heatmap"
+    end
+
+    test "returns error for conversational text with follow-up questions" do
+      content =
+        "I can help you with that! Could you specify which tables you'd like to query and what time range you're interested in?"
+
+      assert {:error, {:unable_to_generate, _}} = SQLGeneration.extract_sql(content)
     end
   end
 

--- a/test/lotus/ai/sql_generator_test.exs
+++ b/test/lotus/ai/sql_generator_test.exs
@@ -72,13 +72,14 @@ defmodule Lotus.AI.SQLGeneratorTest do
     test "includes schema query tools" do
       mock_with_assertion(fn _model, _context, opts ->
         tools = opts[:tools]
-        assert length(tools) == 4
+        assert length(tools) == 5
 
         tool_names = Enum.map(tools, & &1.name)
         assert "list_schemas" in tool_names
         assert "list_tables" in tool_names
         assert "get_table_schema" in tool_names
         assert "get_column_values" in tool_names
+        assert "validate_sql" in tool_names
       end)
 
       assert {:ok, _} =

--- a/test/lotus/sql/optional_clause_test.exs
+++ b/test/lotus/sql/optional_clause_test.exs
@@ -106,4 +106,31 @@ defmodule Lotus.SQL.OptionalClauseTest do
       assert OptionalClause.extract_optional_variable_names(sql) == MapSet.new(["name"])
     end
   end
+
+  describe "strip_brackets/1" do
+    test "removes brackets and keeps inner content" do
+      assert OptionalClause.strip_brackets("WHERE 1=1 [[AND status = 'active']]") ==
+               "WHERE 1=1 AND status = 'active'"
+    end
+
+    test "handles multiple bracket pairs" do
+      sql = "WHERE 1=1 [[AND a = 1]] [[AND b = 2]]"
+      assert OptionalClause.strip_brackets(sql) == "WHERE 1=1 AND a = 1 AND b = 2"
+    end
+
+    test "preserves variables inside brackets" do
+      sql = "WHERE 1=1 [[AND name = {{name}}]]"
+      assert OptionalClause.strip_brackets(sql) == "WHERE 1=1 AND name = {{name}}"
+    end
+
+    test "passes through SQL with no brackets" do
+      sql = "SELECT * FROM users"
+      assert OptionalClause.strip_brackets(sql) == sql
+    end
+
+    test "handles multiline content inside brackets" do
+      sql = "WHERE 1=1\n[[AND a = 1\nAND b = 2]]"
+      assert OptionalClause.strip_brackets(sql) == "WHERE 1=1\nAND a = 1\nAND b = 2"
+    end
+  end
 end

--- a/test/lotus/sql/validator_test.exs
+++ b/test/lotus/sql/validator_test.exs
@@ -1,0 +1,114 @@
+defmodule Lotus.SQL.ValidatorTest do
+  use Lotus.Case, async: false
+
+  alias Lotus.SQL.Validator
+
+  describe "validate/2 with postgres" do
+    test "accepts PostgreSQL-specific ILIKE syntax" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT * FROM test_users WHERE name ILIKE '%test%'",
+                 "postgres"
+               )
+    end
+
+    test "accepts PostgreSQL array syntax" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT * FROM test_users WHERE id = ANY(ARRAY[1, 2, 3])",
+                 "postgres"
+               )
+    end
+
+    test "accepts PostgreSQL DATE_TRUNC function" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT DATE_TRUNC('month', inserted_at) FROM test_users",
+                 "postgres"
+               )
+    end
+
+    test "returns error for non-existent table" do
+      assert {:error, _reason} =
+               Validator.validate("SELECT * FROM nonexistent_table_xyz", "postgres")
+    end
+
+    test "returns error for invalid SQL" do
+      assert {:error, _} = Validator.validate("NOT VALID SQL AT ALL", "postgres")
+    end
+
+    test "neutralizes {{variables}} before validation" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT * FROM test_users WHERE name ILIKE '%' || {{query}} || '%'",
+                 "postgres"
+               )
+    end
+
+    test "strips [[optional clauses]] before validation" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT * FROM test_users WHERE 1=1 [[AND name ILIKE '%' || {{name}} || '%']]",
+                 "postgres"
+               )
+    end
+
+    test "rejects conversational text" do
+      assert {:error, _} =
+               Validator.validate(
+                 "I'm sorry, I cannot generate a query for that question.",
+                 "postgres"
+               )
+    end
+  end
+
+  describe "validate/2 with sqlite" do
+    @tag :sqlite
+    test "accepts SQLite-specific strftime function" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT strftime('%Y-%m', inserted_at) FROM test_users",
+                 "sqlite"
+               )
+    end
+
+    @tag :sqlite
+    test "accepts SQLite typeof function" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT typeof(name) FROM test_users",
+                 "sqlite"
+               )
+    end
+
+    @tag :sqlite
+    test "returns error for invalid SQL" do
+      assert {:error, _} = Validator.validate("NOT VALID SQL AT ALL", "sqlite")
+    end
+  end
+
+  describe "validate/2 with mysql" do
+    @tag :mysql
+    test "accepts MySQL-specific IFNULL function" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT IFNULL(name, 'unknown') FROM test_users",
+                 "mysql"
+               )
+    end
+
+    @tag :mysql
+    test "accepts MySQL backtick-quoted identifiers" do
+      assert :ok =
+               Validator.validate(
+                 "SELECT `name` FROM `test_users`",
+                 "mysql"
+               )
+    end
+
+    @tag :mysql
+    test "returns error for invalid SQL" do
+      assert {:error, _} = Validator.validate("NOT VALID SQL AT ALL", "mysql")
+    end
+  end
+end

--- a/test/lotus/variables_test.exs
+++ b/test/lotus/variables_test.exs
@@ -1,0 +1,73 @@
+defmodule Lotus.VariablesTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Variables
+
+  describe "regex/0" do
+    test "matches valid variable placeholders" do
+      assert Regex.match?(Variables.regex(), "{{user_id}}")
+      assert Regex.match?(Variables.regex(), "{{_private}}")
+      assert Regex.match?(Variables.regex(), "{{Name123}}")
+    end
+
+    test "captures variable name without braces" do
+      assert [_, "user_id"] = Regex.run(Variables.regex(), "{{user_id}}")
+    end
+
+    test "does not match invalid variable names" do
+      refute Regex.match?(Variables.regex(), "{{123abc}}")
+      refute Regex.match?(Variables.regex(), "{{a-b}}")
+      refute Regex.match?(Variables.regex(), "{{}}")
+    end
+  end
+
+  describe "extract_names/1" do
+    test "extracts variable names in order" do
+      assert Variables.extract_names("WHERE id = {{user_id}} AND status = {{status}}") ==
+               ["user_id", "status"]
+    end
+
+    test "preserves duplicate names" do
+      assert Variables.extract_names("{{a}} and {{b}} and {{a}}") == ["a", "b", "a"]
+    end
+
+    test "returns empty list when no variables" do
+      assert Variables.extract_names("SELECT * FROM users") == []
+    end
+
+    test "handles variables in complex expressions" do
+      content = """
+      SELECT * FROM users
+      WHERE name ILIKE '%' || {{query}} || '%'
+        AND age BETWEEN {{min_age}} AND {{max_age}}
+      """
+
+      assert Variables.extract_names(content) == ["query", "min_age", "max_age"]
+    end
+  end
+
+  describe "neutralize/2" do
+    test "replaces variables with NULL" do
+      assert Variables.neutralize("WHERE id = {{user_id}}", "NULL") ==
+               "WHERE id = NULL"
+    end
+
+    test "replaces multiple variables" do
+      assert Variables.neutralize("WHERE id = {{id}} AND status = {{status}}", "NULL") ==
+               "WHERE id = NULL AND status = NULL"
+    end
+
+    test "replaces with empty string" do
+      assert Variables.neutralize("Hello {{name}}!", "") == "Hello !"
+    end
+
+    test "replaces with custom placeholder" do
+      assert Variables.neutralize("{{greeting}} world", "Hello") == "Hello world"
+    end
+
+    test "passes through content with no variables" do
+      content = "no variables here"
+      assert Variables.neutralize(content, "NULL") == content
+    end
+  end
+end

--- a/test/support/ai_case.ex
+++ b/test/support/ai_case.ex
@@ -34,6 +34,12 @@ defmodule Lotus.AICase do
       setup do
         Mimic.copy(Lotus.Schema)
         Mimic.copy(Lotus.Sources)
+        Mimic.copy(Lotus.SQL.Validator)
+
+        stub(Lotus.SQL.Validator, :validate, fn _sql, _ds ->
+          {:error, "syntax error"}
+        end)
+
         :ok
       end
     end

--- a/test/support/mocks/req_llm_mocks.ex
+++ b/test/support/mocks/req_llm_mocks.ex
@@ -46,6 +46,8 @@ defmodule Lotus.ReqLLMMocks do
     expect(ReqLLM, :generate_text, fn _model, _context, _opts ->
       {:ok, build_response(plain_sql_response())}
     end)
+
+    expect(Lotus.SQL.Validator, :validate, fn _sql, _ds -> :ok end)
   end
 
   @doc """


### PR DESCRIPTION
Reject LLM responses that lack a ```sql code block instead of treating raw content as valid SQL. Conversational text now returns an {:error, {:unable_to_generate, content}} tuple.

Closes https://github.com/typhoonworks/lotus/issues/127