### PR TITLE
Strip trailing semicolons before CTE wrapping in filter/sort injectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-03-08
+
+### Fixed
+
+- **FIX:** Strip trailing semicolons from SQL queries before wrapping them in CTEs in `FilterInjector` and `SortInjector` — queries ending with `;` (e.g. CTE queries) would trigger the "Only a single statement is allowed" error when filters or sorts were applied
+- **NEW:** Extract shared `Lotus.SQL.Sanitizer` module for SQL string cleanup helpers used by injectors
+
 ## [0.16.1] - 2026-03-08
 
 ### Fixed

--- a/lib/lotus/sql/filter_injector.ex
+++ b/lib/lotus/sql/filter_injector.ex
@@ -16,6 +16,8 @@ defmodule Lotus.SQL.FilterInjector do
 
   alias Lotus.Query.Filter
 
+  import Lotus.SQL.Sanitizer, only: [strip_trailing_semicolon: 1]
+
   @doc """
   Wraps the given SQL in a CTE and appends WHERE clauses for each filter.
 
@@ -28,7 +30,8 @@ defmodule Lotus.SQL.FilterInjector do
 
   def apply(sql, filters, quote_fn) when is_list(filters) and is_function(quote_fn, 1) do
     conditions = Enum.map_join(filters, " AND ", &build_condition(&1, quote_fn))
-    "WITH _base AS (#{sql}) SELECT * FROM _base WHERE #{conditions}"
+    bare = strip_trailing_semicolon(sql)
+    "WITH _base AS (#{bare}) SELECT * FROM _base WHERE #{conditions}"
   end
 
   defp build_condition(%Filter{column: column, op: :is_null}, quote_fn) do

--- a/lib/lotus/sql/sanitizer.ex
+++ b/lib/lotus/sql/sanitizer.ex
@@ -1,0 +1,16 @@
+defmodule Lotus.SQL.Sanitizer do
+  @moduledoc """
+  Shared helpers for cleaning SQL strings before further processing.
+  """
+
+  @doc """
+  Strips a trailing semicolon (and surrounding whitespace) from a SQL string.
+
+  This is used by injectors that wrap queries in CTEs, where an embedded
+  trailing semicolon would be misdetected as a multi-statement query.
+  """
+  @spec strip_trailing_semicolon(String.t()) :: String.t()
+  def strip_trailing_semicolon(sql) do
+    sql |> String.trim_trailing() |> String.trim_trailing(";") |> String.trim_trailing()
+  end
+end

--- a/lib/lotus/sql/sort_injector.ex
+++ b/lib/lotus/sql/sort_injector.ex
@@ -19,6 +19,8 @@ defmodule Lotus.SQL.SortInjector do
 
   alias Lotus.Query.Sort
 
+  import Lotus.SQL.Sanitizer, only: [strip_trailing_semicolon: 1]
+
   @doc """
   Wraps the given SQL in a CTE and appends ORDER BY for each sort directive.
 
@@ -31,7 +33,8 @@ defmodule Lotus.SQL.SortInjector do
 
   def apply(sql, sorts, quote_fn) when is_list(sorts) and is_function(quote_fn, 1) do
     order_clause = Enum.map_join(sorts, ", ", &build_sort_clause(&1, quote_fn))
-    "WITH _sorted AS (#{sql}) SELECT * FROM _sorted ORDER BY #{order_clause}"
+    bare = strip_trailing_semicolon(sql)
+    "WITH _sorted AS (#{bare}) SELECT * FROM _sorted ORDER BY #{order_clause}"
   end
 
   defp build_sort_clause(%Sort{column: column, direction: direction}, quote_fn) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus"
