### PR TITLE
Fix UUID binary JSON encoding crash in Result struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.16.4] - 2026-03-10
+
 ### Fixed
 
 - **FIX:** Remove `@derive {Lotus.JSON.encoder(), ...}` from `Result` struct that caused `{:invalid_byte, 255}` crashes when query results contained raw UUID binaries from PostgreSQL. Added `Result.to_encodable/1` for explicit JSON-safe serialization with value normalization. Regression introduced in v0.16.0 (#135)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Changed
 
-- **REFACTOR:** Extract `Lotus.Normalizer` protocol from `Lotus.Export.Normalizer` into a top-level module for general-purpose value normalization (UUID binaries, Dates, Decimals, Postgrex/MyXQL types). `Lotus.Export.Value` now delegates to `Lotus.Normalizer`
+- **REFACTOR:** Extract `Lotus.Normalizer` protocol from `Lotus.Export.Normalizer` into a top-level module for general-purpose value normalization (UUID binaries, Dates, Decimals, Postgrex/MyXQL types). `Lotus.Export.Value` now delegates to `Lotus.Normalizer`. **`Lotus.Export.Normalizer` has been removed** — if you implemented this protocol for custom types, implement `Lotus.Normalizer` instead.
 - **NEW:** Added `guides/middleware.md` documentation for the middleware pipeline
 
 ## [0.16.3] - 2026-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **FIX:** Remove `@derive {Lotus.JSON.encoder(), ...}` from `Result` struct that caused `{:invalid_byte, 255}` crashes when query results contained raw UUID binaries from PostgreSQL. Added `Result.to_encodable/1` for explicit JSON-safe serialization with value normalization. Regression introduced in v0.16.0 (#135)
+
+### Changed
+
+- **REFACTOR:** Extract `Lotus.Normalizer` protocol from `Lotus.Export.Normalizer` into a top-level module for general-purpose value normalization (UUID binaries, Dates, Decimals, Postgrex/MyXQL types). `Lotus.Export.Value` now delegates to `Lotus.Normalizer`
+- **NEW:** Added `guides/middleware.md` documentation for the middleware pipeline
+
 ## [0.16.3] - 2026-03-08
 
 ### Fixed

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -1,0 +1,223 @@
+# Middleware
+
+Lotus provides a middleware pipeline that lets you hook into query execution and schema discovery events. Middleware follows the familiar Plug pattern — each module implements `init/1` and `call/2`.
+
+## How It Works
+
+A middleware module looks like this:
+
+```elixir
+defmodule MyApp.AuditMiddleware do
+  def init(opts), do: opts
+
+  def call(payload, _opts) do
+    # Inspect or transform the payload
+    {:cont, payload}   # continue to next middleware
+    # or
+    {:halt, "reason"}  # stop pipeline, Lotus returns {:error, reason}
+  end
+end
+```
+
+Each middleware receives a payload map whose contents depend on the pipeline event (see below), and must return either `{:cont, payload}` to continue or `{:halt, reason}` to abort.
+
+## Pipeline Events
+
+| Event | Triggered | Payload keys |
+|-------|-----------|--------------|
+| `:before_query` | After preflight visibility check, before SQL execution | `:sql`, `:params`, `:repo`, `:context` |
+| `:after_query` | After execution, before result returned to caller | `:result`, `:sql`, `:params`, `:repo`, `:context` |
+| `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:repo`, `:context` |
+| `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:repo`, `:context` |
+| `:after_get_table_schema` | After table schema introspection and column visibility | `:table_schema`, `:repo`, `:context` |
+| `:after_list_relations` | After relation discovery and visibility filtering | `:relations`, `:repo`, `:context` |
+
+## Configuration
+
+Register middleware in your Lotus config. Each entry is a `{module, opts}` tuple — `opts` is passed to `init/1` at compile time:
+
+```elixir
+config :lotus,
+  middleware: %{
+    before_query: [
+      {MyApp.AccessControlMiddleware, []},
+      {MyApp.QueryAuditMiddleware, [repo: MyApp.AuditRepo]}
+    ],
+    after_query: [
+      {MyApp.ResultRedactionMiddleware, [fields: ~w(email phone ssn)]}
+    ],
+    after_list_tables: [
+      {MyApp.TableFilterMiddleware, []}
+    ]
+  }
+```
+
+Middleware runs in the order listed. Multiple middleware can be chained on the same event.
+
+## Context
+
+A `:context` key carries opaque user data (e.g. the current user) through to middleware. Lotus never inspects this value — it's purely for your application's use.
+
+```elixir
+# Pass context when running a query
+Lotus.run_sql("SELECT * FROM orders", [], context: %{user_id: current_user.id})
+```
+
+```elixir
+defmodule MyApp.AccessControlMiddleware do
+  def init(opts), do: opts
+
+  def call(%{context: %{user_id: nil}} = _payload, _opts) do
+    {:halt, "authentication required"}
+  end
+
+  def call(payload, _opts) do
+    {:cont, payload}
+  end
+end
+```
+
+## Examples
+
+### Audit Logging
+
+Log every query execution with the user who ran it:
+
+```elixir
+defmodule MyApp.QueryAuditMiddleware do
+  require Logger
+
+  def init(opts), do: opts
+
+  def call(%{sql: sql, context: context} = payload, _opts) do
+    user_id = Map.get(context || %{}, :user_id, "anonymous")
+    Logger.info("[Lotus] user=#{user_id} sql=#{inspect(sql)}")
+    {:cont, payload}
+  end
+end
+```
+
+### Row-Level Security
+
+Block queries that don't include a tenant filter:
+
+```elixir
+defmodule MyApp.TenantMiddleware do
+  def init(opts), do: opts
+
+  def call(%{sql: sql, context: context} = payload, _opts) do
+    tenant_id = Map.get(context || %{}, :tenant_id)
+
+    cond do
+      is_nil(tenant_id) ->
+        {:halt, "tenant context required"}
+
+      not String.contains?(String.downcase(sql), "tenant_id") ->
+        {:halt, "queries must filter by tenant_id"}
+
+      true ->
+        {:cont, payload}
+    end
+  end
+end
+```
+
+### Redacting Sensitive Data in Results
+
+Mask PII columns (emails, phone numbers, etc.) so non-admin users only see partial values:
+
+```elixir
+defmodule MyApp.ResultRedactionMiddleware do
+  @moduledoc """
+  Masks sensitive columns in query results based on configurable field names.
+  Admins (identified via context) see full values; everyone else sees masked output.
+  """
+
+  def init(opts), do: Keyword.get(opts, :fields, [])
+
+  def call(%{result: result, context: context} = payload, fields) do
+    if admin?(context) do
+      {:cont, payload}
+    else
+      col_indexes =
+        result.columns
+        |> Enum.with_index()
+        |> Enum.filter(fn {col, _i} -> col in fields end)
+        |> Enum.map(fn {_col, i} -> i end)
+        |> MapSet.new()
+
+      redacted_rows =
+        Enum.map(result.rows, fn row ->
+          row
+          |> Enum.with_index()
+          |> Enum.map(fn {val, i} ->
+            if i in col_indexes, do: mask(val), else: val
+          end)
+        end)
+
+      {:cont, put_in(payload, [:result, Access.key(:rows)], redacted_rows)}
+    end
+  end
+
+  defp admin?(%{role: :admin}), do: true
+  defp admin?(_), do: false
+
+  defp mask(val) when is_binary(val) and byte_size(val) > 4 do
+    String.slice(val, 0, 2) <> String.duplicate("*", max(String.length(val) - 4, 3)) <> String.slice(val, -2, 2)
+  end
+
+  defp mask(_val), do: "****"
+end
+```
+
+Configure which fields to redact:
+
+```elixir
+config :lotus,
+  middleware: %{
+    after_query: [
+      {MyApp.ResultRedactionMiddleware, [fields: ~w(email phone ssn)]}
+    ]
+  }
+```
+
+A query like `SELECT name, email FROM users` would return:
+
+| name | email |
+|------|-------|
+| Alice Johnson | al***************om |
+| Bob Smith | bo***********om |
+
+### Filtering Schema Discovery
+
+Hide internal tables from the schema browser:
+
+```elixir
+defmodule MyApp.TableFilterMiddleware do
+  @hidden_prefixes ["_internal_", "oban_"]
+
+  def init(opts), do: opts
+
+  def call(%{tables: tables} = payload, _opts) do
+    filtered = Enum.reject(tables, fn table ->
+      Enum.any?(@hidden_prefixes, &String.starts_with?(table.name, &1))
+    end)
+
+    {:cont, %{payload | tables: filtered}}
+  end
+end
+```
+
+## Halting the Pipeline
+
+When a middleware returns `{:halt, reason}`, the pipeline stops immediately and Lotus returns `{:error, reason}` to the caller. This is useful for enforcing access control, rate limiting, or any validation that should prevent execution:
+
+```elixir
+def call(%{sql: sql} = payload, _opts) do
+  if String.contains?(String.downcase(sql), "pg_sleep") do
+    {:halt, "pg_sleep is not allowed"}
+  else
+    {:cont, payload}
+  end
+end
+```

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -122,6 +122,8 @@ defmodule MyApp.TenantMiddleware do
 end
 ```
 
+> **Note:** The `String.contains?` check above is intentionally simplified for illustration. It can be bypassed (e.g. via SQL comments). For real row-level security, inject a parameterized filter using the `:filters` option on `Lotus.run_query/2` instead of inspecting raw SQL text.
+
 ### Redacting Sensitive Data in Results
 
 Mask PII columns (emails, phone numbers, etc.) so non-admin users only see partial values:
@@ -162,7 +164,7 @@ defmodule MyApp.ResultRedactionMiddleware do
   defp admin?(%{role: :admin}), do: true
   defp admin?(_), do: false
 
-  defp mask(val) when is_binary(val) and byte_size(val) > 4 do
+  defp mask(val) when is_binary(val) and String.length(val) > 4 do
     String.slice(val, 0, 2) <> String.duplicate("*", max(String.length(val) - 4, 3)) <> String.slice(val, -2, 2)
   end
 

--- a/lib/lotus/ai/actions/execute_sql.ex
+++ b/lib/lotus/ai/actions/execute_sql.ex
@@ -43,7 +43,10 @@ defmodule Lotus.AI.Actions.ExecuteSQL do
 
     case Lotus.run_sql(params.sql, [], repo: params.data_source, read_only: true) do
       {:ok, result} ->
-        preview_rows = Enum.take(result.rows, @max_preview_rows)
+        preview_rows =
+          result.rows
+          |> Enum.take(@max_preview_rows)
+          |> Enum.map(fn row -> Enum.map(row, &Lotus.Normalizer.normalize/1) end)
 
         {:ok,
          %{

--- a/lib/lotus/ai/actions/get_column_values.ex
+++ b/lib/lotus/ai/actions/get_column_values.ex
@@ -68,7 +68,7 @@ defmodule Lotus.AI.Actions.GetColumnValues do
   defp run_and_format(query, params) do
     case Lotus.run_sql(query, [], repo: params.data_source) do
       {:ok, result} ->
-        values = Enum.map(result.rows, fn [value] -> value end)
+        values = Enum.map(result.rows, fn [value] -> Lotus.Normalizer.normalize(value) end)
 
         {:ok,
          %{

--- a/lib/lotus/export/value.ex
+++ b/lib/lotus/export/value.ex
@@ -1,20 +1,10 @@
-defprotocol Lotus.Export.Normalizer do
-  @moduledoc """
-  Protocol for normalizing database values for export formats.
-  """
-
-  @doc "Normalize a value for export (JSON/CSV-safe)"
-  @spec normalize(t) :: term()
-  def normalize(value)
-end
-
 defmodule Lotus.Export.Value do
   @moduledoc """
   Value normalization for export formats.
   Handles various database types and edge cases for CSV and JSON export.
   """
 
-  alias Lotus.Export.Normalizer
+  alias Lotus.Normalizer
 
   @doc """
   Normalizes a value for CSV export, converting to a string representation.
@@ -61,101 +51,4 @@ defmodule Lotus.Export.Value do
   end
 
   defp value_to_string(value), do: to_string(value)
-end
-
-defimpl Lotus.Export.Normalizer, for: Atom do
-  def normalize(nil), do: nil
-  def normalize(true), do: true
-  def normalize(false), do: false
-  def normalize(atom), do: to_string(atom)
-end
-
-defimpl Lotus.Export.Normalizer, for: BitString do
-  def normalize(value) when is_binary(value) do
-    cond do
-      # Check if it's a 16-byte UUID binary
-      byte_size(value) == 16 and not String.valid?(value) ->
-        case Ecto.UUID.load(value) do
-          {:ok, uuid} -> uuid
-          :error -> Base.encode64(value)
-        end
-
-      # Check if it's valid UTF-8
-      String.valid?(value) ->
-        value
-
-      # Non-UTF-8 binary data
-      true ->
-        Base.encode64(value)
-    end
-  end
-
-  # MySQL BIT fields (non-binary bitstrings)
-  def normalize(value) when is_bitstring(value) do
-    size = bit_size(value)
-    <<int::size(size)>> = value
-    to_string(int)
-  end
-end
-
-defimpl Lotus.Export.Normalizer, for: Integer do
-  def normalize(value), do: value
-end
-
-defimpl Lotus.Export.Normalizer, for: Float do
-  def normalize(value), do: value
-end
-
-defimpl Lotus.Export.Normalizer, for: List do
-  def normalize(value) do
-    if List.ascii_printable?(value) do
-      to_string(value)
-    else
-      value
-    end
-  end
-end
-
-defimpl Lotus.Export.Normalizer, for: Map do
-  def normalize(value), do: value
-end
-
-defimpl Lotus.Export.Normalizer, for: Tuple do
-  def normalize(value), do: inspect(value)
-end
-
-defimpl Lotus.Export.Normalizer, for: Date do
-  def normalize(value), do: Date.to_iso8601(value)
-end
-
-defimpl Lotus.Export.Normalizer, for: Time do
-  def normalize(value), do: Time.to_iso8601(value)
-end
-
-defimpl Lotus.Export.Normalizer, for: DateTime do
-  def normalize(value), do: DateTime.to_iso8601(value)
-end
-
-defimpl Lotus.Export.Normalizer, for: NaiveDateTime do
-  def normalize(value), do: NaiveDateTime.to_iso8601(value)
-end
-
-defimpl Lotus.Export.Normalizer, for: Decimal do
-  def normalize(value) do
-    case Decimal.to_string(value) do
-      "NaN" -> "NaN"
-      "Inf" -> "Infinity"
-      "-Inf" -> "-Infinity"
-      str -> str
-    end
-  end
-end
-
-defimpl Lotus.Export.Normalizer, for: URI do
-  def normalize(value), do: inspect(value)
-end
-
-# Fallback for any other type
-defimpl Lotus.Export.Normalizer, for: Any do
-  def normalize(value), do: inspect(value)
 end

--- a/lib/lotus/normalizer.ex
+++ b/lib/lotus/normalizer.ex
@@ -1,0 +1,110 @@
+defprotocol Lotus.Normalizer do
+  @moduledoc """
+  Protocol for normalizing raw database values into JSON-safe, displayable forms.
+
+  Lotus applies this protocol to all query result values before they reach
+  consumers (UI, exports, API). Implement this protocol for custom database
+  types that need special handling.
+  """
+
+  @doc "Normalize a value so it is JSON-safe and human-readable."
+  @spec normalize(t) :: term()
+  def normalize(value)
+end
+
+defimpl Lotus.Normalizer, for: Atom do
+  def normalize(nil), do: nil
+  def normalize(true), do: true
+  def normalize(false), do: false
+  def normalize(atom), do: to_string(atom)
+end
+
+defimpl Lotus.Normalizer, for: BitString do
+  def normalize(value) when is_binary(value) do
+    cond do
+      # Check if it's a 16-byte UUID binary
+      byte_size(value) == 16 and not String.valid?(value) ->
+        case Ecto.UUID.load(value) do
+          {:ok, uuid} -> uuid
+          :error -> Base.encode64(value)
+        end
+
+      # Check if it's valid UTF-8
+      String.valid?(value) ->
+        value
+
+      # Non-UTF-8 binary data
+      true ->
+        Base.encode64(value)
+    end
+  end
+
+  # MySQL BIT fields (non-binary bitstrings)
+  def normalize(value) when is_bitstring(value) do
+    size = bit_size(value)
+    <<int::size(size)>> = value
+    to_string(int)
+  end
+end
+
+defimpl Lotus.Normalizer, for: Integer do
+  def normalize(value), do: value
+end
+
+defimpl Lotus.Normalizer, for: Float do
+  def normalize(value), do: value
+end
+
+defimpl Lotus.Normalizer, for: List do
+  def normalize(value) do
+    if List.ascii_printable?(value) do
+      to_string(value)
+    else
+      value
+    end
+  end
+end
+
+defimpl Lotus.Normalizer, for: Map do
+  def normalize(value), do: value
+end
+
+defimpl Lotus.Normalizer, for: Tuple do
+  def normalize(value), do: inspect(value)
+end
+
+defimpl Lotus.Normalizer, for: Date do
+  def normalize(value), do: Date.to_iso8601(value)
+end
+
+defimpl Lotus.Normalizer, for: Time do
+  def normalize(value), do: Time.to_iso8601(value)
+end
+
+defimpl Lotus.Normalizer, for: DateTime do
+  def normalize(value), do: DateTime.to_iso8601(value)
+end
+
+defimpl Lotus.Normalizer, for: NaiveDateTime do
+  def normalize(value), do: NaiveDateTime.to_iso8601(value)
+end
+
+defimpl Lotus.Normalizer, for: Decimal do
+  def normalize(value) do
+    case Decimal.to_string(value) do
+      "NaN" -> "NaN"
+      "Inf" -> "Infinity"
+      "-Inf" -> "-Infinity"
+      str -> str
+    end
+  end
+end
+
+defimpl Lotus.Normalizer, for: URI do
+  def normalize(value), do: inspect(value)
+end
+
+# Fallback for any other type
+defimpl Lotus.Normalizer, for: Any do
+  def normalize(value), do: inspect(value)
+end

--- a/lib/lotus/normalizer.ex
+++ b/lib/lotus/normalizer.ex
@@ -22,7 +22,9 @@ end
 defimpl Lotus.Normalizer, for: BitString do
   def normalize(value) when is_binary(value) do
     cond do
-      # Check if it's a 16-byte UUID binary
+      # Some databases return UUID values as raw 16-byte binaries rather than strings.
+      # Detect by checking for exactly 16 non-UTF-8 bytes, which avoids misidentifying
+      # valid UTF-8 strings that happen to be 16 bytes long.
       byte_size(value) == 16 and not String.valid?(value) ->
         case Ecto.UUID.load(value) do
           {:ok, uuid} -> uuid
@@ -60,13 +62,15 @@ defimpl Lotus.Normalizer, for: List do
     if List.ascii_printable?(value) do
       to_string(value)
     else
-      value
+      Enum.map(value, &Lotus.Normalizer.normalize/1)
     end
   end
 end
 
 defimpl Lotus.Normalizer, for: Map do
-  def normalize(value), do: value
+  def normalize(value) do
+    Map.new(value, fn {k, v} -> {k, Lotus.Normalizer.normalize(v)} end)
+  end
 end
 
 defimpl Lotus.Normalizer, for: Tuple do

--- a/lib/lotus/normalizer/mysql.ex
+++ b/lib/lotus/normalizer/mysql.ex
@@ -2,7 +2,7 @@
 # Only compiled when MyXQL types are available
 
 if Code.ensure_loaded?(MyXQL.Geometry) do
-  defimpl Lotus.Export.Normalizer, for: MyXQL.Geometry do
+  defimpl Lotus.Normalizer, for: MyXQL.Geometry do
     def normalize(%MyXQL.Geometry{} = geom) do
       # Export as WKT (Well-Known Text) or WKB Base64
       Base.encode64(geom.wkb || "")

--- a/lib/lotus/normalizer/postgres.ex
+++ b/lib/lotus/normalizer/postgres.ex
@@ -2,7 +2,7 @@
 # Only compiled when Postgrex types are available
 
 if Code.ensure_loaded?(Postgrex.Range) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.Range do
+  defimpl Lotus.Normalizer, for: Postgrex.Range do
     def normalize(%Postgrex.Range{} = range) do
       lower_bound = if range.lower_inclusive, do: "[", else: "("
       upper_bound = if range.upper_inclusive, do: "]", else: ")"
@@ -17,13 +17,13 @@ if Code.ensure_loaded?(Postgrex.Range) do
     defp format_range_value(:unbound), do: ""
 
     defp format_range_value(value) do
-      Lotus.Export.Normalizer.normalize(value)
+      Lotus.Normalizer.normalize(value)
     end
   end
 end
 
 if Code.ensure_loaded?(Postgrex.INET) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.INET do
+  defimpl Lotus.Normalizer, for: Postgrex.INET do
     def normalize(%Postgrex.INET{address: address, netmask: netmask}) do
       addr_str = format_address(address)
 
@@ -47,15 +47,14 @@ if Code.ensure_loaded?(Postgrex.INET) do
         8 ->
           address
           |> Tuple.to_list()
-          |> Enum.map(&Integer.to_string(&1, 16))
-          |> Enum.join(":")
+          |> Enum.map_join(":", &Integer.to_string(&1, 16))
       end
     end
   end
 end
 
 if Code.ensure_loaded?(Postgrex.Interval) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.Interval do
+  defimpl Lotus.Normalizer, for: Postgrex.Interval do
     # Postgrex.Interval has: months, days, secs, microsecs
     def normalize(%Postgrex.Interval{} = interval) do
       parts = build_date_parts(interval)
@@ -134,7 +133,7 @@ if Code.ensure_loaded?(Postgrex.Interval) do
 end
 
 if Code.ensure_loaded?(Postgrex.Point) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.Point do
+  defimpl Lotus.Normalizer, for: Postgrex.Point do
     def normalize(%Postgrex.Point{x: x, y: y}) do
       "(#{x},#{y})"
     end
@@ -142,28 +141,25 @@ if Code.ensure_loaded?(Postgrex.Point) do
 end
 
 if Code.ensure_loaded?(Postgrex.LineSegment) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.LineSegment do
+  defimpl Lotus.Normalizer, for: Postgrex.LineSegment do
     def normalize(%Postgrex.LineSegment{point1: p1, point2: p2}) do
-      "[#{Lotus.Export.Normalizer.normalize(p1)},#{Lotus.Export.Normalizer.normalize(p2)}]"
+      "[#{Lotus.Normalizer.normalize(p1)},#{Lotus.Normalizer.normalize(p2)}]"
     end
   end
 end
 
 if Code.ensure_loaded?(Postgrex.Box) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.Box do
+  defimpl Lotus.Normalizer, for: Postgrex.Box do
     def normalize(%Postgrex.Box{upper_right: ur, bottom_left: bl}) do
-      "(#{Lotus.Export.Normalizer.normalize(ur)},#{Lotus.Export.Normalizer.normalize(bl)})"
+      "(#{Lotus.Normalizer.normalize(ur)},#{Lotus.Normalizer.normalize(bl)})"
     end
   end
 end
 
 if Code.ensure_loaded?(Postgrex.Path) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.Path do
+  defimpl Lotus.Normalizer, for: Postgrex.Path do
     def normalize(%Postgrex.Path{points: points, open: open}) do
-      points_str =
-        points
-        |> Enum.map(&Lotus.Export.Normalizer.normalize/1)
-        |> Enum.join(",")
+      points_str = Enum.map_join(points, ",", &Lotus.Normalizer.normalize/1)
 
       if open do
         "[#{points_str}]"
@@ -175,12 +171,9 @@ if Code.ensure_loaded?(Postgrex.Path) do
 end
 
 if Code.ensure_loaded?(Postgrex.Polygon) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.Polygon do
+  defimpl Lotus.Normalizer, for: Postgrex.Polygon do
     def normalize(%Postgrex.Polygon{vertices: vertices}) do
-      points_str =
-        vertices
-        |> Enum.map(&Lotus.Export.Normalizer.normalize/1)
-        |> Enum.join(",")
+      points_str = Enum.map_join(vertices, ",", &Lotus.Normalizer.normalize/1)
 
       "(#{points_str})"
     end
@@ -188,9 +181,9 @@ if Code.ensure_loaded?(Postgrex.Polygon) do
 end
 
 if Code.ensure_loaded?(Postgrex.Circle) do
-  defimpl Lotus.Export.Normalizer, for: Postgrex.Circle do
+  defimpl Lotus.Normalizer, for: Postgrex.Circle do
     def normalize(%Postgrex.Circle{center: center, radius: radius}) do
-      "<#{Lotus.Export.Normalizer.normalize(center)},#{radius}>"
+      "<#{Lotus.Normalizer.normalize(center)},#{radius}>"
     end
   end
 end

--- a/lib/lotus/result.ex
+++ b/lib/lotus/result.ex
@@ -5,9 +5,6 @@ defmodule Lotus.Result do
   Contains the columns, rows, and metadata about the query result.
   """
 
-  @derive {Lotus.JSON.encoder(),
-           only: [:columns, :rows, :num_rows, :duration_ms, :command, :meta]}
-
   @enforce_keys [:columns, :rows]
 
   defstruct columns: [],
@@ -50,5 +47,29 @@ defmodule Lotus.Result do
       command: Keyword.get(opts, :command),
       meta: Keyword.get(opts, :meta, %{})
     }
+  end
+
+  @doc """
+  Returns a JSON-safe map representation of the result.
+
+  Normalizes all row values (UUID binaries, Dates, Decimals, etc.) using
+  `Lotus.Normalizer` so the output is safe for JSON encoding.
+  """
+  @spec to_encodable(t()) :: map()
+  def to_encodable(%__MODULE__{} = result) do
+    %{
+      columns: result.columns,
+      rows: normalize_rows(result.rows),
+      num_rows: result.num_rows,
+      duration_ms: result.duration_ms,
+      command: result.command,
+      meta: result.meta
+    }
+  end
+
+  defp normalize_rows(rows) do
+    Enum.map(rows, fn row ->
+      Enum.map(row, &Lotus.Normalizer.normalize/1)
+    end)
   end
 end

--- a/lib/lotus/value.ex
+++ b/lib/lotus/value.ex
@@ -3,8 +3,8 @@ defmodule Lotus.Value do
   Central value normalization for JSON/CSV/UI display.
 
   This module provides a unified interface for normalizing database values
-  for different output formats while keeping the underlying normalization
-  logic centralized in the Export.Value module.
+  for different output formats. The underlying normalization logic is provided
+  by the `Lotus.Normalizer` protocol.
   """
 
   alias Lotus.Export.Value

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus"
-  @version "0.16.3"
+  @version "0.16.4"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -133,6 +133,7 @@ defmodule Lotus.MixProject do
       "guides/advanced-variables.md",
       "guides/ai_query_generation.md",
       "guides/configuration.md",
+      "guides/middleware.md",
       "guides/visibility.md",
       "guides/caching.md",
       "guides/telemetry.md",

--- a/test/lotus/export_test.exs
+++ b/test/lotus/export_test.exs
@@ -146,7 +146,7 @@ defmodule Lotus.ExportTest do
   end
 
   describe "date/time handling" do
-    test "normalizes DateTime values" do
+    test "normalizes DateTime values in CSV" do
       dt = ~U[2024-01-15 10:30:00Z]
       result = Result.new(["timestamp"], [[dt]])
 
@@ -156,7 +156,7 @@ defmodule Lotus.ExportTest do
       assert csv_string =~ "2024-01-15T10:30:00Z"
     end
 
-    test "normalizes Date values" do
+    test "normalizes Date values in CSV" do
       date = ~D[2024-01-15]
       result = Result.new(["date"], [[date]])
 
@@ -166,7 +166,7 @@ defmodule Lotus.ExportTest do
       assert csv_string =~ "2024-01-15"
     end
 
-    test "normalizes NaiveDateTime values" do
+    test "normalizes NaiveDateTime values in CSV" do
       ndt = ~N[2024-01-15 10:30:00]
       result = Result.new(["timestamp"], [[ndt]])
 
@@ -174,6 +174,114 @@ defmodule Lotus.ExportTest do
       csv_string = IO.iodata_to_binary(csv_iodata)
 
       assert csv_string =~ "2024-01-15T10:30:00"
+    end
+
+    test "normalizes DateTime values in JSON" do
+      dt = ~U[2024-01-15 10:30:00Z]
+      result = Result.new(["timestamp"], [[dt]])
+
+      decoded = result |> Export.to_json() |> Lotus.JSON.decode!()
+      assert [%{"timestamp" => "2024-01-15T10:30:00Z"}] = decoded
+    end
+
+    test "normalizes Date values in JSON" do
+      date = ~D[2024-01-15]
+      result = Result.new(["date"], [[date]])
+
+      decoded = result |> Export.to_json() |> Lotus.JSON.decode!()
+      assert [%{"date" => "2024-01-15"}] = decoded
+    end
+
+    test "normalizes NaiveDateTime values in JSON" do
+      ndt = ~N[2024-01-15 10:30:00]
+      result = Result.new(["timestamp"], [[ndt]])
+
+      decoded = result |> Export.to_json() |> Lotus.JSON.decode!()
+      assert [%{"timestamp" => "2024-01-15T10:30:00"}] = decoded
+    end
+  end
+
+  describe "raw database type handling" do
+    test "exports UUID binaries in CSV" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+      result = Result.new(["id", "name"], [[uuid_binary, "Alice"]])
+
+      csv_string = result |> Export.to_csv() |> IO.iodata_to_binary()
+
+      assert csv_string =~ "550e8400-e29b-41d4-a716-446655440000"
+      assert csv_string =~ "Alice"
+    end
+
+    test "exports UUID binaries in JSON" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+      result = Result.new(["id", "name"], [[uuid_binary, "Alice"]])
+
+      decoded = result |> Export.to_json() |> Lotus.JSON.decode!()
+
+      assert [%{"id" => "550e8400-e29b-41d4-a716-446655440000", "name" => "Alice"}] = decoded
+    end
+
+    test "exports UUID binaries in JSONL" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+      result = Result.new(["id"], [[uuid_binary]])
+
+      decoded = result |> Export.to_jsonl() |> Lotus.JSON.decode!()
+
+      assert %{"id" => "550e8400-e29b-41d4-a716-446655440000"} = decoded
+    end
+
+    test "exports Decimal values in JSON" do
+      result = Result.new(["amount"], [[Decimal.new("123.45")]])
+
+      decoded = result |> Export.to_json() |> Lotus.JSON.decode!()
+
+      assert [%{"amount" => "123.45"}] = decoded
+    end
+
+    test "exports Decimal values in CSV" do
+      result = Result.new(["amount"], [[Decimal.new("123.45")]])
+
+      csv_string = result |> Export.to_csv() |> IO.iodata_to_binary()
+
+      assert csv_string =~ "123.45"
+    end
+
+    test "exports mixed raw database types in JSON" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+
+      result =
+        Result.new(
+          ["id", "name", "created_at", "amount"],
+          [[uuid_binary, "Alice", ~D[2024-06-15], Decimal.new("99.99")]]
+        )
+
+      decoded = result |> Export.to_json() |> Lotus.JSON.decode!()
+
+      assert [
+               %{
+                 "id" => "550e8400-e29b-41d4-a716-446655440000",
+                 "name" => "Alice",
+                 "created_at" => "2024-06-15",
+                 "amount" => "99.99"
+               }
+             ] = decoded
+    end
+
+    test "exports mixed raw database types in CSV" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+
+      result =
+        Result.new(
+          ["id", "name", "created_at", "amount"],
+          [[uuid_binary, "Alice", ~D[2024-06-15], Decimal.new("99.99")]]
+        )
+
+      csv_string = result |> Export.to_csv() |> IO.iodata_to_binary()
+
+      assert csv_string =~ "550e8400-e29b-41d4-a716-446655440000"
+      assert csv_string =~ "Alice"
+      assert csv_string =~ "2024-06-15"
+      assert csv_string =~ "99.99"
     end
   end
 end

--- a/test/lotus/result_test.exs
+++ b/test/lotus/result_test.exs
@@ -1,0 +1,143 @@
+defmodule Lotus.ResultTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Result
+
+  describe "new/3" do
+    test "creates result with columns and rows" do
+      result = Result.new(["name", "age"], [["Alice", 30], ["Bob", 25]])
+
+      assert result.columns == ["name", "age"]
+      assert result.rows == [["Alice", 30], ["Bob", 25]]
+      assert result.num_rows == 2
+    end
+
+    test "creates result with opts" do
+      result =
+        Result.new(["id"], [[1]], num_rows: 1, duration_ms: 42, command: "select", meta: %{x: 1})
+
+      assert result.num_rows == 1
+      assert result.duration_ms == 42
+      assert result.command == "select"
+      assert result.meta == %{x: 1}
+    end
+
+    test "handles nil columns and rows" do
+      result = Result.new(nil, nil)
+
+      assert result.columns == []
+      assert result.rows == []
+      assert result.num_rows == 0
+    end
+
+    test "preserves raw values in rows" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+      result = Result.new(["id"], [[uuid_binary]])
+
+      assert result.rows == [[uuid_binary]]
+    end
+  end
+
+  describe "to_encodable/1" do
+    test "returns JSON-safe map with primitive values" do
+      result = Result.new(["name", "count"], [["Alice", 42]])
+      encodable = Result.to_encodable(result)
+
+      assert encodable.columns == ["name", "count"]
+      assert encodable.rows == [["Alice", 42]]
+      assert encodable.num_rows == 1
+    end
+
+    test "normalizes UUID binary values to strings" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+      result = Result.new(["id", "name"], [[uuid_binary, "Alice"]])
+      encodable = Result.to_encodable(result)
+
+      assert [[id, "Alice"]] = encodable.rows
+      assert id == "550e8400-e29b-41d4-a716-446655440000"
+    end
+
+    test "normalizes Date values to ISO8601 strings" do
+      result = Result.new(["created_at"], [[~D[2024-06-15]]])
+      encodable = Result.to_encodable(result)
+
+      assert encodable.rows == [["2024-06-15"]]
+    end
+
+    test "normalizes DateTime values to ISO8601 strings" do
+      result = Result.new(["created_at"], [[~U[2024-06-15 10:30:00Z]]])
+      encodable = Result.to_encodable(result)
+
+      assert encodable.rows == [["2024-06-15T10:30:00Z"]]
+    end
+
+    test "normalizes NaiveDateTime values to ISO8601 strings" do
+      result = Result.new(["created_at"], [[~N[2024-06-15 10:30:00]]])
+      encodable = Result.to_encodable(result)
+
+      assert encodable.rows == [["2024-06-15T10:30:00"]]
+    end
+
+    test "normalizes Decimal values to strings" do
+      result = Result.new(["amount"], [[Decimal.new("123.45")]])
+      encodable = Result.to_encodable(result)
+
+      assert encodable.rows == [["123.45"]]
+    end
+
+    test "normalizes non-UTF-8 binaries to Base64" do
+      binary = <<255, 254, 253, 252>>
+      result = Result.new(["data"], [[binary]])
+      encodable = Result.to_encodable(result)
+
+      assert encodable.rows == [[Base.encode64(binary)]]
+    end
+
+    test "normalizes mixed database types" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+
+      result =
+        Result.new(
+          ["id", "name", "created_at", "amount", "active"],
+          [[uuid_binary, "Alice", ~D[2024-06-15], Decimal.new("99.99"), true]]
+        )
+
+      encodable = Result.to_encodable(result)
+
+      assert [["550e8400-e29b-41d4-a716-446655440000", "Alice", "2024-06-15", "99.99", true]] =
+               encodable.rows
+    end
+
+    test "is JSON-encodable" do
+      {:ok, uuid_binary} = Ecto.UUID.dump("550e8400-e29b-41d4-a716-446655440000")
+
+      result =
+        Result.new(
+          ["id", "name", "created_at"],
+          [[uuid_binary, "Alice", ~D[2024-06-15]]]
+        )
+
+      # Must not raise
+      encoded = Lotus.JSON.encode!(Result.to_encodable(result))
+      decoded = Lotus.JSON.decode!(encoded)
+
+      assert [["550e8400-e29b-41d4-a716-446655440000", "Alice", "2024-06-15"]] = decoded["rows"]
+    end
+
+    test "preserves nil values" do
+      result = Result.new(["name", "age"], [["Alice", nil]])
+      encodable = Result.to_encodable(result)
+
+      assert encodable.rows == [["Alice", nil]]
+    end
+
+    test "includes metadata fields" do
+      result = Result.new(["id"], [[1]], duration_ms: 42, command: "select", meta: %{x: 1})
+      encodable = Result.to_encodable(result)
+
+      assert encodable.duration_ms == 42
+      assert encodable.command == "select"
+      assert encodable.meta == %{x: 1}
+    end
+  end
+end

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -914,4 +914,56 @@ defmodule Lotus.RunnerTest do
       assert is_list(meta.messages)
     end
   end
+
+  describe "UUID column handling" do
+    setup do
+      uuid1 = Ecto.UUID.generate()
+      uuid2 = Ecto.UUID.generate()
+      {:ok, uuid1_bin} = Ecto.UUID.dump(uuid1)
+      {:ok, uuid2_bin} = Ecto.UUID.dump(uuid2)
+
+      Repo.query!(
+        "INSERT INTO test_uuid_records (id, name, ref_id) VALUES ($1, $2, $3)",
+        [uuid1_bin, "Record A", uuid2_bin]
+      )
+
+      Repo.query!(
+        "INSERT INTO test_uuid_records (id, name, ref_id) VALUES ($1, $2, NULL)",
+        [uuid2_bin, "Record B"]
+      )
+
+      %{uuid1: uuid1, uuid2: uuid2}
+    end
+
+    test "returns raw UUID binaries in result rows", %{uuid1: uuid1} do
+      {:ok, result} =
+        Runner.run_sql(Repo, "SELECT id, name FROM test_uuid_records WHERE name = $1", [
+          "Record A"
+        ])
+
+      assert %{columns: ["id", "name"], rows: [[id_bin, "Record A"]]} = result
+      # Postgrex returns UUIDs as raw 16-byte binaries
+      assert byte_size(id_bin) == 16
+      {:ok, loaded} = Ecto.UUID.load(id_bin)
+      assert loaded == uuid1
+    end
+
+    test "result with UUID columns is JSON-encodable via to_encodable", %{
+      uuid1: uuid1,
+      uuid2: uuid2
+    } do
+      {:ok, result} =
+        Runner.run_sql(Repo, "SELECT id, name, ref_id FROM test_uuid_records ORDER BY name")
+
+      # to_encodable normalizes UUIDs to strings
+      encodable = Lotus.Result.to_encodable(result)
+      encoded = Lotus.JSON.encode!(encodable)
+      decoded = Lotus.JSON.decode!(encoded)
+
+      assert [[id_a, "Record A", ref_a], [id_b, "Record B", nil]] = decoded["rows"]
+      assert id_a == uuid1
+      assert ref_a == uuid2
+      assert id_b == uuid2
+    end
+  end
 end

--- a/test/support/postgres/migrations/00_create_test_tables.exs
+++ b/test/support/postgres/migrations/00_create_test_tables.exs
@@ -27,5 +27,11 @@ defmodule Lotus.Test.Repo.Migrations.CreateTestTables do
 
     create(index(:test_posts, [:user_id]))
     create(index(:test_posts, [:published]))
+
+    create table(:test_uuid_records, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:name, :string, null: false)
+      add(:ref_id, :uuid)
+    end
   end
 end


### PR DESCRIPTION
Remove @derive {Lotus.JSON.encoder()} from Result that caused {:invalid_byte, 255} crashes when results contained raw UUID binaries from PostgreSQL. Added Result.to_encodable/1 for explicit JSON-safe serialization. Regression introduced in v0.16.0.

Extract Lotus.Normalizer protocol from Lotus.Export.Normalizer into a top-level module for general-purpose value normalization. Add middleware guide and UUID/Result test coverage.

Closes #149
