### PR TITLE
Fix SQL injection vulnerabilities in FilterInjector and SortInjector …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Security
+
+- **FIX:** Use parameterized queries in `FilterInjector` instead of string-interpolated values — filter values are now bound as query parameters (`$1`, `?`) and never appear in the SQL string, eliminating SQL injection risk via crafted filter values (#152)
+- **FIX:** Validate column names in `FilterInjector` and `SortInjector` against `[a-zA-Z_][a-zA-Z0-9_]*` using `Lotus.SQL.Identifier`, rejecting column names containing spaces, quotes, semicolons, or other special characters (#152)
+
+### Changed
+
+- **BREAKING:** `FilterInjector.apply/3` is now `apply/5` — accepts `params` (existing parameter list) and `placeholder_fn` (database-specific placeholder generator), returns `{sql, params}` tuple instead of a plain SQL string
+- **BREAKING:** `Lotus.Source.apply_filters/2` callback is now `apply_filters/3` — accepts `params` list and returns `{sql, params}` tuple. All source adapters (Postgres, MySQL, SQLite3, Default) updated accordingly
+- Removed `FilterInjector.quote_value/1` — no longer needed since values are parameterized
+
 ## [0.16.4] - 2026-03-10
 
 ### Fixed

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -446,7 +446,7 @@ defmodule Lotus do
     final_opts = prepare_final_opts(opts, search_path)
 
     filters = Keyword.get(opts, :filters, [])
-    sql = Lotus.Source.apply_filters(repo_mod, sql, filters)
+    {sql, params} = Lotus.Source.apply_filters(repo_mod, sql, params, filters)
 
     sorts = Keyword.get(opts, :sorts, [])
     sql = Lotus.Source.apply_sorts(repo_mod, sql, sorts)
@@ -598,7 +598,7 @@ defmodule Lotus do
     search_path = Keyword.get(runner_opts, :search_path)
 
     filters = Keyword.get(opts, :filters, [])
-    sql = Lotus.Source.apply_filters(repo_mod, sql, filters)
+    {sql, params} = Lotus.Source.apply_filters(repo_mod, sql, params, filters)
 
     sorts = Keyword.get(opts, :sorts, [])
     sql = Lotus.Source.apply_sorts(repo_mod, sql, sorts)

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -23,14 +23,20 @@ defmodule Lotus.Source do
   @callback quote_identifier(String.t()) :: String.t()
 
   @doc """
-  Applies a list of filters to an existing query, returning a new query string.
+  Applies a list of filters to an existing query using parameterized queries.
 
   For SQL sources, this typically wraps the original query in a CTE and appends
-  WHERE clauses. Non-SQL sources may implement entirely different strategies.
+  WHERE clauses with parameter placeholders. Non-SQL sources may implement
+  entirely different strategies.
 
-  Returns the original query unchanged when filters is empty.
+  Returns `{sql, params}` unchanged when filters is empty.
   """
-  @callback apply_filters(sql :: String.t(), filters :: [Lotus.Query.Filter.t()]) :: String.t()
+  @callback apply_filters(
+              sql :: String.t(),
+              params :: list(),
+              filters :: [Lotus.Query.Filter.t()]
+            ) ::
+              {String.t(), list()}
 
   @doc """
   Applies a list of sorts to an existing query, returning a new query string.
@@ -431,14 +437,14 @@ defmodule Lotus.Source do
   @doc """
   Applies filters to a query using the source-specific implementation.
 
-  Returns the original query unchanged when filters is empty.
+  Returns `{sql, params}` unchanged when filters is empty.
   """
-  @spec apply_filters(repo | String.t() | nil, String.t(), [Lotus.Query.Filter.t()]) ::
-          String.t()
-  def apply_filters(_repo_or_name, sql, []), do: sql
+  @spec apply_filters(repo | String.t() | nil, String.t(), list(), [Lotus.Query.Filter.t()]) ::
+          {String.t(), list()}
+  def apply_filters(_repo_or_name, sql, params, []), do: {sql, params}
 
-  def apply_filters(repo_or_name, sql, filters) do
-    impl_for(resolve_repo!(repo_or_name)).apply_filters(sql, filters)
+  def apply_filters(repo_or_name, sql, params, filters) do
+    impl_for(resolve_repo!(repo_or_name)).apply_filters(sql, params, filters)
   end
 
   @doc """

--- a/lib/lotus/sources/default.ex
+++ b/lib/lotus/sources/default.ex
@@ -157,8 +157,8 @@ defmodule Lotus.Sources.Default do
 
   @impl true
   @doc "Applies filters using standard SQL CTE wrapping with double-quoted identifiers."
-  def apply_filters(sql, filters) do
-    FilterInjector.apply(sql, filters, &quote_identifier/1)
+  def apply_filters(sql, params, filters) do
+    FilterInjector.apply(sql, params, filters, &quote_identifier/1, fn _idx -> "?" end)
   end
 
   @impl true

--- a/lib/lotus/sources/mysql.ex
+++ b/lib/lotus/sources/mysql.ex
@@ -324,8 +324,8 @@ defmodule Lotus.Sources.MySQL do
   end
 
   @impl true
-  def apply_filters(sql, filters) do
-    FilterInjector.apply(sql, filters, &quote_identifier/1)
+  def apply_filters(sql, params, filters) do
+    FilterInjector.apply(sql, params, filters, &quote_identifier/1, fn _idx -> "?" end)
   end
 
   @impl true

--- a/lib/lotus/sources/postgres.ex
+++ b/lib/lotus/sources/postgres.ex
@@ -248,9 +248,11 @@ defmodule Lotus.Sources.Postgres do
   end
 
   @impl true
-  def apply_filters(sql, filters) do
-    FilterInjector.apply(sql, filters, &quote_identifier/1)
+  def apply_filters(sql, params, filters) do
+    FilterInjector.apply(sql, params, filters, &quote_identifier/1, &placeholder/1)
   end
+
+  defp placeholder(idx), do: "$#{idx}"
 
   @impl true
   def apply_sorts(sql, sorts) do

--- a/lib/lotus/sources/sqlite.ex
+++ b/lib/lotus/sources/sqlite.ex
@@ -195,8 +195,8 @@ defmodule Lotus.Sources.SQLite3 do
   end
 
   @impl true
-  def apply_filters(sql, filters) do
-    FilterInjector.apply(sql, filters, &quote_identifier/1)
+  def apply_filters(sql, params, filters) do
+    FilterInjector.apply(sql, params, filters, &quote_identifier/1, fn _idx -> "?" end)
   end
 
   @impl true

--- a/lib/lotus/sql/filter_injector.ex
+++ b/lib/lotus/sql/filter_injector.ex
@@ -2,48 +2,110 @@ defmodule Lotus.SQL.FilterInjector do
   @moduledoc ~S"""
   Shared helpers for SQL-based sources to inject filter conditions into queries.
 
-  Wraps the original query in a CTE and appends WHERE clauses. Each SQL source
-  calls this with its own `quote_fn` for identifier quoting.
+  Wraps the original query in a CTE and appends WHERE clauses using parameterized
+  queries. Each SQL source calls this with its own `quote_fn` and `placeholder_fn`
+  for database-specific identifier quoting and parameter placeholders.
 
   ## Example
 
       quote_fn = fn id -> ~s("#{id}") end
-      Lotus.SQL.FilterInjector.apply("SELECT * FROM users", [
+      placeholder_fn = fn idx -> "$#{idx}" end
+      Lotus.SQL.FilterInjector.apply("SELECT * FROM users", [25], [
         %Lotus.Query.Filter{column: "region", op: :eq, value: "US"}
-      ], quote_fn)
-      #=> ~s(WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US')
+      ], quote_fn, placeholder_fn)
+      #=> {~s(WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = $2), [25, "US"]}
   """
 
   alias Lotus.Query.Filter
+  alias Lotus.SQL.Identifier
 
   import Lotus.SQL.Sanitizer, only: [strip_trailing_semicolon: 1]
 
   @doc """
-  Wraps the given SQL in a CTE and appends WHERE clauses for each filter.
+  Wraps the given SQL in a CTE and appends parameterized WHERE clauses for each filter.
 
   `quote_fn` is a 1-arity function that quotes an identifier for the target database.
+  `placeholder_fn` is a 1-arity function that takes a 1-based parameter index and
+  returns the placeholder string (e.g., `"$1"` for Postgres, `"?"` for MySQL).
 
-  Returns the original SQL unchanged if filters is empty.
+  Returns `{sql, params}` where params is the updated parameter list with filter
+  values appended. Returns `{sql, params}` unchanged if filters is empty.
   """
-  @spec apply(String.t(), [Filter.t()], (String.t() -> String.t())) :: String.t()
-  def apply(sql, [], _quote_fn), do: sql
+  @spec apply(String.t(), list(), [Filter.t()], (String.t() -> String.t()), (pos_integer() ->
+                                                                               String.t())) ::
+          {String.t(), list()}
+  def apply(sql, params, [], _quote_fn, _placeholder_fn), do: {sql, params}
 
-  def apply(sql, filters, quote_fn) when is_list(filters) and is_function(quote_fn, 1) do
-    conditions = Enum.map_join(filters, " AND ", &build_condition(&1, quote_fn))
+  def apply(sql, params, filters, quote_fn, placeholder_fn)
+      when is_list(filters) and is_function(quote_fn, 1) and is_function(placeholder_fn, 1) do
+    base_index = length(params)
+
+    {condition_fragments, new_params} =
+      build_conditions(filters, quote_fn, placeholder_fn, base_index, [], [])
+
+    conditions = Enum.join(condition_fragments, " AND ")
     bare = strip_trailing_semicolon(sql)
-    "WITH _base AS (#{bare}) SELECT * FROM _base WHERE #{conditions}"
+    new_sql = "WITH _base AS (#{bare}) SELECT * FROM _base WHERE #{conditions}"
+
+    {new_sql, params ++ new_params}
   end
 
-  defp build_condition(%Filter{column: column, op: :is_null}, quote_fn) do
-    "#{quote_fn.(column)} IS NULL"
+  defp build_conditions([], _quote_fn, _placeholder_fn, _idx, frags, params) do
+    {Enum.reverse(frags), Enum.reverse(params)}
   end
 
-  defp build_condition(%Filter{column: column, op: :is_not_null}, quote_fn) do
-    "#{quote_fn.(column)} IS NOT NULL"
+  defp build_conditions([filter | rest], quote_fn, placeholder_fn, idx, frags, params) do
+    {frag, new_params, next_idx} = build_condition(filter, quote_fn, placeholder_fn, idx)
+
+    build_conditions(
+      rest,
+      quote_fn,
+      placeholder_fn,
+      next_idx,
+      [frag | frags],
+      new_params ++ params
+    )
   end
 
-  defp build_condition(%Filter{column: column, op: op, value: value}, quote_fn) do
-    "#{quote_fn.(column)} #{op_to_sql(op)} #{quote_value(value)}"
+  defp build_condition(%Filter{column: column, op: :is_null}, quote_fn, _placeholder_fn, idx) do
+    validate_column!(column)
+    {"#{quote_fn.(column)} IS NULL", [], idx}
+  end
+
+  defp build_condition(%Filter{column: column, op: :is_not_null}, quote_fn, _placeholder_fn, idx) do
+    validate_column!(column)
+    {"#{quote_fn.(column)} IS NOT NULL", [], idx}
+  end
+
+  defp build_condition(
+         %Filter{column: column, op: op, value: nil},
+         quote_fn,
+         _placeholder_fn,
+         idx
+       ) do
+    validate_column!(column)
+
+    case op do
+      :eq -> {"#{quote_fn.(column)} IS NULL", [], idx}
+      :neq -> {"#{quote_fn.(column)} IS NOT NULL", [], idx}
+      _ -> {"#{quote_fn.(column)} #{op_to_sql(op)} NULL", [], idx}
+    end
+  end
+
+  defp build_condition(
+         %Filter{column: column, op: op, value: value},
+         quote_fn,
+         placeholder_fn,
+         idx
+       ) do
+    validate_column!(column)
+    param_idx = idx + 1
+    placeholder = placeholder_fn.(param_idx)
+    {"#{quote_fn.(column)} #{op_to_sql(op)} #{placeholder}", [value], param_idx}
+  end
+
+  defp validate_column!(column) do
+    Identifier.validate_identifier!(column, "filter column")
   end
 
   defp op_to_sql(:eq), do: "="
@@ -53,23 +115,4 @@ defmodule Lotus.SQL.FilterInjector do
   defp op_to_sql(:gte), do: ">="
   defp op_to_sql(:lte), do: "<="
   defp op_to_sql(:like), do: "LIKE"
-
-  @doc """
-  Quotes a value as a SQL literal, handling type-appropriate formatting.
-  """
-  @spec quote_value(term()) :: String.t()
-  def quote_value(nil), do: "NULL"
-  def quote_value(value) when is_integer(value), do: Integer.to_string(value)
-  def quote_value(value) when is_float(value), do: Float.to_string(value)
-  def quote_value(true), do: "TRUE"
-  def quote_value(false), do: "FALSE"
-
-  def quote_value(%Decimal{} = value), do: Decimal.to_string(value)
-
-  def quote_value(value) when is_binary(value) do
-    escaped = String.replace(value, "'", "''")
-    "'#{escaped}'"
-  end
-
-  def quote_value(value), do: quote_value(to_string(value))
 end

--- a/lib/lotus/sql/sort_injector.ex
+++ b/lib/lotus/sql/sort_injector.ex
@@ -18,6 +18,7 @@ defmodule Lotus.SQL.SortInjector do
   """
 
   alias Lotus.Query.Sort
+  alias Lotus.SQL.Identifier
 
   import Lotus.SQL.Sanitizer, only: [strip_trailing_semicolon: 1]
 
@@ -27,6 +28,8 @@ defmodule Lotus.SQL.SortInjector do
   `quote_fn` is a 1-arity function that quotes an identifier for the target database.
 
   Returns the original SQL unchanged if sorts is empty.
+
+  Raises `ArgumentError` if any sort column name contains invalid characters.
   """
   @spec apply(String.t(), [Sort.t()], (String.t() -> String.t())) :: String.t()
   def apply(sql, [], _quote_fn), do: sql
@@ -38,6 +41,7 @@ defmodule Lotus.SQL.SortInjector do
   end
 
   defp build_sort_clause(%Sort{column: column, direction: direction}, quote_fn) do
+    Identifier.validate_identifier!(column, "sort column")
     "#{quote_fn.(column)} #{direction_to_sql(direction)}"
   end
 

--- a/test/lotus/sql/filter_injector_test.exs
+++ b/test/lotus/sql/filter_injector_test.exs
@@ -6,24 +6,31 @@ defmodule Lotus.SQL.FilterInjectorTest do
 
   defp double_quote(id), do: ~s("#{id}")
   defp backtick_quote(id), do: "`#{id}`"
+  defp pg_placeholder(idx), do: "$#{idx}"
+  defp mysql_placeholder(_idx), do: "?"
 
-  describe "apply/3" do
-    test "returns original SQL when filters is empty" do
+  describe "apply/5" do
+    test "returns original SQL and params when filters is empty" do
       sql = "SELECT * FROM users"
-      assert FilterInjector.apply(sql, [], &double_quote/1) == sql
+
+      assert FilterInjector.apply(sql, [25], [], &double_quote/1, &pg_placeholder/1) ==
+               {sql, [25]}
     end
 
-    test "wraps SQL in CTE with single eq filter" do
+    test "wraps SQL in CTE with parameterized eq filter" do
       sql = "SELECT * FROM users"
       filters = [Filter.new("region", :eq, "US")]
 
-      result = FilterInjector.apply(sql, filters, &double_quote/1)
+      {result, params} =
+        FilterInjector.apply(sql, [], filters, &double_quote/1, &pg_placeholder/1)
 
       assert result ==
-               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = $1]
+
+      assert params == ["US"]
     end
 
-    test "handles multiple filters with AND" do
+    test "handles multiple filters with AND and correct parameter indices" do
       sql = "SELECT * FROM orders"
 
       filters = [
@@ -31,71 +38,161 @@ defmodule Lotus.SQL.FilterInjectorTest do
         Filter.new("status", :neq, "cancelled")
       ]
 
-      result = FilterInjector.apply(sql, filters, &double_quote/1)
+      {result, params} =
+        FilterInjector.apply(sql, [], filters, &double_quote/1, &pg_placeholder/1)
 
       assert result ==
-               ~s[WITH _base AS (SELECT * FROM orders) SELECT * FROM _base WHERE "region" = 'US' AND "status" != 'cancelled']
+               ~s[WITH _base AS (SELECT * FROM orders) SELECT * FROM _base WHERE "region" = $1 AND "status" != $2]
+
+      assert params == ["US", "cancelled"]
     end
 
-    test "handles numeric values without quotes" do
-      filters = [Filter.new("price", :gt, 100)]
-      result = FilterInjector.apply("SELECT * FROM products", filters, &double_quote/1)
-      assert result =~ ~s("price" > 100)
-    end
-
-    test "handles float values" do
-      filters = [Filter.new("rating", :gte, 4.5)]
-      result = FilterInjector.apply("SELECT * FROM reviews", filters, &double_quote/1)
-      assert result =~ ~s("rating" >= 4.5)
-    end
-
-    test "handles IS NULL operator" do
-      filters = [Filter.new("deleted_at", :is_null)]
-      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
-      assert result =~ ~s("deleted_at" IS NULL)
-    end
-
-    test "handles IS NOT NULL operator" do
-      filters = [Filter.new("email", :is_not_null)]
-      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
-      assert result =~ ~s("email" IS NOT NULL)
-    end
-
-    test "handles LIKE operator" do
-      filters = [Filter.new("name", :like, "%John%")]
-      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
-      assert result =~ ~s("name" LIKE '%John%')
-    end
-
-    test "escapes single quotes in string values" do
-      filters = [Filter.new("name", :eq, "O'Brien")]
-      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
-      assert result =~ ~s("name" = 'O''Brien')
-    end
-
-    test "handles boolean values" do
-      filters = [Filter.new("active", :eq, true)]
-      result = FilterInjector.apply("SELECT * FROM users", filters, &double_quote/1)
-      assert result =~ ~s("active" = TRUE)
-    end
-
-    test "works with backtick quoting (MySQL style)" do
+    test "continues parameter indexing from existing params" do
+      sql = "SELECT * FROM users WHERE age > $1"
+      existing_params = [25]
       filters = [Filter.new("region", :eq, "US")]
-      result = FilterInjector.apply("SELECT * FROM users", filters, &backtick_quote/1)
+
+      {result, params} =
+        FilterInjector.apply(sql, existing_params, filters, &double_quote/1, &pg_placeholder/1)
 
       assert result ==
-               "WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE `region` = 'US'"
+               ~s[WITH _base AS (SELECT * FROM users WHERE age > $1) SELECT * FROM _base WHERE "region" = $2]
+
+      assert params == [25, "US"]
     end
 
-    test "escapes double quotes in column names" do
-      quote_fn = fn id ->
-        escaped = String.replace(id, "\"", "\"\"")
-        ~s("#{escaped}")
-      end
+    test "handles numeric values as parameters" do
+      filters = [Filter.new("price", :gt, 100)]
 
-      filters = [Filter.new(~s(col"name), :eq, "val")]
-      result = FilterInjector.apply("SELECT * FROM t", filters, quote_fn)
-      assert result =~ ~s("col""name" = 'val')
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM products",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("price" > $1)
+      assert params == [100]
+    end
+
+    test "handles float values as parameters" do
+      filters = [Filter.new("rating", :gte, 4.5)]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM reviews",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("rating" >= $1)
+      assert params == [4.5]
+    end
+
+    test "handles IS NULL operator without parameters" do
+      filters = [Filter.new("deleted_at", :is_null)]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("deleted_at" IS NULL)
+      assert params == []
+    end
+
+    test "handles IS NOT NULL operator without parameters" do
+      filters = [Filter.new("email", :is_not_null)]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("email" IS NOT NULL)
+      assert params == []
+    end
+
+    test "handles LIKE operator with parameterized value" do
+      filters = [Filter.new("name", :like, "%John%")]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("name" LIKE $1)
+      assert params == ["%John%"]
+    end
+
+    test "string values with special characters are safely parameterized" do
+      filters = [Filter.new("name", :eq, "O'Brien; DROP TABLE users; --")]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("name" = $1)
+      assert params == ["O'Brien; DROP TABLE users; --"]
+      refute result =~ "O'Brien"
+    end
+
+    test "handles boolean values as parameters" do
+      filters = [Filter.new("active", :eq, true)]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("active" = $1)
+      assert params == [true]
+    end
+
+    test "works with MySQL-style placeholders" do
+      filters = [
+        Filter.new("region", :eq, "US"),
+        Filter.new("status", :eq, "active")
+      ]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &backtick_quote/1,
+          &mysql_placeholder/1
+        )
+
+      assert result ==
+               "WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE `region` = ? AND `status` = ?"
+
+      assert params == ["US", "active"]
     end
 
     test "handles all comparison operators" do
@@ -103,8 +200,12 @@ defmodule Lotus.SQL.FilterInjectorTest do
 
       for {op, sql_op} <- ops do
         filters = [Filter.new("col", op, "val")]
-        result = FilterInjector.apply("SELECT 1", filters, &double_quote/1)
-        assert result =~ ~s("col" #{sql_op} 'val'), "Failed for op: #{op}"
+
+        {result, params} =
+          FilterInjector.apply("SELECT 1", [], filters, &double_quote/1, &pg_placeholder/1)
+
+        assert result =~ ~s("col" #{sql_op} $1), "Failed for op: #{op}"
+        assert params == ["val"]
       end
     end
 
@@ -112,20 +213,22 @@ defmodule Lotus.SQL.FilterInjectorTest do
       sql = "SELECT * FROM users;"
       filters = [Filter.new("region", :eq, "US")]
 
-      result = FilterInjector.apply(sql, filters, &double_quote/1)
+      {result, _params} =
+        FilterInjector.apply(sql, [], filters, &double_quote/1, &pg_placeholder/1)
 
       assert result ==
-               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = $1]
     end
 
     test "strips trailing semicolon with surrounding whitespace" do
       sql = "SELECT * FROM users ;  "
       filters = [Filter.new("region", :eq, "US")]
 
-      result = FilterInjector.apply(sql, filters, &double_quote/1)
+      {result, _params} =
+        FilterInjector.apply(sql, [], filters, &double_quote/1, &pg_placeholder/1)
 
       assert result ==
-               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+               ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = $1]
     end
 
     test "handles CTE query with trailing semicolon" do
@@ -136,11 +239,13 @@ defmodule Lotus.SQL.FilterInjectorTest do
 
       filters = [Filter.new("name", :eq, "test")]
 
-      result = FilterInjector.apply(sql, filters, &double_quote/1)
+      {result, params} =
+        FilterInjector.apply(sql, [], filters, &double_quote/1, &pg_placeholder/1)
 
       assert result =~ "WITH _base AS ("
       refute result =~ ";"
-      assert result =~ ~s(SELECT * FROM _base WHERE "name" = 'test')
+      assert result =~ ~s(SELECT * FROM _base WHERE "name" = $1)
+      assert params == ["test"]
     end
 
     test "wraps complex queries safely" do
@@ -149,9 +254,73 @@ defmodule Lotus.SQL.FilterInjectorTest do
 
       filters = [Filter.new("name", :eq, "test")]
 
-      result = FilterInjector.apply(sql, filters, &double_quote/1)
+      {result, params} =
+        FilterInjector.apply(sql, [], filters, &double_quote/1, &pg_placeholder/1)
+
       assert result =~ "WITH _base AS (#{sql})"
-      assert result =~ ~s(SELECT * FROM _base WHERE "name" = 'test')
+      assert result =~ ~s(SELECT * FROM _base WHERE "name" = $1)
+      assert params == ["test"]
+    end
+
+    test "handles eq with nil value as IS NULL" do
+      filters = [Filter.new("deleted_at", :eq, nil)]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("deleted_at" IS NULL)
+      assert params == []
+    end
+
+    test "handles neq with nil value as IS NOT NULL" do
+      filters = [Filter.new("deleted_at", :neq, nil)]
+
+      {result, params} =
+        FilterInjector.apply(
+          "SELECT * FROM users",
+          [],
+          filters,
+          &double_quote/1,
+          &pg_placeholder/1
+        )
+
+      assert result =~ ~s("deleted_at" IS NOT NULL)
+      assert params == []
+    end
+  end
+
+  describe "column validation" do
+    test "rejects column names with SQL injection attempts" do
+      filters = [Filter.new("col; DROP TABLE users", :eq, "val")]
+
+      assert_raise ArgumentError, ~r/Invalid filter column/, fn ->
+        FilterInjector.apply("SELECT 1", [], filters, &double_quote/1, &pg_placeholder/1)
+      end
+    end
+
+    test "rejects column names with special characters" do
+      for bad_col <- ["col name", "col'name", "col\"name", "col;name", "col--name"] do
+        filters = [Filter.new(bad_col, :eq, "val")]
+
+        assert_raise ArgumentError, ~r/Invalid filter column/, fn ->
+          FilterInjector.apply("SELECT 1", [], filters, &double_quote/1, &pg_placeholder/1)
+        end
+      end
+    end
+
+    test "accepts valid column names" do
+      for good_col <- ["name", "user_name", "_id", "Column1", "a"] do
+        filters = [Filter.new(good_col, :eq, "val")]
+
+        {_result, _params} =
+          FilterInjector.apply("SELECT 1", [], filters, &double_quote/1, &pg_placeholder/1)
+      end
     end
   end
 end

--- a/test/lotus/sql/sort_injector_test.exs
+++ b/test/lotus/sql/sort_injector_test.exs
@@ -55,17 +55,6 @@ defmodule Lotus.SQL.SortInjectorTest do
                "WITH _sorted AS (SELECT * FROM users) SELECT * FROM _sorted ORDER BY `name` ASC"
     end
 
-    test "escapes double quotes in column names" do
-      quote_fn = fn id ->
-        escaped = String.replace(id, "\"", "\"\"")
-        ~s("#{escaped}")
-      end
-
-      sorts = [Sort.new(~s(col"name), :desc)]
-      result = SortInjector.apply("SELECT * FROM t", sorts, quote_fn)
-      assert result =~ ~s("col""name" DESC)
-    end
-
     test "strips trailing semicolon before wrapping in CTE" do
       sql = "SELECT * FROM users;"
       sorts = [Sort.new("name", :asc)]
@@ -98,13 +87,41 @@ defmodule Lotus.SQL.SortInjectorTest do
 
     test "works after CTE-wrapped filtered query" do
       sql =
-        ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US']
+        ~s[WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = $1]
 
       sorts = [Sort.new("name", :asc)]
       result = SortInjector.apply(sql, sorts, &double_quote/1)
 
       assert result ==
-               ~s[WITH _sorted AS (WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = 'US') SELECT * FROM _sorted ORDER BY "name" ASC]
+               ~s[WITH _sorted AS (WITH _base AS (SELECT * FROM users) SELECT * FROM _base WHERE "region" = $1) SELECT * FROM _sorted ORDER BY "name" ASC]
+    end
+  end
+
+  describe "column validation" do
+    test "rejects column names with SQL injection attempts" do
+      sorts = [Sort.new("name; DROP TABLE users", :asc)]
+
+      assert_raise ArgumentError, ~r/Invalid sort column/, fn ->
+        SortInjector.apply("SELECT 1", sorts, &double_quote/1)
+      end
+    end
+
+    test "rejects column names with special characters" do
+      for bad_col <- ["col name", "col'name", "col\"name", "col;name", "col--name"] do
+        sorts = [Sort.new(bad_col, :asc)]
+
+        assert_raise ArgumentError, ~r/Invalid sort column/, fn ->
+          SortInjector.apply("SELECT 1", sorts, &double_quote/1)
+        end
+      end
+    end
+
+    test "accepts valid column names" do
+      for good_col <- ["name", "user_name", "_id", "Column1", "a"] do
+        sorts = [Sort.new(good_col, :asc)]
+        result = SortInjector.apply("SELECT 1", sorts, &double_quote/1)
+        assert result =~ "ORDER BY"
+      end
     end
   end
 end


### PR DESCRIPTION
Parameterize filter values instead of string-interpolating them into SQL, and validate filter/sort column names against a safe identifier pattern.

Closes https://github.com/typhoonworks/lotus/issues/152