### PR TITLE
Sanitize interpolated SQL identifiers (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
   - Supports parameter binding via `:bind` option to hide/pre-fill parameters from the LLM
   - Built-in actions: `ListSchemas`, `ListTables`, `GetTableSchema`, `GetColumnValues`, `ListDataSources`, `ExecuteSQL`
 - **NEW:** `Lotus.AI.Tool.run/4` — shared tool-calling loop that replaces duplicated loops in `SQLGenerator`, `QueryOptimizer`, and `QueryExplainer`
+- **NEW:** `Lotus.SQL.Identifier` — shared module for SQL identifier validation and parsing
+  - Validates identifiers against `[a-zA-Z_][a-zA-Z0-9_]*` to prevent SQL injection in interpolated values
+  - `validate_identifier!/2` and `validate_search_path!/1` guard Postgres `search_path` and SQLite `PRAGMA` interpolations
+  - Consolidates `parse_table_name/1`, `validate_identifier/2`, and `validate_table_parts/2` previously in `Lotus.AI.Actions.Helpers`
 - Added `JSON.Encoder` derive for `Lotus.Result` struct
 
 ### Breaking

--- a/lib/lotus/ai/actions/get_column_values.ex
+++ b/lib/lotus/ai/actions/get_column_values.ex
@@ -8,7 +8,7 @@ defmodule Lotus.AI.Actions.GetColumnValues do
 
   @behaviour Lotus.AI.Action
 
-  alias Lotus.AI.Actions.Helpers
+  alias Lotus.SQL.Identifier
 
   @impl true
   def name, do: "get_column_values"
@@ -43,10 +43,10 @@ defmodule Lotus.AI.Actions.GetColumnValues do
 
   @impl true
   def run(params, _context) do
-    {schema, table} = Helpers.parse_table_name(params.table_name)
+    {schema, table} = Identifier.parse_table_name(params.table_name)
 
-    with :ok <- Helpers.validate_table_parts(schema, table),
-         :ok <- Helpers.validate_identifier(params.column_name, "column name") do
+    with :ok <- Identifier.validate_table_parts(schema, table),
+         :ok <- Identifier.validate_identifier(params.column_name, "column name") do
       execute_query(schema, table, params)
     end
   end

--- a/lib/lotus/ai/actions/get_table_schema.ex
+++ b/lib/lotus/ai/actions/get_table_schema.ex
@@ -8,7 +8,7 @@ defmodule Lotus.AI.Actions.GetTableSchema do
 
   @behaviour Lotus.AI.Action
 
-  alias Lotus.AI.Actions.Helpers
+  alias Lotus.SQL.Identifier
 
   @impl true
   def name, do: "get_table_schema"
@@ -33,9 +33,9 @@ defmodule Lotus.AI.Actions.GetTableSchema do
 
   @impl true
   def run(params, _context) do
-    {schema, table} = Helpers.parse_table_name(params.table_name)
+    {schema, table} = Identifier.parse_table_name(params.table_name)
 
-    with :ok <- Helpers.validate_table_parts(schema, table) do
+    with :ok <- Identifier.validate_table_parts(schema, table) do
       fetch_schema(params.data_source, schema, table, params.table_name)
     end
   end

--- a/lib/lotus/sources/postgres.ex
+++ b/lib/lotus/sources/postgres.ex
@@ -5,6 +5,7 @@ defmodule Lotus.Sources.Postgres do
 
   alias Lotus.Sources.Default
   alias Lotus.SQL.FilterInjector
+  alias Lotus.SQL.Identifier
 
   @postgrex_error Module.concat([:Postgrex, :Error])
 
@@ -19,7 +20,11 @@ defmodule Lotus.Sources.Postgres do
       fn ->
         if read_only?, do: repo.query!("SET LOCAL transaction_read_only = on")
         repo.query!("SET LOCAL statement_timeout = #{stmt_ms}")
-        if search_path, do: repo.query!("SET LOCAL search_path = #{search_path}")
+
+        if search_path do
+          Identifier.validate_search_path!(search_path)
+          repo.query!("SET LOCAL search_path = #{search_path}")
+        end
 
         fun.()
       end,
@@ -37,6 +42,7 @@ defmodule Lotus.Sources.Postgres do
 
   @impl true
   def set_search_path(repo, search_path) when is_binary(search_path) do
+    Identifier.validate_search_path!(search_path)
     repo.query!("SET LOCAL search_path = #{search_path}")
     :ok
   end
@@ -190,7 +196,12 @@ defmodule Lotus.Sources.Postgres do
     result =
       repo.transaction(fn ->
         repo.query!("SET LOCAL transaction_read_only = on")
-        if search_path, do: repo.query!("SET LOCAL search_path = #{search_path}")
+
+        if search_path do
+          Identifier.validate_search_path!(search_path)
+          repo.query!("SET LOCAL search_path = #{search_path}")
+        end
+
         repo.query(explain_sql, params)
       end)
       |> case do

--- a/lib/lotus/sources/sqlite.ex
+++ b/lib/lotus/sources/sqlite.ex
@@ -7,6 +7,7 @@ defmodule Lotus.Sources.SQLite3 do
 
   alias Lotus.Sources.Default
   alias Lotus.SQL.FilterInjector
+  alias Lotus.SQL.Identifier
 
   @exlite_error Module.concat([:Exqlite, :Error])
 
@@ -146,6 +147,7 @@ defmodule Lotus.Sources.SQLite3 do
   @impl true
   def get_table_schema(repo, _schema, table_name) do
     # SQLite doesn't use schemas, ignore the schema parameter
+    Identifier.validate_identifier!(table_name, "table name")
     query = "PRAGMA table_info(#{table_name})"
 
     result = repo.query!(query)

--- a/lib/lotus/sql/identifier.ex
+++ b/lib/lotus/sql/identifier.ex
@@ -1,4 +1,4 @@
-defmodule Lotus.AI.Actions.Helpers do
+defmodule Lotus.SQL.Identifier do
   @moduledoc false
 
   # Regex for valid SQL identifiers: letters, digits, underscores.
@@ -34,6 +34,17 @@ defmodule Lotus.AI.Actions.Helpers do
   end
 
   @doc """
+  Validates that a string is a safe SQL identifier, raising on failure.
+  """
+  @spec validate_identifier!(String.t(), String.t()) :: :ok
+  def validate_identifier!(value, label) do
+    case validate_identifier(value, label) do
+      :ok -> :ok
+      {:error, reason} -> raise ArgumentError, reason
+    end
+  end
+
+  @doc """
   Validates all parts of a table reference (schema + table, or just table).
   """
   @spec validate_table_parts(String.t() | nil, String.t()) :: :ok | {:error, String.t()}
@@ -43,5 +54,21 @@ defmodule Lotus.AI.Actions.Helpers do
     with :ok <- validate_identifier(schema, "schema name") do
       validate_identifier(table, "table name")
     end
+  end
+
+  @doc """
+  Validates a Postgres search_path string.
+
+  Splits on `,`, trims whitespace, and validates each part as an identifier.
+  Raises `ArgumentError` if any part is invalid.
+  """
+  @spec validate_search_path!(String.t()) :: :ok
+  def validate_search_path!(search_path) do
+    search_path
+    |> String.split(",")
+    |> Enum.each(fn part ->
+      part = String.trim(part)
+      validate_identifier!(part, "search_path entry")
+    end)
   end
 end

--- a/test/lotus/sql/identifier_test.exs
+++ b/test/lotus/sql/identifier_test.exs
@@ -1,0 +1,109 @@
+defmodule Lotus.SQL.IdentifierTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.SQL.Identifier
+
+  describe "parse_table_name/1" do
+    test "parses unqualified table name" do
+      assert {nil, "users"} = Identifier.parse_table_name("users")
+    end
+
+    test "parses schema-qualified table name" do
+      assert {"public", "users"} = Identifier.parse_table_name("public.users")
+    end
+
+    test "handles extra dots in table name" do
+      assert {"public", "users.extra"} = Identifier.parse_table_name("public.users.extra")
+    end
+  end
+
+  describe "validate_identifier/2" do
+    test "accepts valid identifiers" do
+      assert :ok = Identifier.validate_identifier("users", "table name")
+      assert :ok = Identifier.validate_identifier("_private", "table name")
+      assert :ok = Identifier.validate_identifier("table_123", "table name")
+      assert :ok = Identifier.validate_identifier("A", "table name")
+    end
+
+    test "rejects identifiers starting with a digit" do
+      assert {:error, msg} = Identifier.validate_identifier("123abc", "table name")
+      assert msg =~ "Invalid table name"
+    end
+
+    test "rejects identifiers with special characters" do
+      assert {:error, _} = Identifier.validate_identifier("users; DROP TABLE", "table name")
+      assert {:error, _} = Identifier.validate_identifier("table-name", "column name")
+      assert {:error, _} = Identifier.validate_identifier("name space", "schema name")
+    end
+
+    test "rejects empty string" do
+      assert {:error, _} = Identifier.validate_identifier("", "table name")
+    end
+  end
+
+  describe "validate_identifier!/2" do
+    test "returns :ok for valid identifiers" do
+      assert :ok = Identifier.validate_identifier!("users", "table name")
+    end
+
+    test "raises ArgumentError for invalid identifiers" do
+      assert_raise ArgumentError, ~r/Invalid table name/, fn ->
+        Identifier.validate_identifier!("users; DROP TABLE", "table name")
+      end
+    end
+  end
+
+  describe "validate_table_parts/2" do
+    test "validates unqualified table name" do
+      assert :ok = Identifier.validate_table_parts(nil, "users")
+    end
+
+    test "validates schema-qualified table name" do
+      assert :ok = Identifier.validate_table_parts("public", "users")
+    end
+
+    test "rejects invalid table name" do
+      assert {:error, _} = Identifier.validate_table_parts(nil, "bad; table")
+    end
+
+    test "rejects invalid schema name" do
+      assert {:error, msg} = Identifier.validate_table_parts("bad schema", "users")
+      assert msg =~ "Invalid schema name"
+    end
+
+    test "rejects invalid table with valid schema" do
+      assert {:error, msg} = Identifier.validate_table_parts("public", "bad-table")
+      assert msg =~ "Invalid table name"
+    end
+  end
+
+  describe "validate_search_path!/1" do
+    test "accepts single schema" do
+      assert :ok = Identifier.validate_search_path!("public")
+    end
+
+    test "accepts comma-separated schemas" do
+      assert :ok = Identifier.validate_search_path!("public, reporting, analytics")
+    end
+
+    test "accepts schemas without spaces" do
+      assert :ok = Identifier.validate_search_path!("public,reporting")
+    end
+
+    test "rejects invalid characters in search path" do
+      assert_raise ArgumentError, ~r/Invalid search_path entry/, fn ->
+        Identifier.validate_search_path!("public; DROP TABLE users --")
+      end
+    end
+
+    test "rejects SQL injection attempts" do
+      assert_raise ArgumentError, fn ->
+        Identifier.validate_search_path!("public, 'bad")
+      end
+
+      assert_raise ArgumentError, fn ->
+        Identifier.validate_search_path!("public; DROP")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Lotus.SQL.Identifier module with defense-in-depth validation for SQL identifiers interpolated into query strings. Validates Postgres search_path and SQLite PRAGMA table_name against a safe identifier regex to prevent potential SQL injection from config-controlled values.

Closes https://github.com/typhoonworks/lotus/issues/130