### PR TITLE
Add result sorting via :sorts option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@
   - Source-aware: each database adapter (PostgreSQL, MySQL, SQLite) handles its own identifier quoting via new `quote_identifier/1` and `apply_filters/2` callbacks on `Lotus.Source`
   - New `Lotus.Query.Filter` struct for source-agnostic filter representation
   - New `Lotus.SQL.FilterInjector` shared helper for SQL-based sources
+- **NEW:** Result sorting via `:sorts` option on `Lotus.run_query/2` and `Lotus.run_sql/3`
+  - Pass a list of `Lotus.Query.Sort` structs to apply ORDER BY on top of any query
+  - Sorts are applied by wrapping the original query in a CTE, so they work safely with any SQL complexity (joins, subqueries, unions, existing ORDER BY, etc.)
+  - Supports `:asc` and `:desc` directions
+  - Source-aware: each database adapter handles its own identifier quoting via new `apply_sorts/2` callback on `Lotus.Source`
+  - New `Lotus.Query.Sort` struct for source-agnostic sort representation
+  - New `Lotus.SQL.SortInjector` shared helper for SQL-based sources
 - **FIX:** AI SQL generation now validates plain SQL responses (without `` ```sql `` code blocks) against the database using EXPLAIN before rejecting them — valid SQL is accepted, conversational text is still rejected as `{:error, {:unable_to_generate, content}}` ([#127](https://github.com/typhoonworks/lotus/issues/127))
 - **NEW:** `Lotus.SQL.Validator` — validates SQL syntax against the database without executing, using EXPLAIN. Neutralizes `{{var}}` and `[[...]]` template syntax before validation
 - **NEW:** `Lotus.AI.Actions.ValidateSQL` — AI tool action that lets the LLM validate its SQL against the database before returning it

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For the complete setup guide (caching, multiple databases, visibility controls),
 - **Result caching** — TTL-based caching with ETS backend, cache profiles, and tag-based invalidation
 - **CSV export** — download query results with streaming support for large datasets
 - **Result filters** — apply column-level filters on query results via `Lotus.Query.Filter`; multiple filters stack with AND and wrap the original query in a CTE for safe application
+- **Result sorting** — apply column-level sorting on query results via `Lotus.Query.Sort`; sorts wrap the original query in a CTE so they work safely with any SQL complexity
 - **Schema explorer** — browse tables, columns, and statistics interactively
 - **AI query generation** — ask your database questions in plain English; schema-aware, multi-turn conversations using OpenAI, Anthropic, or Gemini (BYOK)
 - **AI query explanation** — get plain-language explanations of what a query does, including selected fragments; understands Lotus `{{variable}}` and `[[optional]]` syntax

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -448,6 +448,9 @@ defmodule Lotus do
     filters = Keyword.get(opts, :filters, [])
     sql = Lotus.Source.apply_filters(repo_mod, sql, filters)
 
+    sorts = Keyword.get(opts, :sorts, [])
+    sql = Lotus.Source.apply_sorts(repo_mod, sql, sorts)
+
     {sql, params, window_meta, cache_bound} =
       maybe_apply_window(
         sql,
@@ -596,6 +599,9 @@ defmodule Lotus do
 
     filters = Keyword.get(opts, :filters, [])
     sql = Lotus.Source.apply_filters(repo_mod, sql, filters)
+
+    sorts = Keyword.get(opts, :sorts, [])
+    sql = Lotus.Source.apply_sorts(repo_mod, sql, sorts)
 
     {sql, params, window_meta, cache_bound} =
       maybe_apply_window(

--- a/lib/lotus/query/sort.ex
+++ b/lib/lotus/query/sort.ex
@@ -1,0 +1,47 @@
+defmodule Lotus.Query.Sort do
+  @moduledoc """
+  Represents a sort directive to apply on query results.
+
+  Sorts are source-agnostic data structures that describe a column-level
+  ordering. Each source adapter knows how to translate sorts into its
+  native query language (e.g., SQL ORDER BY clauses).
+
+  ## Examples
+
+      %Sort{column: "created_at", direction: :desc}
+      %Sort{column: "name", direction: :asc}
+  """
+
+  @type direction :: :asc | :desc
+
+  @type t :: %__MODULE__{
+          column: String.t(),
+          direction: direction()
+        }
+
+  @enforce_keys [:column, :direction]
+  defstruct [:column, :direction]
+
+  @directions ~w(asc desc)a
+
+  @doc """
+  Creates a new sort, validating the direction.
+  """
+  @spec new(String.t(), direction()) :: t()
+  def new(column, direction) when direction in @directions do
+    %__MODULE__{column: column, direction: direction}
+  end
+
+  @doc """
+  Returns the list of valid direction atoms.
+  """
+  @spec directions() :: [direction(), ...]
+  def directions, do: @directions
+
+  @doc """
+  Returns a human-readable label for the given direction.
+  """
+  @spec direction_label(direction()) :: String.t()
+  def direction_label(:asc), do: "ASC"
+  def direction_label(:desc), do: "DESC"
+end

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -33,6 +33,16 @@ defmodule Lotus.Source do
   @callback apply_filters(sql :: String.t(), filters :: [Lotus.Query.Filter.t()]) :: String.t()
 
   @doc """
+  Applies a list of sorts to an existing query, returning a new query string.
+
+  For SQL sources, this appends an ORDER BY clause. Applied after filters
+  so the ORDER BY operates on the filtered result set.
+
+  Returns the original query unchanged when sorts is empty.
+  """
+  @callback apply_sorts(sql :: String.t(), sorts :: [Lotus.Query.Sort.t()]) :: String.t()
+
+  @doc """
   Return the list of built-in deny rules for system tables and metadata relations
   that should be hidden from the schema browser for this source.
 
@@ -429,5 +439,18 @@ defmodule Lotus.Source do
 
   def apply_filters(repo_or_name, sql, filters) do
     impl_for(resolve_repo!(repo_or_name)).apply_filters(sql, filters)
+  end
+
+  @doc """
+  Applies sorts to a query using the source-specific implementation.
+
+  Returns the original query unchanged when sorts is empty.
+  """
+  @spec apply_sorts(repo | String.t() | nil, String.t(), [Lotus.Query.Sort.t()]) ::
+          String.t()
+  def apply_sorts(_repo_or_name, sql, []), do: sql
+
+  def apply_sorts(repo_or_name, sql, sorts) do
+    impl_for(resolve_repo!(repo_or_name)).apply_sorts(sql, sorts)
   end
 end

--- a/lib/lotus/sources/default.ex
+++ b/lib/lotus/sources/default.ex
@@ -9,6 +9,7 @@ defmodule Lotus.Sources.Default do
   @behaviour Lotus.Source
 
   alias Lotus.SQL.FilterInjector
+  alias Lotus.SQL.SortInjector
 
   @impl true
   @doc "Simple transaction wrapper for unsupported sources."
@@ -158,5 +159,11 @@ defmodule Lotus.Sources.Default do
   @doc "Applies filters using standard SQL CTE wrapping with double-quoted identifiers."
   def apply_filters(sql, filters) do
     FilterInjector.apply(sql, filters, &quote_identifier/1)
+  end
+
+  @impl true
+  @doc "Applies sorts by appending ORDER BY clause with double-quoted identifiers."
+  def apply_sorts(sql, sorts) do
+    SortInjector.apply(sql, sorts, &quote_identifier/1)
   end
 end

--- a/lib/lotus/sources/mysql.ex
+++ b/lib/lotus/sources/mysql.ex
@@ -6,6 +6,7 @@ defmodule Lotus.Sources.MySQL do
 
   alias Lotus.Sources.Default
   alias Lotus.SQL.FilterInjector
+  alias Lotus.SQL.SortInjector
 
   @myxql_error Module.concat([:MyXQL, :Error])
 
@@ -325,6 +326,11 @@ defmodule Lotus.Sources.MySQL do
   @impl true
   def apply_filters(sql, filters) do
     FilterInjector.apply(sql, filters, &quote_identifier/1)
+  end
+
+  @impl true
+  def apply_sorts(sql, sorts) do
+    SortInjector.apply(sql, sorts, &quote_identifier/1)
   end
 
   defp format_mysql_type("varchar", char_len, _, _) when not is_nil(char_len),

--- a/lib/lotus/sources/postgres.ex
+++ b/lib/lotus/sources/postgres.ex
@@ -6,6 +6,7 @@ defmodule Lotus.Sources.Postgres do
   alias Lotus.Sources.Default
   alias Lotus.SQL.FilterInjector
   alias Lotus.SQL.Identifier
+  alias Lotus.SQL.SortInjector
 
   @postgrex_error Module.concat([:Postgrex, :Error])
 
@@ -249,6 +250,11 @@ defmodule Lotus.Sources.Postgres do
   @impl true
   def apply_filters(sql, filters) do
     FilterInjector.apply(sql, filters, &quote_identifier/1)
+  end
+
+  @impl true
+  def apply_sorts(sql, sorts) do
+    SortInjector.apply(sql, sorts, &quote_identifier/1)
   end
 
   defp format_postgres_type("character varying", char_len, _, _) when not is_nil(char_len),

--- a/lib/lotus/sources/sqlite.ex
+++ b/lib/lotus/sources/sqlite.ex
@@ -8,6 +8,7 @@ defmodule Lotus.Sources.SQLite3 do
   alias Lotus.Sources.Default
   alias Lotus.SQL.FilterInjector
   alias Lotus.SQL.Identifier
+  alias Lotus.SQL.SortInjector
 
   @exlite_error Module.concat([:Exqlite, :Error])
 
@@ -196,5 +197,10 @@ defmodule Lotus.Sources.SQLite3 do
   @impl true
   def apply_filters(sql, filters) do
     FilterInjector.apply(sql, filters, &quote_identifier/1)
+  end
+
+  @impl true
+  def apply_sorts(sql, sorts) do
+    SortInjector.apply(sql, sorts, &quote_identifier/1)
   end
 end

--- a/lib/lotus/sql/sort_injector.ex
+++ b/lib/lotus/sql/sort_injector.ex
@@ -1,0 +1,43 @@
+defmodule Lotus.SQL.SortInjector do
+  @moduledoc """
+  Shared helpers for SQL-based sources to inject sort directives into queries.
+
+  Wraps the original query in a CTE and appends an ORDER BY clause.
+  This ensures sorting works even when the original query already contains
+  ORDER BY, GROUP BY, or other trailing clauses.
+
+  Each SQL source calls this with its own `quote_fn` for identifier quoting.
+
+  ## Example
+
+      quote_fn = fn id -> ~s("\#{id}") end
+      Lotus.SQL.SortInjector.apply("SELECT * FROM users ORDER BY id", [
+        %Lotus.Query.Sort{column: "created_at", direction: :desc}
+      ], quote_fn)
+      #=> ~s(WITH _sorted AS (SELECT * FROM users ORDER BY id) SELECT * FROM _sorted ORDER BY "created_at" DESC)
+  """
+
+  alias Lotus.Query.Sort
+
+  @doc """
+  Wraps the given SQL in a CTE and appends ORDER BY for each sort directive.
+
+  `quote_fn` is a 1-arity function that quotes an identifier for the target database.
+
+  Returns the original SQL unchanged if sorts is empty.
+  """
+  @spec apply(String.t(), [Sort.t()], (String.t() -> String.t())) :: String.t()
+  def apply(sql, [], _quote_fn), do: sql
+
+  def apply(sql, sorts, quote_fn) when is_list(sorts) and is_function(quote_fn, 1) do
+    order_clause = Enum.map_join(sorts, ", ", &build_sort_clause(&1, quote_fn))
+    "WITH _sorted AS (#{sql}) SELECT * FROM _sorted ORDER BY #{order_clause}"
+  end
+
+  defp build_sort_clause(%Sort{column: column, direction: direction}, quote_fn) do
+    "#{quote_fn.(column)} #{direction_to_sql(direction)}"
+  end
+
+  defp direction_to_sql(:asc), do: "ASC"
+  defp direction_to_sql(:desc), do: "DESC"
+end

--- a/test/lotus/sql/sort_injector_test.exs
+++ b/test/lotus/sql/sort_injector_test.exs
@@ -1,0 +1,90 @@
+defmodule Lotus.SQL.SortInjectorTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Query.Sort
+  alias Lotus.SQL.SortInjector
+
+  defp double_quote(id), do: ~s("#{id}")
+  defp backtick_quote(id), do: "`#{id}`"
+
+  describe "apply/3" do
+    test "returns original SQL when sorts is empty" do
+      sql = "SELECT * FROM users"
+      assert SortInjector.apply(sql, [], &double_quote/1) == sql
+    end
+
+    test "wraps SQL in CTE with single asc sort" do
+      sql = "SELECT * FROM users"
+      sorts = [Sort.new("name", :asc)]
+
+      result = SortInjector.apply(sql, sorts, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _sorted AS (SELECT * FROM users) SELECT * FROM _sorted ORDER BY "name" ASC]
+    end
+
+    test "wraps SQL in CTE with single desc sort" do
+      sql = "SELECT * FROM users"
+      sorts = [Sort.new("created_at", :desc)]
+
+      result = SortInjector.apply(sql, sorts, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _sorted AS (SELECT * FROM users) SELECT * FROM _sorted ORDER BY "created_at" DESC]
+    end
+
+    test "handles multiple sorts" do
+      sql = "SELECT * FROM orders"
+
+      sorts = [
+        Sort.new("status", :asc),
+        Sort.new("created_at", :desc)
+      ]
+
+      result = SortInjector.apply(sql, sorts, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _sorted AS (SELECT * FROM orders) SELECT * FROM _sorted ORDER BY "status" ASC, "created_at" DESC]
+    end
+
+    test "works with backtick quoting (MySQL style)" do
+      sorts = [Sort.new("name", :asc)]
+      result = SortInjector.apply("SELECT * FROM users", sorts, &backtick_quote/1)
+
+      assert result ==
+               "WITH _sorted AS (SELECT * FROM users) SELECT * FROM _sorted ORDER BY `name` ASC"
+    end
+
+    test "escapes double quotes in column names" do
+      quote_fn = fn id ->
+        escaped = String.replace(id, "\"", "\"\"")
+        ~s("#{escaped}")
+      end
+
+      sorts = [Sort.new(~s(col"name), :desc)]
+      result = SortInjector.apply("SELECT * FROM t", sorts, quote_fn)
+      assert result =~ ~s("col""name" DESC)
+    end
+
+    test "safely wraps queries that already have ORDER BY" do
+      sql = "SELECT * FROM users ORDER BY id"
+      sorts = [Sort.new("name", :desc)]
+
+      result = SortInjector.apply(sql, sorts, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _sorted AS (SELECT * FROM users ORDER BY id) SELECT * FROM _sorted ORDER BY "name" DESC]
+    end
+
+    test "works after CTE-wrapped filtered query" do
+      sql =
+        ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+
+      sorts = [Sort.new("name", :asc)]
+      result = SortInjector.apply(sql, sorts, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _sorted AS (WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US') SELECT * FROM _sorted ORDER BY "name" ASC]
+    end
+  end
+end


### PR DESCRIPTION
Introduce Lotus.Query.Sort struct and Lotus.SQL.SortInjector to apply ORDER BY directives on query results. Sorts wrap the original query in a CTE, mirroring the filter injector pattern, so they work safely with any SQL complexity. Each source adapter implements the new apply_sorts/2 callback with its own identifier quoting.