### PR TITLE
Wrap raw LLM provider errors in Lotus.AI.Error domain exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-03-08
+
+### Fixed
+
+- **FIX:** Wrap raw LLM provider errors in `Lotus.AI.Error` domain exceptions before returning them to callers — raw errors from ReqLLM (containing API endpoints, stack traces, provider metadata) are now logged server-side and replaced with user-safe error structs: `RateLimitError`, `AuthenticationError`, `ServerError`, `TimeoutError`, `ServiceError`
+
 ## [0.16.0] - 2026-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Get a fully working BI dashboard in your Phoenix app in under 5 minutes.
 # mix.exs
 def deps do
   [
-    {:lotus, "~> 0.16.0"},
+    {:lotus, "~> 0.16.1"},
     {:lotus_web, "~> 0.14.0"}
   ]
 end

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -16,7 +16,7 @@ Add `lotus` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:lotus, "~> 0.16.0"}
+    {:lotus, "~> 0.16.1"}
   ]
 end
 ```
@@ -244,7 +244,7 @@ Add `lotus_web` to your dependencies:
 ```elixir
 def deps do
   [
-    {:lotus, "~> 0.16.0"},
+    {:lotus, "~> 0.16.1"},
     {:lotus_web, "~> 0.14.0"}
   ]
 end

--- a/lib/lotus/ai/error.ex
+++ b/lib/lotus/ai/error.ex
@@ -1,0 +1,67 @@
+defmodule Lotus.AI.Error do
+  @moduledoc """
+  Domain errors for AI service failures.
+
+  Wraps raw provider errors (from ReqLLM) into Lotus-owned exceptions
+  with user-friendly messages. The raw error is logged server-side;
+  only the wrapped error is returned to callers.
+  """
+
+  defmodule RateLimitError do
+    @moduledoc "The AI provider rejected the request due to rate limits or quota."
+    defexception message:
+                   "The AI service is temporarily unavailable due to rate limits. Please try again later."
+  end
+
+  defmodule AuthenticationError do
+    @moduledoc "The AI provider rejected the request due to invalid or missing credentials."
+    defexception message:
+                   "AI service authentication failed. Please check your API key configuration."
+  end
+
+  defmodule ServerError do
+    @moduledoc "The AI provider returned a server-side error (5xx)."
+    defexception message: "The AI service is temporarily unavailable. Please try again later."
+  end
+
+  defmodule TimeoutError do
+    @moduledoc "The AI request timed out."
+    defexception message: "The AI request timed out. Please try again."
+  end
+
+  defmodule ServiceError do
+    @moduledoc "Catch-all for unexpected AI service errors."
+    defexception message: "An unexpected error occurred with the AI service. Please try again."
+  end
+
+  @doc """
+  Wraps a raw LLM provider error into a Lotus AI domain error.
+
+  Pattern-matches on known `ReqLLM.Error` types and HTTP status codes
+  to return the appropriate exception. Unknown errors become `ServiceError`.
+
+  ## Examples
+
+      iex> raw = %ReqLLM.Error.API.Request{status: 429, reason: "rate limited"}
+      iex> %Lotus.AI.Error.RateLimitError{} = Lotus.AI.Error.wrap(raw)
+
+      iex> Lotus.AI.Error.wrap(:something_unexpected)
+      %Lotus.AI.Error.ServiceError{}
+
+  """
+  @spec wrap(term()) :: Exception.t()
+  def wrap(%ReqLLM.Error.API.Request{status: 429}), do: %RateLimitError{}
+
+  def wrap(%ReqLLM.Error.API.Request{status: status}) when status in [401, 403],
+    do: %AuthenticationError{}
+
+  def wrap(%ReqLLM.Error.API.Request{status: status})
+      when is_integer(status) and status >= 500,
+      do: %ServerError{}
+
+  def wrap(%ReqLLM.Error.API.Request{reason: reason}) when is_binary(reason) do
+    if reason =~ ~r/timed?\s*out/i, do: %TimeoutError{}, else: %ServiceError{}
+  end
+
+  def wrap(_error), do: %ServiceError{}
+end

