### PR TITLE
Fix ExDoc warning about unclosed backquotes in sql_generation docs

### DIFF
--- a/lib/lotus/ai/prompts/sql_generation.ex
+++ b/lib/lotus/ai/prompts/sql_generation.ex
@@ -134,10 +134,10 @@ defmodule Lotus.AI.Prompts.SQLGeneration do
     end
   end
 
-  @doc """
+  @doc ~S"""
   Extract variable configurations from LLM response content.
 
-  Parses a ```variables JSON block from the response. Returns an empty list
+  Parses a ```` ```variables ```` JSON block from the response. Returns an empty list
   if no block is found or if the JSON is malformed.
 
   ## Parameters
@@ -150,7 +150,7 @@ defmodule Lotus.AI.Prompts.SQLGeneration do
 
   ## Examples
 
-      iex> extract_variables("```variables\\n[{\\"name\\": \\"status\\", \\"type\\": \\"text\\"}]\\n```")
+      iex> extract_variables("```variables\n[{\"name\": \"status\", \"type\": \"text\"}]\n```")
       [%{"name" => "status", "type" => "text", "widget" => "input", "list" => false}]
 
       iex> extract_variables("Just some SQL without variables")


### PR DESCRIPTION
Use ~S sigil for the @doc string and wrap inline triple backticks with quadruple backticks in the prose text.