-  @version "0.16.1"
+  @version "0.16.2"
 
   def project do
     [

--- a/test/lotus/sql/filter_injector_test.exs
+++ b/test/lotus/sql/filter_injector_test.exs
@@ -108,6 +108,41 @@ defmodule Lotus.SQL.FilterInjectorTest do
       end
     end
 
+    test "strips trailing semicolon before wrapping in CTE" do
+      sql = "SELECT * FROM users;"
+      filters = [Filter.new("region", :eq, "US")]
+
+      result = FilterInjector.apply(sql, filters, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+    end
+
+    test "strips trailing semicolon with surrounding whitespace" do
+      sql = "SELECT * FROM users ;  "
+      filters = [Filter.new("region", :eq, "US")]
+
+      result = FilterInjector.apply(sql, filters, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+    end
+
+    test "handles CTE query with trailing semicolon" do
+      sql = """
+      WITH cte AS (SELECT id, name FROM users)
+      SELECT * FROM cte;
+      """
+
+      filters = [Filter.new("name", :eq, "test")]
+
+      result = FilterInjector.apply(sql, filters, &double_quote/1)
+
+      assert result =~ "WITH _base AS ("
+      refute result =~ ";"
+      assert result =~ ~s(SELECT * FROM _base WHERE "name" = 'test')
+    end
+
     test "wraps complex queries safely" do
       sql =
         "SELECT a.*, b.name FROM a JOIN b ON a.id = b.a_id WHERE a.active = true UNION SELECT c.*, d.name FROM c JOIN d ON c.id = d.c_id"

--- a/test/lotus/sql/sanitizer_test.exs
+++ b/test/lotus/sql/sanitizer_test.exs
@@ -1,0 +1,24 @@
+defmodule Lotus.SQL.SanitizerTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.SQL.Sanitizer
+
+  describe "strip_trailing_semicolon/1" do
+    test "strips trailing semicolon" do
+      assert Sanitizer.strip_trailing_semicolon("SELECT 1;") == "SELECT 1"
+    end
+
+    test "strips trailing semicolon with whitespace" do
+      assert Sanitizer.strip_trailing_semicolon("SELECT 1 ;  ") == "SELECT 1"
+    end
+
+    test "returns unchanged SQL without trailing semicolon" do
+      assert Sanitizer.strip_trailing_semicolon("SELECT 1") == "SELECT 1"
+    end
+
+    test "handles CTE query with trailing semicolon" do
+      sql = "WITH cte AS (SELECT 1) SELECT * FROM cte;"
+      assert Sanitizer.strip_trailing_semicolon(sql) == "WITH cte AS (SELECT 1) SELECT * FROM cte"
+    end
+  end
+end

--- a/test/lotus/sql/sort_injector_test.exs
+++ b/test/lotus/sql/sort_injector_test.exs
@@ -66,6 +66,26 @@ defmodule Lotus.SQL.SortInjectorTest do
       assert result =~ ~s("col""name" DESC)
     end
 
+    test "strips trailing semicolon before wrapping in CTE" do
+      sql = "SELECT * FROM users;"
+      sorts = [Sort.new("name", :asc)]
+
+      result = SortInjector.apply(sql, sorts, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _sorted AS (SELECT * FROM users) SELECT * FROM _sorted ORDER BY "name" ASC]
+    end
+
+    test "strips trailing semicolon with surrounding whitespace" do
+      sql = "SELECT * FROM users ;  "
+      sorts = [Sort.new("name", :asc)]
+
+      result = SortInjector.apply(sql, sorts, &double_quote/1)
+
+      assert result ==
+               ~s[WITH _sorted AS (SELECT * FROM users) SELECT * FROM _sorted ORDER BY "name" ASC]
+    end
+
     test "safely wraps queries that already have ORDER BY" do
       sql = "SELECT * FROM users ORDER BY id"
       sorts = [Sort.new("name", :desc)]


### PR DESCRIPTION
Queries ending with a semicolon triggered "Only a single statement is allowed" when filters or sorts were applied, because the semicolon ended up inside the CTE parentheses rather than at the end. Extract shared Lotus.SQL.Sanitizer module for the cleanup helper.