--- a/lib/lotus/ai/tool.ex
+++ b/lib/lotus/ai/tool.ex
@@ -19,6 +19,8 @@ defmodule Lotus.AI.Tool do
       {:ok, response} = Tool.run("openai:gpt-4o", context, tools, api_key: "sk-...")
   """
 
+  alias Lotus.AI.Error
+
   require Logger
 
   @default_max_iterations 10
@@ -135,8 +137,9 @@ defmodule Lotus.AI.Tool do
             {:ok, response}
         end
 
-      {:error, _} = error ->
-        error
+      {:error, raw_error} ->
+        Logger.error("AI service error: #{inspect(raw_error)}")
+        {:error, Error.wrap(raw_error)}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus"
-  @version "0.16.0"
+  @version "0.16.1"
 
   def project do
     [

--- a/test/lotus/ai/error_test.exs
+++ b/test/lotus/ai/error_test.exs
@@ -1,0 +1,58 @@
+defmodule Lotus.AI.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.AI.Error
+  alias ReqLLM.Error.API.Request, as: APIRequest
+
+  describe "wrap/1" do
+    test "wraps 429 status as RateLimitError" do
+      raw = APIRequest.exception(status: 429, reason: "Too many requests")
+      assert %Error.RateLimitError{} = Error.wrap(raw)
+    end
+
+    test "wraps 401 status as AuthenticationError" do
+      raw = APIRequest.exception(status: 401, reason: "Unauthorized")
+      assert %Error.AuthenticationError{} = Error.wrap(raw)
+    end
+
+    test "wraps 403 status as AuthenticationError" do
+      raw = APIRequest.exception(status: 403, reason: "Forbidden")
+      assert %Error.AuthenticationError{} = Error.wrap(raw)
+    end
+
+    test "wraps 5xx status as ServerError" do
+      raw = APIRequest.exception(status: 500, reason: "Internal Server Error")
+      assert %Error.ServerError{} = Error.wrap(raw)
+
+      raw = APIRequest.exception(status: 503, reason: "Service Unavailable")
+      assert %Error.ServerError{} = Error.wrap(raw)
+    end
+
+    test "wraps timeout reason as TimeoutError" do
+      raw = APIRequest.exception(status: nil, reason: "request timed out")
+      assert %Error.TimeoutError{} = Error.wrap(raw)
+
+      raw = APIRequest.exception(status: nil, reason: "timeout")
+      assert %Error.TimeoutError{} = Error.wrap(raw)
+    end
+
+    test "wraps other API request errors as ServiceError" do
+      raw = APIRequest.exception(status: 400, reason: "Bad Request")
+      assert %Error.ServiceError{} = Error.wrap(raw)
+    end
+
+    test "wraps unknown error terms as ServiceError" do
+      assert %Error.ServiceError{} = Error.wrap(:something_unexpected)
+      assert %Error.ServiceError{} = Error.wrap("string error")
+      assert %Error.ServiceError{} = Error.wrap(%RuntimeError{message: "boom"})
+    end
+
+    test "all error structs implement Exception with user-friendly messages" do
+      assert Exception.message(%Error.RateLimitError{}) =~ "rate limits"
+      assert Exception.message(%Error.AuthenticationError{}) =~ "authentication"
+      assert Exception.message(%Error.ServerError{}) =~ "temporarily unavailable"
+      assert Exception.message(%Error.TimeoutError{}) =~ "timed out"
+      assert Exception.message(%Error.ServiceError{}) =~ "unexpected error"
+    end
+  end
+end

--- a/test/lotus/ai/query_explainer_test.exs
+++ b/test/lotus/ai/query_explainer_test.exs
@@ -148,10 +148,10 @@ defmodule Lotus.AI.QueryExplainerTest do
                )
     end
 
-    test "returns error when API fails" do
+    test "returns wrapped error when API fails" do
       mock_api_error("Invalid API key")
 
-      assert {:error, "Invalid API key"} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                QueryExplainer.explain_query("openai:gpt-4o",
                  sql: "SELECT * FROM orders",
                  data_source: "postgres",
@@ -159,10 +159,10 @@ defmodule Lotus.AI.QueryExplainerTest do
                )
     end
 
-    test "returns error when request times out" do
+    test "returns wrapped error when request times out" do
       mock_timeout()
 
-      assert {:error, :timeout} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                QueryExplainer.explain_query("openai:gpt-4o",
                  sql: "SELECT * FROM orders",
                  data_source: "postgres",

--- a/test/lotus/ai/query_optimizer_test.exs
+++ b/test/lotus/ai/query_optimizer_test.exs
@@ -107,10 +107,10 @@ defmodule Lotus.AI.QueryOptimizerTest do
                )
     end
 
-    test "returns error when API fails" do
+    test "returns wrapped error when API fails" do
       mock_api_error("Invalid API key")
 
-      assert {:error, "Invalid API key"} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                QueryOptimizer.suggest_optimizations("openai:gpt-4o",
                  sql: "SELECT * FROM orders",
                  data_source: "postgres",
@@ -118,10 +118,10 @@ defmodule Lotus.AI.QueryOptimizerTest do
                )
     end
 
-    test "returns error when request times out" do
+    test "returns wrapped error when request times out" do
       mock_timeout()
 
-      assert {:error, :timeout} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                QueryOptimizer.suggest_optimizations("openai:gpt-4o",
                  sql: "SELECT * FROM orders",
                  data_source: "postgres",

--- a/test/lotus/ai/sql_generator_test.exs
+++ b/test/lotus/ai/sql_generator_test.exs
@@ -138,10 +138,10 @@ defmodule Lotus.AI.SQLGeneratorTest do
       assert reason == "This is a weather question, not a database query"
     end
 
-    test "returns error when API fails" do
+    test "returns wrapped error when API fails" do
       mock_api_error("Invalid API key")
 
-      assert {:error, "Invalid API key"} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                SQLGenerator.generate_sql("openai:gpt-4o",
                  prompt: "Test",
                  data_source: "postgres",
@@ -149,10 +149,10 @@ defmodule Lotus.AI.SQLGeneratorTest do
                )
     end
 
-    test "returns error when request times out" do
+    test "returns wrapped error when request times out" do
       mock_timeout()
 
-      assert {:error, :timeout} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                SQLGenerator.generate_sql("openai:gpt-4o",
                  prompt: "Test",
                  data_source: "postgres",

--- a/test/lotus/ai_test.exs
+++ b/test/lotus/ai_test.exs
@@ -146,20 +146,20 @@ defmodule Lotus.AITest do
       assert reason == "This is a weather question, not a database query"
     end
 
-    test "returns error when API fails" do
+    test "returns wrapped error when API fails" do
       mock_api_error("Rate limit exceeded")
 
-      assert {:error, "Rate limit exceeded"} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                AI.generate_query(
                  prompt: "test",
                  data_source: "postgres"
                )
     end
 
-    test "returns error when request times out" do
+    test "returns wrapped error when request times out" do
       mock_timeout()
 
-      assert {:error, :timeout} =
+      assert {:error, %Lotus.AI.Error.ServiceError{}} =
                AI.generate_query(
                  prompt: "test",
                  data_source: "postgres"


### PR DESCRIPTION
Raw errors from ReqLLM were passed through the entire call chain and could leak sensitive internal details (API endpoints, stack traces, provider metadata). Errors are now logged server-side and wrapped into user-safe exception structs before being returned to callers.

Release v0.16.1

Closes https://github.com/typhoonworks/lotus/issues/142