### PR TITLE
Introduce pluggable source adapter abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- Pluggable source adapter abstraction (`Lotus.Source.Adapter`) for wrapping data sources behind a uniform callback interface
+- `Lotus.Source.Resolver` behaviour for configurable source resolution
+- `Lotus.Visibility.Resolver` behaviour for configurable visibility rule resolution
+- Default implementations: `Lotus.Source.Resolvers.Static`, `Lotus.Visibility.Resolvers.Static`, `Lotus.Source.Adapters.Ecto`
+- Config keys: `:source_resolver` (default `Lotus.Source.Resolvers.Static`), `:visibility_resolver` (default `Lotus.Visibility.Resolvers.Static`)
+
+### Changed (BREAKING — internal API only, public API unchanged)
+
+- `Sources.resolve!/2` returns `%Adapter{}` instead of `{module, name}` tuple
+- `Runner.run_sql/4` accepts `%Adapter{}` instead of repo module
+- `Preflight.authorize` accepts `%Adapter{}` instead of `(repo, repo_name)`
+- Source behaviour SQL generation callbacks now take `state` as first argument
+
 ### Security
 
 - **FIX:** Use parameterized queries in `FilterInjector` instead of string-interpolated values — filter values are now bound as query parameters (`$1`, `?`) and never appear in the SQL string, eliminating SQL injection risk via crafted filter values (#152)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,23 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- `Sources.resolve!/2` returns `%Lotus.Source.Adapter{}` struct instead of `{module, name}` tuple
+- `Runner.run_sql/4` first argument changed from repo module to `%Lotus.Source.Adapter{}`
+- `Preflight.authorize` accepts `%Lotus.Source.Adapter{}` instead of `(repo, repo_name)` tuple
+- Source behaviour SQL generation callbacks (`param_placeholder`, `apply_filters`, `apply_sorts`, `quote_identifier`, `limit_offset_placeholders`) now take `state` as first argument
+- Source behaviour error handling callbacks (`format_error`, `handled_errors`) now take `state` as first argument
+- **Note:** The public API (`Lotus.run_query/2`, `Lotus.run_sql/3`, `Lotus.list_schemas/2`, etc.) is unchanged. These are internal API changes affecting code that calls `Runner`, `Sources`, `Preflight`, or `Source` directly.
+
 ### Added
 
-- Pluggable source adapter abstraction (`Lotus.Source.Adapter`) for wrapping data sources behind a uniform callback interface
+- Pluggable source adapter abstraction (`Lotus.Source.Adapter`) — behaviour and struct wrapping data sources behind a uniform callback interface with consistent `{:ok, _} | {:error, _}` return types
 - `Lotus.Source.Resolver` behaviour for configurable source resolution
 - `Lotus.Visibility.Resolver` behaviour for configurable visibility rule resolution
 - Default implementations: `Lotus.Source.Resolvers.Static`, `Lotus.Visibility.Resolvers.Static`, `Lotus.Source.Adapters.Ecto`
 - Config keys: `:source_resolver` (default `Lotus.Source.Resolvers.Static`), `:visibility_resolver` (default `Lotus.Visibility.Resolvers.Static`)
-
-### Changed (BREAKING — internal API only, public API unchanged)
-
-- `Sources.resolve!/2` returns `%Adapter{}` instead of `{module, name}` tuple
-- `Runner.run_sql/4` accepts `%Adapter{}` instead of repo module
-- `Preflight.authorize` accepts `%Adapter{}` instead of `(repo, repo_name)`
-- Source behaviour SQL generation callbacks now take `state` as first argument
+- Guide: `source-adapters.md` documenting the adapter system, custom resolvers, and custom adapters
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For the complete setup guide (caching, multiple databases, visibility controls),
 - **AI query explanation** — get plain-language explanations of what a query does, including selected fragments; understands Lotus `{{variable}}` and `[[optional]]` syntax
 - **AI query optimization** — get actionable optimization suggestions (indexes, rewrites, schema changes) powered by EXPLAIN plan analysis
 - **Read-only by default** — all queries run in read-only transactions with automatic timeout controls and session state management (opt out per-query with `read_only: false`)
+- **Pluggable adapters** — data sources are wrapped in a uniform `Lotus.Source.Adapter` behaviour, decoupling the execution pipeline from Ecto. The default `Ecto` adapter works out of the box with your existing `data_repos` config. Custom adapters can target non-Ecto sources, and custom resolvers can load sources dynamically from a database or external service. See the [source adapters guide](guides/source-adapters.md).
 
 ## Production Ready
 

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -13,7 +13,7 @@ The adapter struct carries four fields:
 | `name` | `String.t()` | Human-readable identifier (e.g. `"main"`, `"warehouse"`) |
 | `module` | `module()` | The module implementing `Lotus.Source.Adapter` callbacks |
 | `state` | `term()` | Opaque connection state managed by the adapter (e.g. an Ecto.Repo module) |
-| `source_type` | `atom()` | Database kind — `:postgres`, `:mysql`, `:sqlite`, `:tds`, or `:other` |
+| `source_type` | `atom()` | Database kind — `:postgres`, `:mysql`, `:sqlite`, or `:other` |
 
 When a query is executed, Lotus asks the configured **source resolver** to turn a repo name (or module) into an `%Adapter{}` struct. The resolver returns the struct, and from that point every pipeline stage — SQL generation, preflight authorization, execution, introspection — dispatches through `Adapter` dispatch helpers which delegate to the underlying `module`, passing `state` as the first argument.
 

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -1,0 +1,220 @@
+# Source Adapters
+
+## Overview
+
+Source adapters wrap data sources behind a uniform callback interface so that the Lotus execution pipeline does not depend on any particular database driver or connection strategy. Every data source — whether it is an Ecto repo, a raw database connection, or an external API — is represented as a `%Lotus.Source.Adapter{}` struct that the runner, preflight checks, and introspection modules all accept identically.
+
+## How It Works
+
+The adapter struct carries four fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `String.t()` | Human-readable identifier (e.g. `"main"`, `"warehouse"`) |
+| `module` | `module()` | The module implementing `Lotus.Source.Adapter` callbacks |
+| `state` | `term()` | Opaque connection state managed by the adapter (e.g. an Ecto.Repo module) |
+| `source_type` | `atom()` | Database kind — `:postgres`, `:mysql`, `:sqlite`, `:tds`, or `:other` |
+
+When a query is executed, Lotus asks the configured **source resolver** to turn a repo name (or module) into an `%Adapter{}` struct. The resolver returns the struct, and from that point every pipeline stage — SQL generation, preflight authorization, execution, introspection — dispatches through `Adapter` dispatch helpers which delegate to the underlying `module`, passing `state` as the first argument.
+
+```
+User calls Lotus.run_sql("SELECT 1", [], repo: "main")
+  │
+  ▼
+Source Resolver  ──▶  %Adapter{name: "main", module: Ecto, state: MyApp.Repo, source_type: :postgres}
+  │
+  ▼
+Runner / Preflight / Schema  ──▶  Adapter.execute_query(adapter, sql, params, opts)
+                                     └─▶  Ecto.execute_query(MyApp.Repo, sql, params, opts)
+```
+
+## Default Behaviour
+
+If you are using Ecto repos and static configuration, no changes are needed. The default source resolver (`Lotus.Source.Resolvers.Static`) reads your existing `data_repos` config and wraps each repo in `Lotus.Source.Adapters.Ecto` automatically. Your existing configuration continues to work as before:
+
+```elixir
+config :lotus,
+  ecto_repo: MyApp.Repo,
+  default_repo: "main",
+  data_repos: %{
+    "main" => MyApp.Repo,
+    "analytics" => MyApp.AnalyticsRepo
+  }
+```
+
+The public API (`Lotus.run_query/2`, `Lotus.run_sql/3`, etc.) is unchanged.
+
+## Configuration
+
+Two config keys control how adapters and visibility rules are resolved:
+
+```elixir
+config :lotus,
+  # Determines how repo names are resolved to %Adapter{} structs.
+  # Default: Lotus.Source.Resolvers.Static
+  source_resolver: MyApp.SourceResolver,
+
+  # Determines how visibility rules (schema, table, column) are loaded.
+  # Default: Lotus.Visibility.Resolvers.Static
+  visibility_resolver: MyApp.VisibilityResolver
+```
+
+Both keys are optional. When omitted, the defaults read from static application config — the same behaviour Lotus has always had.
+
+## Custom Source Resolvers
+
+Implement the `Lotus.Source.Resolver` behaviour to load data sources dynamically — for example from a database registry or an external service.
+
+```elixir
+defmodule MyApp.SourceResolver do
+  @behaviour Lotus.Source.Resolver
+
+  @impl true
+  def resolve(repo_opt, _fallback) do
+    case MyApp.DataSources.find(repo_opt) do
+      nil -> {:error, :not_found}
+      source -> {:ok, build_adapter(source)}
+    end
+  end
+
+  @impl true
+  def list_sources do
+    MyApp.DataSources.all()
+    |> Enum.map(&build_adapter/1)
+  end
+
+  @impl true
+  def get_source!(name) do
+    source = MyApp.DataSources.find!(name)
+    build_adapter(source)
+  end
+
+  @impl true
+  def list_source_names do
+    MyApp.DataSources.all()
+    |> Enum.map(& &1.name)
+  end
+
+  @impl true
+  def default_source do
+    source = MyApp.DataSources.default!()
+    {source.name, build_adapter(source)}
+  end
+
+  defp build_adapter(source) do
+    Lotus.Source.Adapters.Ecto.wrap(source.name, source.repo_module)
+  end
+end
+```
+
+Then configure it:
+
+```elixir
+config :lotus,
+  source_resolver: MyApp.SourceResolver
+```
+
+The five required callbacks are:
+
+| Callback | Returns |
+|---|---|
+| `resolve/2` | `{:ok, %Adapter{}}` or `{:error, term()}` |
+| `list_sources/0` | `[%Adapter{}]` |
+| `get_source!/1` | `%Adapter{}` (raises on missing) |
+| `list_source_names/0` | `[String.t()]` |
+| `default_source/0` | `{name, %Adapter{}}` |
+
+## Custom Visibility Resolvers
+
+Implement `Lotus.Visibility.Resolver` to load visibility rules from a database or per-tenant configuration instead of static config.
+
+```elixir
+defmodule MyApp.VisibilityResolver do
+  @behaviour Lotus.Visibility.Resolver
+
+  @impl true
+  def schema_rules_for(source_name) do
+    case MyApp.VisibilityStore.get_schema_rules(source_name) do
+      nil -> [allow: :all, deny: []]
+      rules -> rules
+    end
+  end
+
+  @impl true
+  def table_rules_for(source_name) do
+    case MyApp.VisibilityStore.get_table_rules(source_name) do
+      nil -> [allow: [], deny: []]
+      rules -> rules
+    end
+  end
+
+  @impl true
+  def column_rules_for(source_name) do
+    MyApp.VisibilityStore.get_column_rules(source_name) || []
+  end
+end
+```
+
+Then configure it:
+
+```elixir
+config :lotus,
+  visibility_resolver: MyApp.VisibilityResolver
+```
+
+The three required callbacks are:
+
+| Callback | Returns |
+|---|---|
+| `schema_rules_for/1` | `keyword()` — e.g. `[allow: [...], deny: [...]]` |
+| `table_rules_for/1` | `keyword()` — e.g. `[allow: [...], deny: [...]]` |
+| `column_rules_for/1` | `list()` — column rule tuples |
+
+## Custom Adapters
+
+To support a non-Ecto data source, implement the `Lotus.Source.Adapter` behaviour directly. Callbacks are grouped into categories:
+
+**Query execution** — `execute_query/4`, `transaction/3`
+
+**Introspection** — `list_schemas/1`, `list_tables/3`, `get_table_schema/3`, `resolve_table_schema/3`
+
+**SQL generation** — `quote_identifier/2`, `param_placeholder/4`, `limit_offset_placeholders/3`, `apply_filters/4`, `apply_sorts/3`, `explain_plan/4`
+
+**Safety and visibility** — `builtin_denies/1`, `builtin_schema_denies/1`, `default_schemas/1`
+
+**Lifecycle** — `health_check/1`, `disconnect/1`
+
+**Error handling** — `format_error/2`, `handled_errors/1`
+
+**Source identity** — `source_type/1`, `supports_feature?/2`
+
+All callbacks receive `state` as their first argument — the opaque value stored in the adapter struct. For example, an adapter wrapping a raw `Postgrex` connection pool might store the pool pid as `state`:
+
+```elixir
+defmodule MyApp.RawPostgresAdapter do
+  @behaviour Lotus.Source.Adapter
+
+  def wrap(name, pool_pid) do
+    %Lotus.Source.Adapter{
+      name: name,
+      module: __MODULE__,
+      state: pool_pid,
+      source_type: :postgres
+    }
+  end
+
+  @impl true
+  def execute_query(pool_pid, sql, params, opts) do
+    case Postgrex.query(pool_pid, sql, params, opts) do
+      {:ok, %{columns: cols, rows: rows, num_rows: n}} ->
+        {:ok, %{columns: cols, rows: rows, num_rows: n}}
+      {:error, err} ->
+        {:error, Exception.message(err)}
+    end
+  end
+
+  # ... implement remaining callbacks
+end
+```
+
+See `Lotus.Source.Adapters.Ecto` for a complete reference implementation.

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -440,32 +440,32 @@ defmodule Lotus do
   end
 
   defp execute_query(q, sql, params, vars, opts) do
-    {repo_mod, repo_name} = Sources.resolve!(Keyword.get(opts, :repo), q.data_repo)
+    adapter = Sources.resolve!(Keyword.get(opts, :repo), q.data_repo)
 
     search_path = Keyword.get(opts, :search_path) || q.search_path
     final_opts = prepare_final_opts(opts, search_path)
 
     filters = Keyword.get(opts, :filters, [])
-    {sql, params} = Lotus.Source.apply_filters(repo_mod, sql, params, filters)
+    {sql, params} = Lotus.Source.apply_filters(adapter, sql, params, filters)
 
     sorts = Keyword.get(opts, :sorts, [])
-    sql = Lotus.Source.apply_sorts(repo_mod, sql, sorts)
+    sql = Lotus.Source.apply_sorts(adapter, sql, sorts)
 
     {sql, params, window_meta, cache_bound} =
       maybe_apply_window(
         sql,
         params,
-        repo_mod || repo_name,
+        adapter,
         search_path,
         Keyword.get(opts, :window)
       )
 
-    key = result_key(sql, cache_bound || vars, repo_name, search_path)
-    tags = build_cache_tags(q.id, repo_name, opts)
+    key = result_key(sql, cache_bound || vars, adapter.name, search_path)
+    tags = build_cache_tags(q.id, adapter.name, opts)
     profile = determine_cache_profile(opts)
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      with {:ok, %Result{} = res} <- Runner.run_sql(repo_mod, sql, params, final_opts) do
+      with {:ok, %Result{} = res} <- Runner.run_sql(adapter, sql, params, final_opts) do
         {:ok, merge_window_meta(res, window_meta)}
       end
     end)
@@ -588,7 +588,7 @@ defmodule Lotus do
         ]) ::
           {:ok, Result.t()} | {:error, term()}
   def run_sql(sql, params \\ [], opts \\ []) do
-    {repo_mod, repo_name} = Sources.resolve!(Keyword.get(opts, :repo), nil)
+    adapter = Sources.resolve!(Keyword.get(opts, :repo), nil)
 
     runner_opts =
       opts
@@ -598,24 +598,24 @@ defmodule Lotus do
     search_path = Keyword.get(runner_opts, :search_path)
 
     filters = Keyword.get(opts, :filters, [])
-    {sql, params} = Lotus.Source.apply_filters(repo_mod, sql, params, filters)
+    {sql, params} = Lotus.Source.apply_filters(adapter, sql, params, filters)
 
     sorts = Keyword.get(opts, :sorts, [])
-    sql = Lotus.Source.apply_sorts(repo_mod, sql, sorts)
+    sql = Lotus.Source.apply_sorts(adapter, sql, sorts)
 
     {sql, params, window_meta, cache_bound} =
       maybe_apply_window(
         sql,
         params,
-        repo_mod || repo_name,
+        adapter,
         search_path,
         Keyword.get(opts, :window)
       )
 
-    key = result_key(sql, cache_bound || params, repo_name, search_path)
+    key = result_key(sql, cache_bound || params, adapter.name, search_path)
 
     tags =
-      ["repo:#{repo_name}"] ++
+      ["repo:#{adapter.name}"] ++
         if is_list(opts[:cache]), do: Keyword.get(opts[:cache], :tags, []), else: []
 
     profile =
@@ -626,7 +626,7 @@ defmodule Lotus do
       end
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      with {:ok, %Result{} = res} <- Runner.run_sql(repo_mod, sql, params, runner_opts) do
+      with {:ok, %Result{} = res} <- Runner.run_sql(adapter, sql, params, runner_opts) do
         {:ok, merge_window_meta(res, window_meta)}
       end
     end)
@@ -844,19 +844,21 @@ defmodule Lotus do
     end
   end
 
-  defp maybe_apply_window(sql, params, _repo_or_name, _search_path, nil),
+  defp maybe_apply_window(sql, params, _adapter, _search_path, nil),
     do: {sql, params, nil, nil}
 
-  defp maybe_apply_window(sql, params, repo_or_name, search_path, window_opts)
+  defp maybe_apply_window(sql, params, adapter, search_path, window_opts)
        when is_list(window_opts) do
+    alias Lotus.Source.Adapter
+
     base_sql = trim_trailing_semicolon(sql)
     limit = resolve_window_limit(window_opts)
     offset = Keyword.get(window_opts, :offset, 0)
     count_mode = Keyword.get(window_opts, :count, :none)
 
     {limit_ph, offset_ph} =
-      Lotus.Source.limit_offset_placeholders(
-        repo_or_name,
+      Adapter.limit_offset_placeholders(
+        adapter,
         length(params) + 1,
         length(params) + 2
       )
@@ -876,7 +878,7 @@ defmodule Lotus do
             total_mode: :exact,
             count_sql: "SELECT COUNT(*) FROM (" <> base_sql <> ") AS lotus_sub",
             count_params: params,
-            repo_or_name: repo_or_name,
+            adapter: adapter,
             search_path: search_path
           }
 
@@ -920,13 +922,10 @@ defmodule Lotus do
     }
   end
 
-  defp do_count(
-         %{count_sql: count_sql, count_params: count_params, repo_or_name: repo_or_name} = meta
-       ) do
-    {repo_mod, _repo_name} = Sources.resolve!(repo_or_name, nil)
+  defp do_count(%{count_sql: count_sql, count_params: count_params, adapter: adapter} = meta) do
     runner_opts = build_runner_opts(meta)
 
-    repo_mod
+    adapter
     |> Runner.run_sql(count_sql, count_params, runner_opts)
     |> parse_count_result()
   end

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -203,6 +203,18 @@ defmodule Lotus.Config do
             ]
       """
     ],
+    source_resolver: [
+      type: :atom,
+      default: Lotus.Source.Resolvers.Static,
+      doc:
+        "Module implementing `Lotus.Source.Resolver` behaviour. Resolves named data sources to adapter structs."
+    ],
+    visibility_resolver: [
+      type: :atom,
+      default: Lotus.Visibility.Resolvers.Static,
+      doc:
+        "Module implementing `Lotus.Visibility.Resolver` behaviour. Resolves visibility rules for data sources."
+    ],
     middleware: [
       type: {:or, [:map, nil]},
       default: nil,
@@ -253,6 +265,8 @@ defmodule Lotus.Config do
       :schema_visibility,
       :cache,
       :ai,
+      :source_resolver,
+      :visibility_resolver,
       :middleware
     ])
   end
@@ -518,6 +532,18 @@ defmodule Lotus.Config do
   """
   @spec ai_enabled?() :: boolean()
   def ai_enabled?, do: (get(:ai) || [])[:enabled] || false
+
+  @doc """
+  Returns the configured source resolver module.
+  """
+  @spec source_resolver() :: module()
+  def source_resolver, do: load!()[:source_resolver]
+
+  @doc """
+  Returns the configured visibility resolver module.
+  """
+  @spec visibility_resolver() :: module()
+  def visibility_resolver, do: load!()[:visibility_resolver]
 
   @doc """
   Returns the entire validated configuration as a map.

--- a/lib/lotus/preflight.ex
+++ b/lib/lotus/preflight.ex
@@ -40,42 +40,31 @@ defmodule Lotus.Preflight do
 
   defp authorize_pg(%Adapter{} = adapter, sql, params, search_path) do
     explain = "EXPLAIN (VERBOSE, FORMAT JSON) " <> sql
+    opts = if search_path, do: [search_path: search_path], else: []
 
-    opts =
-      if search_path do
-        [search_path: search_path]
-      else
-        []
-      end
-
-    result = Adapter.execute_query(adapter, explain, params, opts)
-
-    case result do
+    case Adapter.execute_query(adapter, explain, params, opts) do
       {:ok, %{rows: [[json]]}} ->
-        plan_data =
-          case json do
-            binary when is_binary(binary) -> Lotus.JSON.decode!(binary)
-            data when is_list(data) or is_map(data) -> data
-          end
-
-        plan =
-          case plan_data do
-            [first | _] -> Map.fetch!(first, "Plan")
-            %{"Plan" => plan} -> plan
-          end
-
-        rels = collect_pg_relations(plan, MapSet.new()) |> MapSet.to_list()
-
-        if Enum.all?(rels, &Visibility.allowed_relation?(adapter.name, &1)) do
-          Relations.put(rels)
-          :ok
-        else
-          blocked_tables = Enum.reject(rels, &Visibility.allowed_relation?(adapter.name, &1))
-          {:error, "Query touches blocked table(s): #{format_relations(blocked_tables)}"}
-        end
+        json
+        |> parse_pg_explain_plan()
+        |> collect_pg_relations(MapSet.new())
+        |> MapSet.to_list()
+        |> check_relations_visibility(adapter.name)
 
       {:error, e} ->
         {:error, normalize_preflight_error(e)}
+    end
+  end
+
+  defp parse_pg_explain_plan(json) do
+    plan_data =
+      case json do
+        binary when is_binary(binary) -> Lotus.JSON.decode!(binary)
+        data when is_list(data) or is_map(data) -> data
+      end
+
+    case plan_data do
+      [first | _] -> Map.fetch!(first, "Plan")
+      %{"Plan" => plan} -> plan
     end
   end
 
@@ -98,13 +87,7 @@ defmodule Lotus.Preflight do
           |> MapSet.to_list()
           |> Enum.map(&{nil, &1})
 
-        if Enum.all?(rels, &Visibility.allowed_relation?(adapter.name, &1)) do
-          Relations.put(rels)
-          :ok
-        else
-          blocked = Enum.reject(rels, &Visibility.allowed_relation?(adapter.name, &1))
-          {:error, "Query touches blocked table(s): #{format_relations(blocked)}"}
-        end
+        check_relations_visibility(rels, adapter.name)
 
       {:error, e} ->
         {:error, normalize_preflight_error(e)}
@@ -118,32 +101,33 @@ defmodule Lotus.Preflight do
 
     case Adapter.execute_query(adapter, explain, params, []) do
       {:ok, %{rows: [[json]]}} ->
-        plan_data = Lotus.JSON.decode!(json)
-
         explain_rels =
-          plan_data
+          json
+          |> Lotus.JSON.decode!()
           |> collect_mysql_relations(MapSet.new())
           |> MapSet.to_list()
           |> Enum.map(fn {schema, table_name} ->
-            actual_name = resolve_alias(table_name, alias_map)
-            {schema, actual_name}
+            {schema, resolve_alias(table_name, alias_map)}
           end)
           |> Enum.reject(fn {_schema, name} -> is_nil(name) end)
 
         sql_rels = extract_mysql_tables_from_sql(sql)
-
         rels = choose_mysql_relations(explain_rels, sql_rels, sql)
 
-        if Enum.all?(rels, &Visibility.allowed_relation?(adapter.name, &1)) do
-          Relations.put(rels)
-          :ok
-        else
-          blocked = Enum.reject(rels, &Visibility.allowed_relation?(adapter.name, &1))
-          {:error, "Query touches blocked table(s): #{format_relations(blocked)}"}
-        end
+        check_relations_visibility(rels, adapter.name)
 
       {:error, e} ->
         {:error, normalize_preflight_error(e)}
+    end
+  end
+
+  defp check_relations_visibility(rels, source_name) do
+    if Enum.all?(rels, &Visibility.allowed_relation?(source_name, &1)) do
+      Relations.put(rels)
+      :ok
+    else
+      blocked = Enum.reject(rels, &Visibility.allowed_relation?(source_name, &1))
+      {:error, "Query touches blocked table(s): #{format_relations(blocked)}"}
     end
   end
 

--- a/lib/lotus/preflight.ex
+++ b/lib/lotus/preflight.ex
@@ -10,7 +10,7 @@ defmodule Lotus.Preflight do
   """
 
   alias Lotus.Preflight.Relations
-  alias Lotus.Sources
+  alias Lotus.Source.Adapter
   alias Lotus.Visibility
 
   @doc """
@@ -21,30 +21,34 @@ defmodule Lotus.Preflight do
 
   ## Examples
 
-      authorize(MyRepo, "postgres", "SELECT * FROM users", [], nil)
+      authorize(adapter, "SELECT * FROM users", [], nil)
       #=> :ok
 
-      authorize(MyRepo, "postgres", "SELECT * FROM schema_migrations", [], "reporting, public")
+      authorize(adapter, "SELECT * FROM schema_migrations", [], "reporting, public")
       #=> {:error, "Query touches a blocked table"}
   """
-  @spec authorize(module(), String.t(), String.t(), list(), String.t() | nil) ::
+  @spec authorize(Adapter.t(), String.t(), list(), String.t() | nil) ::
           :ok | {:error, String.t()}
-  def authorize(repo, repo_name, sql, params, search_path \\ nil) do
-    if Map.has_key?(Lotus.Config.data_repos(), repo_name) do
-      case Sources.source_type(repo) do
-        :postgres -> authorize_pg(repo, repo_name, sql, params, search_path)
-        :sqlite -> authorize_sqlite(repo, repo_name, sql, params, search_path)
-        :mysql -> authorize_mysql(repo, repo_name, sql, params, search_path)
-        _ -> :ok
-      end
-    else
-      {:error, "Unknown data repo '#{repo_name}'"}
+  def authorize(%Adapter{} = adapter, sql, params, search_path \\ nil) do
+    case adapter.source_type do
+      :postgres -> authorize_pg(adapter, sql, params, search_path)
+      :sqlite -> authorize_sqlite(adapter, sql, params, search_path)
+      :mysql -> authorize_mysql(adapter, sql, params, search_path)
+      _ -> :ok
     end
   end
 
-  defp authorize_pg(repo, repo_name, sql, params, search_path) do
+  defp authorize_pg(%Adapter{} = adapter, sql, params, search_path) do
     explain = "EXPLAIN (VERBOSE, FORMAT JSON) " <> sql
-    result = execute_pg_explain(repo, explain, params, search_path)
+
+    opts =
+      if search_path do
+        [search_path: search_path]
+      else
+        []
+      end
+
+    result = Adapter.execute_query(adapter, explain, params, opts)
 
     case result do
       {:ok, %{rows: [[json]]}} ->
@@ -62,11 +66,11 @@ defmodule Lotus.Preflight do
 
         rels = collect_pg_relations(plan, MapSet.new()) |> MapSet.to_list()
 
-        if Enum.all?(rels, &Visibility.allowed_relation?(repo_name, &1)) do
+        if Enum.all?(rels, &Visibility.allowed_relation?(adapter.name, &1)) do
           Relations.put(rels)
           :ok
         else
-          blocked_tables = Enum.reject(rels, &Visibility.allowed_relation?(repo_name, &1))
+          blocked_tables = Enum.reject(rels, &Visibility.allowed_relation?(adapter.name, &1))
           {:error, "Query touches blocked table(s): #{format_relations(blocked_tables)}"}
         end
 
@@ -75,63 +79,30 @@ defmodule Lotus.Preflight do
     end
   end
 
-  defp execute_pg_explain(repo, explain, params, nil) do
-    repo.query(explain, params)
-  end
-
-  defp execute_pg_explain(repo, explain, params, search_path) do
-    result =
-      repo.transaction(fn ->
-        repo.query!("SET LOCAL search_path = #{search_path}")
-        repo.query(explain, params)
-      end)
-
-    case result do
-      {:ok, query_result} -> query_result
-      {:error, err} -> {:error, err}
-    end
-  end
-
-  defp collect_pg_relations(%{"Plans" => plans} = node, acc) do
-    Enum.reduce(plans, collect_pg_here(node, acc), &collect_pg_relations/2)
-  end
-
-  defp collect_pg_relations(node, acc), do: collect_pg_here(node, acc)
-
-  defp collect_pg_here(node, acc) do
-    case {node["Schema"], node["Relation Name"]} do
-      {schema, rel} when is_binary(schema) and is_binary(rel) ->
-        MapSet.put(acc, {schema, rel})
-
-      _ ->
-        acc
-    end
-  end
-
-  defp authorize_sqlite(repo, repo_name, sql, params, _search_path) do
+  defp authorize_sqlite(%Adapter{} = adapter, sql, params, _search_path) do
     alias_map = parse_alias_map(sql)
 
     explain = "EXPLAIN QUERY PLAN " <> sql
 
-    case repo.query(explain, params) do
+    case Adapter.execute_query(adapter, explain, params, []) do
       {:ok, %{rows: rows}} ->
         rels =
           rows
           |> Enum.map(fn row -> Enum.join(row, " ") end)
           # names (base or alias)
           |> Enum.flat_map(&extract_sqlite_relations/1)
-          # <— rewrite alias -> base
+          # rewrite alias -> base
           |> Enum.map(&resolve_alias(&1, alias_map))
           |> Enum.reject(&is_nil/1)
           |> MapSet.new()
           |> MapSet.to_list()
           |> Enum.map(&{nil, &1})
 
-        if Enum.all?(rels, &Visibility.allowed_relation?(repo_name, &1)) do
+        if Enum.all?(rels, &Visibility.allowed_relation?(adapter.name, &1)) do
           Relations.put(rels)
           :ok
         else
-          blocked = Enum.reject(rels, &Visibility.allowed_relation?(repo_name, &1))
+          blocked = Enum.reject(rels, &Visibility.allowed_relation?(adapter.name, &1))
           {:error, "Query touches blocked table(s): #{format_relations(blocked)}"}
         end
 
@@ -140,12 +111,12 @@ defmodule Lotus.Preflight do
     end
   end
 
-  defp authorize_mysql(repo, repo_name, sql, params, _search_path) do
+  defp authorize_mysql(%Adapter{} = adapter, sql, params, _search_path) do
     alias_map = parse_alias_map(sql)
 
     explain = "EXPLAIN FORMAT=JSON " <> sql
 
-    case repo.query(explain, params) do
+    case Adapter.execute_query(adapter, explain, params, []) do
       {:ok, %{rows: [[json]]}} ->
         plan_data = Lotus.JSON.decode!(json)
 
@@ -163,16 +134,32 @@ defmodule Lotus.Preflight do
 
         rels = choose_mysql_relations(explain_rels, sql_rels, sql)
 
-        if Enum.all?(rels, &Visibility.allowed_relation?(repo_name, &1)) do
+        if Enum.all?(rels, &Visibility.allowed_relation?(adapter.name, &1)) do
           Relations.put(rels)
           :ok
         else
-          blocked = Enum.reject(rels, &Visibility.allowed_relation?(repo_name, &1))
+          blocked = Enum.reject(rels, &Visibility.allowed_relation?(adapter.name, &1))
           {:error, "Query touches blocked table(s): #{format_relations(blocked)}"}
         end
 
       {:error, e} ->
         {:error, normalize_preflight_error(e)}
+    end
+  end
+
+  defp collect_pg_relations(%{"Plans" => plans} = node, acc) do
+    Enum.reduce(plans, collect_pg_here(node, acc), &collect_pg_relations/2)
+  end
+
+  defp collect_pg_relations(node, acc), do: collect_pg_here(node, acc)
+
+  defp collect_pg_here(node, acc) do
+    case {node["Schema"], node["Relation Name"]} do
+      {schema, rel} when is_binary(schema) and is_binary(rel) ->
+        MapSet.put(acc, {schema, rel})
+
+      _ ->
+        acc
     end
   end
 
@@ -327,6 +314,10 @@ defmodule Lotus.Preflight do
       {nil, table} -> table
       {schema, table} -> "#{schema}.#{table}"
     end)
+  end
+
+  defp normalize_preflight_error(e) when is_binary(e) do
+    strip_explain_query_tail(e)
   end
 
   defp normalize_preflight_error(e) do

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -7,11 +7,11 @@ defmodule Lotus.Runner do
   `read_only: false` to allow write operations.
   """
 
-  alias Lotus.{Middleware, Preflight, Result, Source, Sources, Telemetry, Visibility}
+  alias Lotus.{Middleware, Preflight, Result, Source, Telemetry, Visibility}
   alias Lotus.Preflight.Relations
+  alias Lotus.Source.Adapter
   alias Lotus.Visibility.Policy
 
-  @type repo :: module()
   @type sql :: String.t()
   @type params :: list()
   @type query_result :: Result.t()
@@ -27,10 +27,11 @@ defmodule Lotus.Runner do
   # The DB-level read-only transaction guard provides an additional safety layer.
   @deny ~r/\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|GRANT|REVOKE|VACUUM|ANALYZE|CALL|LOCK)\b/i
 
-  @spec run_sql(repo(), sql(), params(), opts()) ::
+  @spec run_sql(Adapter.t(), sql(), params(), opts()) ::
           {:ok, query_result()} | {:error, term()}
-  def run_sql(repo, sql, params \\ [], opts \\ []) when is_binary(sql) and is_list(params) do
-    telemetry_meta = %{repo: repo, sql: sql, params: params}
+  def run_sql(%Adapter{} = adapter, sql, params \\ [], opts \\ [])
+      when is_binary(sql) and is_list(params) do
+    telemetry_meta = %{repo: adapter.name, sql: sql, params: params}
     start_time = Telemetry.query_start(telemetry_meta)
     read_only = Keyword.get(opts, :read_only, true)
 
@@ -39,10 +40,10 @@ defmodule Lotus.Runner do
     result =
       with :ok <- assert_single_statement(sql),
            :ok <- assert_not_denied(sql, read_only),
-           :ok <- preflight_visibility(repo, sql, params, opts),
-           :ok <- run_before_query(repo, sql, params, context),
-           {:ok, %Result{} = res} <- exec_read_only(repo, sql, params, opts),
-           {:ok, %Result{} = res} <- run_after_query(repo, sql, params, res, context) do
+           :ok <- preflight_visibility(adapter, sql, params, opts),
+           :ok <- run_before_query(adapter, sql, params, context),
+           {:ok, %Result{} = res} <- exec_read_only(adapter, sql, params, opts),
+           {:ok, %Result{} = res} <- run_after_query(adapter, sql, params, res, context) do
         {:ok, res}
       end
 
@@ -61,18 +62,18 @@ defmodule Lotus.Runner do
     end
   end
 
-  defp exec_read_only(repo, sql, params, opts) do
-    Source.execute_in_transaction(
-      repo,
-      fn ->
+  defp exec_read_only(%Adapter{} = adapter, sql, params, opts) do
+    Adapter.transaction(
+      adapter,
+      fn _state ->
         timeout = Keyword.get(opts, :timeout, 15_000)
 
         {elapsed_us, res} =
           :timer.tc(fn ->
-            repo.query(sql, params, timeout: timeout)
+            Adapter.execute_query(adapter, sql, params, opts ++ [timeout: timeout])
           end)
 
-        handle_query_result(res, elapsed_us, repo)
+        handle_query_result(res, elapsed_us, adapter)
       end,
       opts
     )
@@ -84,20 +85,23 @@ defmodule Lotus.Runner do
     e -> {:error, Source.format_error(e)}
   end
 
-  defp handle_query_result({:ok, %{columns: cols, rows: rows} = raw}, elapsed_us, repo) do
+  defp handle_query_result(
+         {:ok, %{columns: cols, rows: rows} = raw},
+         elapsed_us,
+         %Adapter{} = adapter
+       ) do
     num_rows = Map.get(raw, :num_rows, length(rows || []))
     command = normalize_command(Map.get(raw, :command))
     duration_ms = System.convert_time_unit(elapsed_us, :microsecond, :millisecond)
 
-    repo_name = Sources.name_from_module!(repo)
     rels = Relations.take()
 
     policies =
-      Enum.map(cols || [], fn c -> Visibility.column_policy_for(repo_name, rels, c) end)
+      Enum.map(cols || [], fn c -> Visibility.column_policy_for(adapter.name, rels, c) end)
 
     case enforce_column_policies(cols || [], rows || [], policies) do
       {:error, msg} ->
-        repo.rollback(msg)
+        {:error, msg}
 
       {final_cols, final_rows} ->
         {:ok,
@@ -110,11 +114,11 @@ defmodule Lotus.Runner do
     end
   end
 
-  defp handle_query_result({:error, err}, _elapsed_us, repo) do
-    repo.rollback(Source.format_error(err))
+  defp handle_query_result({:error, err}, _elapsed_us, _adapter) do
+    {:error, err}
   end
 
-  defp handle_query_result(other, _elapsed_us, _repo) do
+  defp handle_query_result(other, _elapsed_us, _adapter) do
     other
   end
 
@@ -294,8 +298,8 @@ defmodule Lotus.Runner do
     end
   end
 
-  defp run_before_query(repo, sql, params, context) do
-    payload = %{repo: repo, sql: sql, params: params, context: context}
+  defp run_before_query(%Adapter{} = adapter, sql, params, context) do
+    payload = %{repo: adapter.name, sql: sql, params: params, context: context}
 
     case Middleware.run(:before_query, payload) do
       {:cont, _} -> :ok
@@ -303,8 +307,8 @@ defmodule Lotus.Runner do
     end
   end
 
-  defp run_after_query(repo, sql, params, %Result{} = result, context) do
-    payload = %{repo: repo, sql: sql, params: params, result: result, context: context}
+  defp run_after_query(%Adapter{} = adapter, sql, params, %Result{} = result, context) do
+    payload = %{repo: adapter.name, sql: sql, params: params, result: result, context: context}
 
     case Middleware.run(:after_query, payload) do
       {:cont, %{result: res}} -> {:ok, res}
@@ -318,13 +322,11 @@ defmodule Lotus.Runner do
     if Regex.match?(@deny, sql), do: {:error, "Only read-only queries are allowed"}, else: :ok
   end
 
-  defp preflight_visibility(repo, sql, params, opts) do
+  defp preflight_visibility(%Adapter{} = adapter, sql, params, opts) do
     if needs_preflight?(sql) do
-      repo_name = Sources.name_from_module!(repo)
-
       search_path = Keyword.get(opts, :search_path)
 
-      case Preflight.authorize(repo, repo_name, sql, params, search_path) do
+      case Preflight.authorize(adapter, sql, params, search_path) do
         :ok -> :ok
         {:error, msg} -> {:error, msg}
       end

--- a/lib/lotus/schema.ex
+++ b/lib/lotus/schema.ex
@@ -287,49 +287,56 @@ defmodule Lotus.Schema do
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
       if Visibility.allowed_relation?(adapter.name, {resolved_schema, table_name}) do
-        try do
-          case Adapter.get_table_schema(adapter, resolved_schema, table_name) do
-            {:ok, cols} ->
-              rels = [{resolved_schema, table_name}]
-
-              annotated =
-                Enum.reduce(cols, [], fn col, acc ->
-                  policy = Visibility.column_policy_for(adapter.name, rels, col.name)
-
-                  cond do
-                    Policy.hidden_from_schema?(policy) ->
-                      acc
-
-                    is_map(policy) ->
-                      [Map.put(col, :visibility, Map.take(policy, [:action, :mask])) | acc]
-
-                    true ->
-                      [col | acc]
-                  end
-                end)
-                |> Enum.reverse()
-
-              run_after_discover(:after_get_table_schema, :columns, %{
-                repo: adapter.name,
-                repo_name: adapter.name,
-                table_name: table_name,
-                schema: resolved_schema,
-                columns: annotated,
-                context: context
-              })
-
-            {:error, reason} ->
-              {:error, reason}
-          end
-        rescue
-          e -> {:error, Exception.message(e)}
-        end
+        fetch_and_annotate_columns(adapter, resolved_schema, table_name, context)
       else
-        {:error,
-         "Table '#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}' is not visible by Lotus policy"}
+        {:error, table_not_visible_message(resolved_schema, table_name)}
       end
     end)
   end
+
+  defp fetch_and_annotate_columns(adapter, resolved_schema, table_name, context) do
+    case Adapter.get_table_schema(adapter, resolved_schema, table_name) do
+      {:ok, cols} ->
+        annotated =
+          annotate_columns_with_visibility(cols, adapter.name, resolved_schema, table_name)
+
+        run_after_discover(:after_get_table_schema, :columns, %{
+          repo: adapter.name,
+          repo_name: adapter.name,
+          table_name: table_name,
+          schema: resolved_schema,
+          columns: annotated,
+          context: context
+        })
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp annotate_columns_with_visibility(cols, source_name, schema, table_name) do
+    rels = [{schema, table_name}]
+
+    cols
+    |> Enum.reduce([], fn col, acc ->
+      policy = Visibility.column_policy_for(source_name, rels, col.name)
+
+      cond do
+        Policy.hidden_from_schema?(policy) -> acc
+        is_map(policy) -> [Map.put(col, :visibility, Map.take(policy, [:action, :mask])) | acc]
+        true -> [col | acc]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp table_not_visible_message(nil, table_name),
+    do: "Table '#{table_name}' is not visible by Lotus policy"
+
+  defp table_not_visible_message(schema, table_name),
+    do: "Table '#{schema}.#{table_name}' is not visible by Lotus policy"
 
   @doc """
   Gets basic statistics about a table.

--- a/lib/lotus/schema.ex
+++ b/lib/lotus/schema.ex
@@ -24,7 +24,8 @@ defmodule Lotus.Schema do
   - **SQLite**: Returns table names as strings (schema-less)
   """
 
-  alias Lotus.{Config, Middleware, Source, Sources, Telemetry, Visibility}
+  alias Lotus.{Config, Middleware, Sources, Telemetry, Visibility}
+  alias Lotus.Source.Adapter
   alias Lotus.Visibility.Policy
 
   @doc """
@@ -54,12 +55,12 @@ defmodule Lotus.Schema do
   @spec list_schemas(module() | String.t(), keyword()) ::
           {:ok, [String.t()]} | {:error, term()}
   def list_schemas(repo_or_name, opts \\ []) do
-    {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    adapter = Sources.resolve!(repo_or_name, nil)
     context = Keyword.get(opts, :context)
-    start_time = Telemetry.schema_introspection_start(:list_schemas, repo_name)
+    start_time = Telemetry.schema_introspection_start(:list_schemas, adapter.name)
 
-    key = schema_key(:list_schemas, repo_name)
-    tags = ["repo:#{repo_name}", "schema:list_schemas"]
+    key = schema_key(:list_schemas, adapter.name)
+    tags = ["repo:#{adapter.name}", "schema:list_schemas"]
 
     profile =
       if is_list(opts[:cache]) do
@@ -71,15 +72,20 @@ defmodule Lotus.Schema do
     result =
       exec_with_cache(opts[:cache], profile, key, tags, fn ->
         try do
-          raw_schemas = Source.list_schemas(repo)
-          filtered_schemas = Visibility.filter_schemas(raw_schemas, repo_name)
+          case Adapter.list_schemas(adapter) do
+            {:ok, raw_schemas} ->
+              filtered_schemas = Visibility.filter_schemas(raw_schemas, adapter.name)
 
-          run_after_discover(:after_list_schemas, :schemas, %{
-            repo: repo,
-            repo_name: repo_name,
-            schemas: filtered_schemas,
-            context: context
-          })
+              run_after_discover(:after_list_schemas, :schemas, %{
+                repo: adapter.name,
+                repo_name: adapter.name,
+                schemas: filtered_schemas,
+                context: context
+              })
+
+            {:error, reason} ->
+              {:error, reason}
+          end
         rescue
           e -> {:error, Exception.message(e)}
         end
@@ -88,7 +94,7 @@ defmodule Lotus.Schema do
     Telemetry.schema_introspection_stop(
       start_time,
       :list_schemas,
-      repo_name,
+      adapter.name,
       result_status(result)
     )
 
@@ -131,26 +137,26 @@ defmodule Lotus.Schema do
   @spec list_tables(module() | String.t(), keyword()) ::
           {:ok, [{String.t(), String.t()}] | [String.t()]} | {:error, term()}
   def list_tables(repo_or_name, opts \\ []) do
-    {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    adapter = Sources.resolve!(repo_or_name, nil)
     context = Keyword.get(opts, :context)
-    start_time = Telemetry.schema_introspection_start(:list_tables, repo_name)
-    schemas = effective_schemas(repo, opts)
+    start_time = Telemetry.schema_introspection_start(:list_tables, adapter.name)
+    schemas = effective_schemas(adapter, opts)
     include_views? = Keyword.get(opts, :include_views, false)
 
     result =
-      case Visibility.validate_schemas(schemas, repo_name) do
+      case Visibility.validate_schemas(schemas, adapter.name) do
         :ok ->
           search_path = Keyword.get(opts, :search_path)
 
           key =
             schema_key(
               :list_tables,
-              repo_name,
+              adapter.name,
               search_path || Enum.join(schemas, ","),
               include_views?
             )
 
-          tags = ["repo:#{repo_name}", "schema:list_tables"]
+          tags = ["repo:#{adapter.name}", "schema:list_tables"]
 
           profile =
             if is_list(opts[:cache]) do
@@ -161,25 +167,29 @@ defmodule Lotus.Schema do
 
           exec_with_cache(opts[:cache], profile, key, tags, fn ->
             try do
-              raw_relations = Source.list_tables(repo, schemas, include_views?)
+              case Adapter.list_tables(adapter, schemas, include_views: include_views?) do
+                {:ok, raw_relations} ->
+                  filtered =
+                    raw_relations
+                    |> Enum.filter(&Visibility.allowed_relation?(adapter.name, &1))
 
-              filtered =
-                raw_relations
-                |> Enum.filter(&Visibility.allowed_relation?(repo_name, &1))
+                  tables =
+                    if Enum.all?(filtered, fn {schema, _table} -> is_nil(schema) end) do
+                      Enum.map(filtered, fn {nil, table} -> table end)
+                    else
+                      filtered
+                    end
 
-              tables =
-                if Enum.all?(filtered, fn {schema, _table} -> is_nil(schema) end) do
-                  Enum.map(filtered, fn {nil, table} -> table end)
-                else
-                  filtered
-                end
+                  run_after_discover(:after_list_tables, :tables, %{
+                    repo: adapter.name,
+                    repo_name: adapter.name,
+                    tables: tables,
+                    context: context
+                  })
 
-              run_after_discover(:after_list_tables, :tables, %{
-                repo: repo,
-                repo_name: repo_name,
-                tables: tables,
-                context: context
-              })
+                {:error, reason} ->
+                  {:error, reason}
+              end
             rescue
               e -> {:error, Exception.message(e)}
             end
@@ -192,7 +202,7 @@ defmodule Lotus.Schema do
     Telemetry.schema_introspection_stop(
       start_time,
       :list_tables,
-      repo_name,
+      adapter.name,
       result_status(result)
     )
 
@@ -225,15 +235,14 @@ defmodule Lotus.Schema do
   @spec get_table_schema(module() | String.t(), String.t(), keyword()) ::
           {:ok, [map()]} | {:error, term()}
   def get_table_schema(repo_or_name, table_name, opts \\ []) do
-    {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    adapter = Sources.resolve!(repo_or_name, nil)
     context = Keyword.get(opts, :context)
-    start_time = Telemetry.schema_introspection_start(:get_table_schema, repo_name)
-    schemas = effective_schemas(repo, opts)
+    start_time = Telemetry.schema_introspection_start(:get_table_schema, adapter.name)
+    schemas = effective_schemas(adapter, opts)
 
     result =
       case resolve_table_schema_with_cache(
-             repo,
-             repo_name,
+             adapter,
              table_name,
              schemas,
              opts[:cache],
@@ -241,30 +250,30 @@ defmodule Lotus.Schema do
            ) do
         nil when schemas == [] ->
           # Schema-less database (SQLite) - nil is expected, proceed with nil schema
-          get_table_schema_cached(repo, repo_name, table_name, nil, context, opts)
+          get_table_schema_cached(adapter, table_name, nil, context, opts)
 
         nil ->
           {:error, "Table '#{table_name}' not found in schemas: #{Enum.join(schemas, ", ")}"}
 
         resolved_schema ->
-          get_table_schema_cached(repo, repo_name, table_name, resolved_schema, context, opts)
+          get_table_schema_cached(adapter, table_name, resolved_schema, context, opts)
       end
 
     Telemetry.schema_introspection_stop(
       start_time,
       :get_table_schema,
-      repo_name,
+      adapter.name,
       result_status(result)
     )
 
     result
   end
 
-  defp get_table_schema_cached(repo, repo_name, table_name, resolved_schema, context, opts) do
-    key = schema_key(:get_table_schema, repo_name, resolved_schema, table_name)
+  defp get_table_schema_cached(adapter, table_name, resolved_schema, context, opts) do
+    key = schema_key(:get_table_schema, adapter.name, resolved_schema, table_name)
 
     tags = [
-      "repo:#{repo_name}",
+      "repo:#{adapter.name}",
       "schema:get_table_schema",
       "table:#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}"
     ]
@@ -277,36 +286,41 @@ defmodule Lotus.Schema do
       end
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      if Visibility.allowed_relation?(repo_name, {resolved_schema, table_name}) do
+      if Visibility.allowed_relation?(adapter.name, {resolved_schema, table_name}) do
         try do
-          cols = Source.get_table_schema(repo, resolved_schema, table_name)
-          rels = [{resolved_schema, table_name}]
+          case Adapter.get_table_schema(adapter, resolved_schema, table_name) do
+            {:ok, cols} ->
+              rels = [{resolved_schema, table_name}]
 
-          annotated =
-            Enum.reduce(cols, [], fn col, acc ->
-              policy = Visibility.column_policy_for(repo_name, rels, col.name)
+              annotated =
+                Enum.reduce(cols, [], fn col, acc ->
+                  policy = Visibility.column_policy_for(adapter.name, rels, col.name)
 
-              cond do
-                Policy.hidden_from_schema?(policy) ->
-                  acc
+                  cond do
+                    Policy.hidden_from_schema?(policy) ->
+                      acc
 
-                is_map(policy) ->
-                  [Map.put(col, :visibility, Map.take(policy, [:action, :mask])) | acc]
+                    is_map(policy) ->
+                      [Map.put(col, :visibility, Map.take(policy, [:action, :mask])) | acc]
 
-                true ->
-                  [col | acc]
-              end
-            end)
-            |> Enum.reverse()
+                    true ->
+                      [col | acc]
+                  end
+                end)
+                |> Enum.reverse()
 
-          run_after_discover(:after_get_table_schema, :columns, %{
-            repo: repo,
-            repo_name: repo_name,
-            table_name: table_name,
-            schema: resolved_schema,
-            columns: annotated,
-            context: context
-          })
+              run_after_discover(:after_get_table_schema, :columns, %{
+                repo: adapter.name,
+                repo_name: adapter.name,
+                table_name: table_name,
+                schema: resolved_schema,
+                columns: annotated,
+                context: context
+              })
+
+            {:error, reason} ->
+              {:error, reason}
+          end
         rescue
           e -> {:error, Exception.message(e)}
         end
@@ -340,44 +354,43 @@ defmodule Lotus.Schema do
   @spec get_table_stats(module() | String.t(), String.t(), keyword()) ::
           {:ok, %{row_count: non_neg_integer()}} | {:error, binary()}
   def get_table_stats(repo_or_name, table_name, opts \\ []) do
-    {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
-    start_time = Telemetry.schema_introspection_start(:get_table_stats, repo_name)
-    schemas = effective_schemas(repo, opts)
+    adapter = Sources.resolve!(repo_or_name, nil)
+    start_time = Telemetry.schema_introspection_start(:get_table_stats, adapter.name)
+    schemas = effective_schemas(adapter, opts)
 
     result =
       case resolve_table_schema_with_cache(
-             repo,
-             repo_name,
+             adapter,
              table_name,
              schemas,
              opts[:cache],
              :results
            ) do
         nil when schemas == [] ->
-          get_table_stats_cached(repo, repo_name, table_name, nil, opts)
+          get_table_stats_cached(adapter, table_name, nil, opts)
 
         nil ->
           {:error, "Table '#{table_name}' not found in schemas: #{Enum.join(schemas, ", ")}"}
 
         resolved_schema ->
-          get_table_stats_cached(repo, repo_name, table_name, resolved_schema, opts)
+          get_table_stats_cached(adapter, table_name, resolved_schema, opts)
       end
 
     Telemetry.schema_introspection_stop(
       start_time,
       :get_table_stats,
-      repo_name,
+      adapter.name,
       result_status(result)
     )
 
     result
   end
 
-  defp get_table_stats_cached(repo, repo_name, table_name, resolved_schema, opts) do
-    key = schema_key(:get_table_stats, repo_name, resolved_schema, table_name)
+  defp get_table_stats_cached(adapter, table_name, resolved_schema, opts) do
+    key = schema_key(:get_table_stats, adapter.name, resolved_schema, table_name)
 
     tags = [
-      "repo:#{repo_name}",
+      "repo:#{adapter.name}",
       "schema:get_table_stats",
       "table:#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}"
     ]
@@ -390,27 +403,23 @@ defmodule Lotus.Schema do
       end
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      if Visibility.allowed_relation?(repo_name, {resolved_schema, table_name}) do
+      if Visibility.allowed_relation?(adapter.name, {resolved_schema, table_name}) do
         try do
-          count =
+          count_sql =
             if resolved_schema do
-              {open_quote, close_quote} = get_quote_chars(repo)
-
-              qt =
-                "#{open_quote}#{String.replace(table_name, close_quote, close_quote <> close_quote)}#{close_quote}"
-
-              qs =
-                "#{open_quote}#{String.replace(resolved_schema, close_quote, close_quote <> close_quote)}#{close_quote}"
-
-              %{rows: [[count]]} = repo.query!("SELECT COUNT(*) FROM #{qs}.#{qt}")
-              count
+              qi = &Adapter.quote_identifier(adapter, &1)
+              "SELECT COUNT(*) FROM #{qi.(resolved_schema)}.#{qi.(table_name)}"
             else
-              # Schema-less database
-              %{rows: [[count]]} = repo.query!("SELECT COUNT(*) FROM #{table_name}")
-              count
+              "SELECT COUNT(*) FROM #{table_name}"
             end
 
-          {:ok, %{row_count: count}}
+          case Adapter.execute_query(adapter, count_sql, [], []) do
+            {:ok, %{rows: [[count]]}} ->
+              {:ok, %{row_count: count}}
+
+            {:error, reason} ->
+              {:error, to_string(reason)}
+          end
         rescue
           e -> {:error, Exception.message(e)}
         end
@@ -435,10 +444,10 @@ defmodule Lotus.Schema do
   @spec list_relations(module() | String.t(), keyword()) ::
           {:ok, [{String.t() | nil, String.t()}]} | {:error, term()}
   def list_relations(repo_or_name, opts \\ []) do
-    {repo, repo_name} = Sources.resolve!(repo_or_name, nil)
+    adapter = Sources.resolve!(repo_or_name, nil)
     context = Keyword.get(opts, :context)
-    start_time = Telemetry.schema_introspection_start(:list_relations, repo_name)
-    schemas = effective_schemas(repo, opts)
+    start_time = Telemetry.schema_introspection_start(:list_relations, adapter.name)
+    schemas = effective_schemas(adapter, opts)
     include_views? = Keyword.get(opts, :include_views, false)
 
     search_path = Keyword.get(opts, :search_path)
@@ -446,12 +455,12 @@ defmodule Lotus.Schema do
     key =
       schema_key(
         :list_relations,
-        repo_name,
+        adapter.name,
         search_path || Enum.join(schemas, ","),
         include_views?
       )
 
-    tags = ["repo:#{repo_name}", "schema:list_relations"]
+    tags = ["repo:#{adapter.name}", "schema:list_relations"]
 
     profile =
       if is_list(opts[:cache]) do
@@ -463,18 +472,22 @@ defmodule Lotus.Schema do
     result =
       exec_with_cache(opts[:cache], profile, key, tags, fn ->
         try do
-          raw_relations = Source.list_tables(repo, schemas, include_views?)
+          case Adapter.list_tables(adapter, schemas, include_views: include_views?) do
+            {:ok, raw_relations} ->
+              filtered =
+                raw_relations
+                |> Enum.filter(&Visibility.allowed_relation?(adapter.name, &1))
 
-          filtered =
-            raw_relations
-            |> Enum.filter(&Visibility.allowed_relation?(repo_name, &1))
+              run_after_discover(:after_list_relations, :relations, %{
+                repo: adapter.name,
+                repo_name: adapter.name,
+                relations: filtered,
+                context: context
+              })
 
-          run_after_discover(:after_list_relations, :relations, %{
-            repo: repo,
-            repo_name: repo_name,
-            relations: filtered,
-            context: context
-          })
+            {:error, reason} ->
+              {:error, reason}
+          end
         rescue
           e -> {:error, Exception.message(e)}
         end
@@ -483,7 +496,7 @@ defmodule Lotus.Schema do
     Telemetry.schema_introspection_stop(
       start_time,
       :list_relations,
-      repo_name,
+      adapter.name,
       result_status(result)
     )
 
@@ -497,7 +510,7 @@ defmodule Lotus.Schema do
     end
   end
 
-  defp effective_schemas(repo, opts) do
+  defp effective_schemas(adapter, opts) do
     schemas =
       cond do
         is_binary(Keyword.get(opts, :schema)) ->
@@ -509,32 +522,28 @@ defmodule Lotus.Schema do
         is_binary(Keyword.get(opts, :search_path)) ->
           parse_search_path(Keyword.fetch!(opts, :search_path))
 
-        sp = get_in(repo.config(), [:parameters, :search_path]) ->
-          parse_search_path(sp)
-
         true ->
-          Source.default_schemas(repo)
+          Adapter.default_schemas(adapter)
       end
       |> Enum.map(&String.trim/1)
       |> Enum.reject(&(&1 == "" or &1 == "$user"))
 
-    if schemas == [], do: Source.default_schemas(repo), else: schemas
+    if schemas == [], do: Adapter.default_schemas(adapter), else: schemas
   end
 
   defp parse_search_path(sp) when is_binary(sp),
     do: sp |> String.split(",") |> Enum.map(&String.trim/1)
 
   defp resolve_table_schema_with_cache(
-         repo,
-         repo_name,
+         adapter,
          table,
          schemas,
          cache_opts,
          default_profile
        ) do
     search_key = Enum.join(schemas, ",")
-    key = schema_key(:resolve_table_schema, repo_name, search_key, table)
-    tags = ["repo:#{repo_name}", "schema:resolve_table_schema", "table:#{table}"]
+    key = schema_key(:resolve_table_schema, adapter.name, search_key, table)
+    tags = ["repo:#{adapter.name}", "schema:resolve_table_schema", "table:#{table}"]
 
     profile =
       if is_list(cache_opts),
@@ -543,9 +552,10 @@ defmodule Lotus.Schema do
 
     cache_result =
       exec_with_cache(cache_opts, profile, key, tags, fn ->
-        case Source.resolve_table_schema(repo, table, schemas) do
-          nil -> {:ok, :not_found}
-          schema -> {:ok, {:found, schema}}
+        case Adapter.resolve_table_schema(adapter, table, schemas) do
+          {:ok, nil} -> {:ok, :not_found}
+          {:ok, schema} -> {:ok, {:found, schema}}
+          {:error, _} -> {:ok, :not_found}
         end
       end)
 
@@ -733,14 +743,6 @@ defmodule Lotus.Schema do
       |> Base.encode16(case: :lower)
 
     "schema:list_schemas:#{repo_name}:#{digest}"
-  end
-
-  defp get_quote_chars(repo) do
-    case repo.__adapter__() do
-      Ecto.Adapters.MyXQL -> {"`", "`"}
-      Ecto.Adapters.Postgres -> {"\"", "\""}
-      _ -> {"\"", "\""}
-    end
   end
 
   defp result_status({:ok, _}), do: :ok

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -438,10 +438,13 @@ defmodule Lotus.Source do
   Applies filters to a query using the source-specific implementation.
 
   Returns `{sql, params}` unchanged when filters is empty.
+  Accepts an adapter struct, repo module, repo name string, or nil.
   """
-  @spec apply_filters(repo | String.t() | nil, String.t(), list(), [Lotus.Query.Filter.t()]) ::
-          {String.t(), list()}
-  def apply_filters(_repo_or_name, sql, params, []), do: {sql, params}
+  def apply_filters(_repo_or_adapter, sql, params, []), do: {sql, params}
+
+  def apply_filters(%Lotus.Source.Adapter{} = adapter, sql, params, filters) do
+    Lotus.Source.Adapter.apply_filters(adapter, sql, params, filters)
+  end
 
   def apply_filters(repo_or_name, sql, params, filters) do
     impl_for(resolve_repo!(repo_or_name)).apply_filters(sql, params, filters)
@@ -451,10 +454,13 @@ defmodule Lotus.Source do
   Applies sorts to a query using the source-specific implementation.
 
   Returns the original query unchanged when sorts is empty.
+  Accepts an adapter struct, repo module, repo name string, or nil.
   """
-  @spec apply_sorts(repo | String.t() | nil, String.t(), [Lotus.Query.Sort.t()]) ::
-          String.t()
-  def apply_sorts(_repo_or_name, sql, []), do: sql
+  def apply_sorts(_repo_or_adapter, sql, []), do: sql
+
+  def apply_sorts(%Lotus.Source.Adapter{} = adapter, sql, sorts) do
+    Lotus.Source.Adapter.apply_sorts(adapter, sql, sorts)
+  end
 
   def apply_sorts(repo_or_name, sql, sorts) do
     impl_for(resolve_repo!(repo_or_name)).apply_sorts(sql, sorts)

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -5,6 +5,8 @@ defmodule Lotus.Source do
   Defines the interface that each database source adapter's operations module must implement.
   """
 
+  alias Lotus.Source.Adapter
+
   @type repo :: Ecto.Repo.t()
 
   @callback execute_in_transaction(repo, (-> any()), keyword()) :: {:ok, any()} | {:error, any()}
@@ -442,8 +444,8 @@ defmodule Lotus.Source do
   """
   def apply_filters(_repo_or_adapter, sql, params, []), do: {sql, params}
 
-  def apply_filters(%Lotus.Source.Adapter{} = adapter, sql, params, filters) do
-    Lotus.Source.Adapter.apply_filters(adapter, sql, params, filters)
+  def apply_filters(%Adapter{} = adapter, sql, params, filters) do
+    Adapter.apply_filters(adapter, sql, params, filters)
   end
 
   def apply_filters(repo_or_name, sql, params, filters) do
@@ -458,8 +460,8 @@ defmodule Lotus.Source do
   """
   def apply_sorts(_repo_or_adapter, sql, []), do: sql
 
-  def apply_sorts(%Lotus.Source.Adapter{} = adapter, sql, sorts) do
-    Lotus.Source.Adapter.apply_sorts(adapter, sql, sorts)
+  def apply_sorts(%Adapter{} = adapter, sql, sorts) do
+    Adapter.apply_sorts(adapter, sql, sorts)
   end
 
   def apply_sorts(repo_or_name, sql, sorts) do

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -99,21 +99,27 @@ defmodule Lotus.Source.Adapter do
   # ---------------------------------------------------------------------------
 
   @doc "Quote a SQL identifier (column, table, schema name) using source-specific syntax."
-  @callback quote_identifier(String.t()) :: String.t()
+  @callback quote_identifier(state :: term(), String.t()) :: String.t()
 
   @doc "Return the parameter placeholder for a variable at the given 1-based index."
-  @callback param_placeholder(index :: pos_integer(), var :: String.t(), type :: atom() | nil) ::
+  @callback param_placeholder(
+              state :: term(),
+              index :: pos_integer(),
+              var :: String.t(),
+              type :: atom() | nil
+            ) ::
               String.t()
 
   @doc "Return `{limit_placeholder, offset_placeholder}` for LIMIT/OFFSET clauses."
-  @callback limit_offset_placeholders(pos_integer(), pos_integer()) :: {String.t(), String.t()}
+  @callback limit_offset_placeholders(state :: term(), pos_integer(), pos_integer()) ::
+              {String.t(), String.t()}
 
   @doc "Append WHERE clauses for the given filters, returning `{sql, params}`."
-  @callback apply_filters(sql :: String.t(), params :: list(), filters :: list()) ::
+  @callback apply_filters(state :: term(), sql :: String.t(), params :: list(), filters :: list()) ::
               {String.t(), list()}
 
   @doc "Append ORDER BY clauses for the given sorts."
-  @callback apply_sorts(sql :: String.t(), sorts :: list()) :: String.t()
+  @callback apply_sorts(state :: term(), sql :: String.t(), sorts :: list()) :: String.t()
 
   @doc "Return the execution plan for a SQL query."
   @callback explain_plan(state :: term(), sql :: String.t(), params :: list(), opts :: keyword()) ::
@@ -148,20 +154,20 @@ defmodule Lotus.Source.Adapter do
   # ---------------------------------------------------------------------------
 
   @doc "Format a database error into a human-readable string."
-  @callback format_error(any()) :: String.t()
+  @callback format_error(state :: term(), any()) :: String.t()
 
   @doc "Return the exception modules this adapter knows how to format."
-  @callback handled_errors() :: [module()]
+  @callback handled_errors(state :: term()) :: [module()]
 
   # ---------------------------------------------------------------------------
   # Callbacks — Source Identity
   # ---------------------------------------------------------------------------
 
   @doc "Return the source type atom (e.g. `:postgres`, `:mysql`)."
-  @callback source_type() :: source_type()
+  @callback source_type(state :: term()) :: source_type()
 
   @doc "Whether this adapter supports a given feature."
-  @callback supports_feature?(atom()) :: boolean()
+  @callback supports_feature?(state :: term(), atom()) :: boolean()
 
   # ---------------------------------------------------------------------------
   # Dispatch helpers — stateful (pass adapter.state as first arg)
@@ -245,60 +251,60 @@ defmodule Lotus.Source.Adapter do
   end
 
   # ---------------------------------------------------------------------------
-  # Dispatch helpers — stateless (no state argument needed)
+  # Dispatch helpers — SQL generation (pass adapter.state for correct dispatch)
   # ---------------------------------------------------------------------------
 
   @doc "Quote a SQL identifier via the adapter."
   @spec quote_identifier(t(), String.t()) :: String.t()
-  def quote_identifier(%__MODULE__{module: mod}, identifier) do
-    mod.quote_identifier(identifier)
+  def quote_identifier(%__MODULE__{module: mod, state: state}, identifier) do
+    mod.quote_identifier(state, identifier)
   end
 
   @doc "Return the parameter placeholder via the adapter."
   @spec param_placeholder(t(), pos_integer(), String.t(), atom() | nil) :: String.t()
-  def param_placeholder(%__MODULE__{module: mod}, index, var, type) do
-    mod.param_placeholder(index, var, type)
+  def param_placeholder(%__MODULE__{module: mod, state: state}, index, var, type) do
+    mod.param_placeholder(state, index, var, type)
   end
 
   @doc "Return LIMIT/OFFSET placeholders via the adapter."
   @spec limit_offset_placeholders(t(), pos_integer(), pos_integer()) :: {String.t(), String.t()}
-  def limit_offset_placeholders(%__MODULE__{module: mod}, limit_index, offset_index) do
-    mod.limit_offset_placeholders(limit_index, offset_index)
+  def limit_offset_placeholders(%__MODULE__{module: mod, state: state}, limit_index, offset_index) do
+    mod.limit_offset_placeholders(state, limit_index, offset_index)
   end
 
   @doc "Apply filters to a query via the adapter."
   @spec apply_filters(t(), String.t(), list(), list()) :: {String.t(), list()}
-  def apply_filters(%__MODULE__{module: mod}, sql, params, filters) do
-    mod.apply_filters(sql, params, filters)
+  def apply_filters(%__MODULE__{module: mod, state: state}, sql, params, filters) do
+    mod.apply_filters(state, sql, params, filters)
   end
 
   @doc "Apply sorts to a query via the adapter."
   @spec apply_sorts(t(), String.t(), list()) :: String.t()
-  def apply_sorts(%__MODULE__{module: mod}, sql, sorts) do
-    mod.apply_sorts(sql, sorts)
+  def apply_sorts(%__MODULE__{module: mod, state: state}, sql, sorts) do
+    mod.apply_sorts(state, sql, sorts)
   end
 
   @doc "Format an error via the adapter."
   @spec format_error(t(), any()) :: String.t()
-  def format_error(%__MODULE__{module: mod}, error) do
-    mod.format_error(error)
+  def format_error(%__MODULE__{module: mod, state: state}, error) do
+    mod.format_error(state, error)
   end
 
   @doc "Return handled error modules via the adapter."
   @spec handled_errors(t()) :: [module()]
-  def handled_errors(%__MODULE__{module: mod}) do
-    mod.handled_errors()
+  def handled_errors(%__MODULE__{module: mod, state: state}) do
+    mod.handled_errors(state)
   end
 
   @doc "Return the source type via the adapter."
   @spec source_type(t()) :: source_type()
-  def source_type(%__MODULE__{module: mod}) do
-    mod.source_type()
+  def source_type(%__MODULE__{module: mod, state: state}) do
+    mod.source_type(state)
   end
 
   @doc "Check feature support via the adapter."
   @spec supports_feature?(t(), atom()) :: boolean()
-  def supports_feature?(%__MODULE__{module: mod}, feature) do
-    mod.supports_feature?(feature)
+  def supports_feature?(%__MODULE__{module: mod, state: state}, feature) do
+    mod.supports_feature?(state, feature)
   end
 end

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -1,0 +1,304 @@
+defmodule Lotus.Source.Adapter do
+  @moduledoc """
+  Behaviour and struct for database adapters in Lotus.
+
+  An adapter wraps a data source behind a uniform interface. Instead of passing
+  raw Ecto.Repo modules throughout the pipeline, consumers work with an
+  `%Adapter{}` struct that carries:
+
+    * `name`        — a human-readable identifier (e.g. `"main"`, `"warehouse"`)
+    * `module`      — the module implementing this behaviour
+    * `state`       — opaque connection state managed by the adapter
+    * `source_type` — an atom identifying the database kind (`:postgres`, `:mysql`, etc.)
+
+  ## Implementing an adapter
+
+  Define a module that uses `@behaviour Lotus.Source.Adapter` and implements all
+  required callbacks. Callbacks fall into several groups:
+
+    * **Query execution** — `execute_query/4`, `transaction/3`
+    * **Introspection** — `list_schemas/1`, `list_tables/3`, `get_table_schema/3`,
+      `resolve_table_schema/3`
+    * **SQL generation** — `quote_identifier/1`, `param_placeholder/3`,
+      `limit_offset_placeholders/2`, `apply_filters/3`, `apply_sorts/2`,
+      `explain_plan/4`
+    * **Safety & visibility** — `builtin_denies/1`, `builtin_schema_denies/1`,
+      `default_schemas/1`
+    * **Lifecycle** — `health_check/1`, `disconnect/1`
+    * **Error handling** — `format_error/1`, `handled_errors/0`
+    * **Source identity** — `source_type/0`, `supports_feature?/1`
+
+  Introspection callbacks consistently return `{:ok, result} | {:error, reason}`
+  tuples so callers can handle failures uniformly.
+
+  ## Dispatch helpers
+
+  This module provides convenience functions that accept an `%Adapter{}` struct
+  and delegate to the underlying module, passing `state` where needed:
+
+      adapter = %Adapter{name: "main", module: MyPostgres, state: conn, source_type: :postgres}
+
+      Adapter.execute_query(adapter, "SELECT 1", [], [])
+      Adapter.list_schemas(adapter)
+      Adapter.quote_identifier(adapter, "users")
+  """
+
+  @type source_type :: :postgres | :mysql | :sqlite | :tds | :other | atom()
+
+  @type column_def :: %{
+          name: String.t(),
+          type: String.t(),
+          nullable: boolean(),
+          default: String.t() | nil,
+          primary_key: boolean()
+        }
+
+  @type t :: %__MODULE__{
+          name: String.t() | nil,
+          module: module() | nil,
+          state: term(),
+          source_type: source_type() | nil
+        }
+
+  defstruct [:name, :module, :state, :source_type]
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Query Execution
+  # ---------------------------------------------------------------------------
+
+  @doc "Execute a SQL query against the data source."
+  @callback execute_query(state :: term(), sql :: String.t(), params :: list(), opts :: keyword()) ::
+              {:ok, %{columns: [String.t()], rows: [[term()]], num_rows: non_neg_integer()}}
+              | {:error, term()}
+
+  @doc "Execute a function within a transaction."
+  @callback transaction(state :: term(), fun :: (term() -> any()), opts :: keyword()) ::
+              {:ok, any()} | {:error, any()}
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Introspection
+  # ---------------------------------------------------------------------------
+
+  @doc "List all schemas in the data source."
+  @callback list_schemas(state :: term()) :: {:ok, [String.t()]} | {:error, term()}
+
+  @doc "List tables (and optionally views) in the given schemas."
+  @callback list_tables(state :: term(), schemas :: [String.t()], opts :: keyword()) ::
+              {:ok, [{schema :: String.t() | nil, table :: String.t()}]} | {:error, term()}
+
+  @doc "Return column definitions for a specific table."
+  @callback get_table_schema(state :: term(), schema :: String.t() | nil, table :: String.t()) ::
+              {:ok, [column_def()]} | {:error, term()}
+
+  @doc "Resolve which schema contains the named table."
+  @callback resolve_table_schema(state :: term(), table :: String.t(), schemas :: [String.t()]) ::
+              {:ok, String.t() | nil} | {:error, term()}
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — SQL Generation
+  # ---------------------------------------------------------------------------
+
+  @doc "Quote a SQL identifier (column, table, schema name) using source-specific syntax."
+  @callback quote_identifier(String.t()) :: String.t()
+
+  @doc "Return the parameter placeholder for a variable at the given 1-based index."
+  @callback param_placeholder(index :: pos_integer(), var :: String.t(), type :: atom() | nil) ::
+              String.t()
+
+  @doc "Return `{limit_placeholder, offset_placeholder}` for LIMIT/OFFSET clauses."
+  @callback limit_offset_placeholders(pos_integer(), pos_integer()) :: {String.t(), String.t()}
+
+  @doc "Append WHERE clauses for the given filters, returning `{sql, params}`."
+  @callback apply_filters(sql :: String.t(), params :: list(), filters :: list()) ::
+              {String.t(), list()}
+
+  @doc "Append ORDER BY clauses for the given sorts."
+  @callback apply_sorts(sql :: String.t(), sorts :: list()) :: String.t()
+
+  @doc "Return the execution plan for a SQL query."
+  @callback explain_plan(state :: term(), sql :: String.t(), params :: list(), opts :: keyword()) ::
+              {:ok, String.t()} | {:error, term()}
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Safety & Visibility
+  # ---------------------------------------------------------------------------
+
+  @doc "Return built-in deny rules for system tables (list of `{schema_pattern, table_pattern}` tuples)."
+  @callback builtin_denies(state :: term()) ::
+              [{String.t() | nil | Regex.t(), String.t() | Regex.t()}]
+
+  @doc "Return schema patterns that should be hidden from schema listings."
+  @callback builtin_schema_denies(state :: term()) :: [String.t() | Regex.t()]
+
+  @doc "Return the default schemas when none are configured."
+  @callback default_schemas(state :: term()) :: [String.t()]
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Lifecycle
+  # ---------------------------------------------------------------------------
+
+  @doc "Check that the data source is reachable."
+  @callback health_check(state :: term()) :: :ok | {:error, term()}
+
+  @doc "Disconnect from the data source and release resources."
+  @callback disconnect(state :: term()) :: :ok
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Error Handling
+  # ---------------------------------------------------------------------------
+
+  @doc "Format a database error into a human-readable string."
+  @callback format_error(any()) :: String.t()
+
+  @doc "Return the exception modules this adapter knows how to format."
+  @callback handled_errors() :: [module()]
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Source Identity
+  # ---------------------------------------------------------------------------
+
+  @doc "Return the source type atom (e.g. `:postgres`, `:mysql`)."
+  @callback source_type() :: source_type()
+
+  @doc "Whether this adapter supports a given feature."
+  @callback supports_feature?(atom()) :: boolean()
+
+  # ---------------------------------------------------------------------------
+  # Dispatch helpers — stateful (pass adapter.state as first arg)
+  # ---------------------------------------------------------------------------
+
+  @doc "Execute a SQL query via the adapter."
+  @spec execute_query(t(), String.t(), list(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def execute_query(%__MODULE__{module: mod, state: state}, sql, params, opts) do
+    mod.execute_query(state, sql, params, opts)
+  end
+
+  @doc "Execute a function within a transaction via the adapter."
+  @spec transaction(t(), (term() -> any()), keyword()) :: {:ok, any()} | {:error, any()}
+  def transaction(%__MODULE__{module: mod, state: state}, fun, opts) do
+    mod.transaction(state, fun, opts)
+  end
+
+  @doc "List all schemas via the adapter."
+  @spec list_schemas(t()) :: {:ok, [String.t()]} | {:error, term()}
+  def list_schemas(%__MODULE__{module: mod, state: state}) do
+    mod.list_schemas(state)
+  end
+
+  @doc "List tables via the adapter."
+  @spec list_tables(t(), [String.t()], keyword()) ::
+          {:ok, [{String.t() | nil, String.t()}]} | {:error, term()}
+  def list_tables(%__MODULE__{module: mod, state: state}, schemas, opts) do
+    mod.list_tables(state, schemas, opts)
+  end
+
+  @doc "Get column definitions for a table via the adapter."
+  @spec get_table_schema(t(), String.t() | nil, String.t()) ::
+          {:ok, [column_def()]} | {:error, term()}
+  def get_table_schema(%__MODULE__{module: mod, state: state}, schema, table) do
+    mod.get_table_schema(state, schema, table)
+  end
+
+  @doc "Resolve which schema contains a table via the adapter."
+  @spec resolve_table_schema(t(), String.t(), [String.t()]) ::
+          {:ok, String.t() | nil} | {:error, term()}
+  def resolve_table_schema(%__MODULE__{module: mod, state: state}, table, schemas) do
+    mod.resolve_table_schema(state, table, schemas)
+  end
+
+  @doc "Get the execution plan for a query via the adapter."
+  @spec explain_plan(t(), String.t(), list(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def explain_plan(%__MODULE__{module: mod, state: state}, sql, params, opts) do
+    mod.explain_plan(state, sql, params, opts)
+  end
+
+  @doc "Return built-in deny rules via the adapter."
+  @spec builtin_denies(t()) :: [{String.t() | nil | Regex.t(), String.t() | Regex.t()}]
+  def builtin_denies(%__MODULE__{module: mod, state: state}) do
+    mod.builtin_denies(state)
+  end
+
+  @doc "Return built-in schema denies via the adapter."
+  @spec builtin_schema_denies(t()) :: [String.t() | Regex.t()]
+  def builtin_schema_denies(%__MODULE__{module: mod, state: state}) do
+    mod.builtin_schema_denies(state)
+  end
+
+  @doc "Return default schemas via the adapter."
+  @spec default_schemas(t()) :: [String.t()]
+  def default_schemas(%__MODULE__{module: mod, state: state}) do
+    mod.default_schemas(state)
+  end
+
+  @doc "Check data source health via the adapter."
+  @spec health_check(t()) :: :ok | {:error, term()}
+  def health_check(%__MODULE__{module: mod, state: state}) do
+    mod.health_check(state)
+  end
+
+  @doc "Disconnect from the data source via the adapter."
+  @spec disconnect(t()) :: :ok
+  def disconnect(%__MODULE__{module: mod, state: state}) do
+    mod.disconnect(state)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Dispatch helpers — stateless (no state argument needed)
+  # ---------------------------------------------------------------------------
+
+  @doc "Quote a SQL identifier via the adapter."
+  @spec quote_identifier(t(), String.t()) :: String.t()
+  def quote_identifier(%__MODULE__{module: mod}, identifier) do
+    mod.quote_identifier(identifier)
+  end
+
+  @doc "Return the parameter placeholder via the adapter."
+  @spec param_placeholder(t(), pos_integer(), String.t(), atom() | nil) :: String.t()
+  def param_placeholder(%__MODULE__{module: mod}, index, var, type) do
+    mod.param_placeholder(index, var, type)
+  end
+
+  @doc "Return LIMIT/OFFSET placeholders via the adapter."
+  @spec limit_offset_placeholders(t(), pos_integer(), pos_integer()) :: {String.t(), String.t()}
+  def limit_offset_placeholders(%__MODULE__{module: mod}, limit_index, offset_index) do
+    mod.limit_offset_placeholders(limit_index, offset_index)
+  end
+
+  @doc "Apply filters to a query via the adapter."
+  @spec apply_filters(t(), String.t(), list(), list()) :: {String.t(), list()}
+  def apply_filters(%__MODULE__{module: mod}, sql, params, filters) do
+    mod.apply_filters(sql, params, filters)
+  end
+
+  @doc "Apply sorts to a query via the adapter."
+  @spec apply_sorts(t(), String.t(), list()) :: String.t()
+  def apply_sorts(%__MODULE__{module: mod}, sql, sorts) do
+    mod.apply_sorts(sql, sorts)
+  end
+
+  @doc "Format an error via the adapter."
+  @spec format_error(t(), any()) :: String.t()
+  def format_error(%__MODULE__{module: mod}, error) do
+    mod.format_error(error)
+  end
+
+  @doc "Return handled error modules via the adapter."
+  @spec handled_errors(t()) :: [module()]
+  def handled_errors(%__MODULE__{module: mod}) do
+    mod.handled_errors()
+  end
+
+  @doc "Return the source type via the adapter."
+  @spec source_type(t()) :: source_type()
+  def source_type(%__MODULE__{module: mod}) do
+    mod.source_type()
+  end
+
+  @doc "Check feature support via the adapter."
+  @spec supports_feature?(t(), atom()) :: boolean()
+  def supports_feature?(%__MODULE__{module: mod}, feature) do
+    mod.supports_feature?(feature)
+  end
+end

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -43,7 +43,7 @@ defmodule Lotus.Source.Adapter do
       Adapter.quote_identifier(adapter, "users")
   """
 
-  @type source_type :: :postgres | :mysql | :sqlite | :tds | :other | atom()
+  @type source_type :: :postgres | :mysql | :sqlite | :other | atom()
 
   @type column_def :: %{
           name: String.t(),

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -72,7 +72,6 @@ defmodule Lotus.Source.Adapters.Ecto do
       Ecto.Adapters.Postgres -> :postgres
       Ecto.Adapters.SQLite3 -> :sqlite
       Ecto.Adapters.MyXQL -> :mysql
-      Ecto.Adapters.Tds -> :tds
       _ -> :other
     end
   end

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -1,0 +1,277 @@
+defmodule Lotus.Source.Adapters.Ecto do
+  @moduledoc """
+  Adapter wrapping any `Ecto.Repo` module in the `Lotus.Source.Adapter` behaviour.
+
+  Delegates database-specific operations to the existing source implementation
+  modules (`Lotus.Sources.Postgres`, `Lotus.Sources.MySQL`, `Lotus.Sources.SQLite3`,
+  `Lotus.Sources.Default`) based on the repo's underlying Ecto adapter.
+
+  ## Usage
+
+      adapter = Lotus.Source.Adapters.Ecto.wrap("main", MyApp.Repo)
+
+      Lotus.Source.Adapter.execute_query(adapter, "SELECT 1", [], [])
+      Lotus.Source.Adapter.list_schemas(adapter)
+
+  The `state` field of the resulting `%Adapter{}` struct holds the repo module
+  itself, since Ecto repos are statically supervised and don't require explicit
+  connection management.
+  """
+
+  @behaviour Lotus.Source.Adapter
+
+  alias Lotus.Source.Adapter
+
+  @impls %{
+    Ecto.Adapters.Postgres => Lotus.Sources.Postgres,
+    Ecto.Adapters.SQLite3 => Lotus.Sources.SQLite3,
+    Ecto.Adapters.MyXQL => Lotus.Sources.MySQL
+  }
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Wraps an `Ecto.Repo` module in an `%Adapter{}` struct.
+
+  The resulting adapter delegates all callbacks to the appropriate source
+  implementation based on the repo's underlying Ecto adapter.
+
+  ## Parameters
+
+    * `name` — a human-readable identifier (e.g. `"main"`, `"warehouse"`)
+    * `repo_module` — the Ecto.Repo module (e.g. `MyApp.Repo`)
+
+  ## Examples
+
+      iex> adapter = Lotus.Source.Adapters.Ecto.wrap("main", MyApp.Repo)
+      %Lotus.Source.Adapter{name: "main", module: Lotus.Source.Adapters.Ecto, ...}
+  """
+  @spec wrap(String.t(), module()) :: Adapter.t()
+  def wrap(name, repo_module) when is_binary(name) and is_atom(repo_module) do
+    %Adapter{
+      name: name,
+      module: __MODULE__,
+      state: repo_module,
+      source_type: detect_source_type(repo_module)
+    }
+  end
+
+  @doc """
+  Detects the source type from a repo module's underlying Ecto adapter.
+
+  ## Examples
+
+      iex> Lotus.Source.Adapters.Ecto.detect_source_type(MyApp.Repo)
+      :postgres
+  """
+  @spec detect_source_type(module()) :: Adapter.source_type()
+  def detect_source_type(repo_module) when is_atom(repo_module) do
+    case repo_module.__adapter__() do
+      Ecto.Adapters.Postgres -> :postgres
+      Ecto.Adapters.SQLite3 -> :sqlite
+      Ecto.Adapters.MyXQL -> :mysql
+      Ecto.Adapters.Tds -> :tds
+      _ -> :other
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Query Execution
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def execute_query(repo, sql, params, opts) do
+    timeout = Keyword.get(opts, :timeout, 15_000)
+    search_path = Keyword.get(opts, :search_path)
+    impl = impl_for(repo)
+
+    impl.execute_in_transaction(
+      repo,
+      fn ->
+        if search_path do
+          impl.set_search_path(repo, search_path)
+        end
+
+        case repo.query(sql, params, timeout: timeout) do
+          {:ok, %{columns: cols, rows: rows} = raw} ->
+            num_rows = Map.get(raw, :num_rows, length(rows || []))
+            %{columns: cols, rows: rows, num_rows: num_rows}
+
+          {:error, err} ->
+            repo.rollback(impl.format_error(err))
+        end
+      end,
+      opts
+    )
+    |> case do
+      {:ok, result} -> {:ok, result}
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  @impl true
+  def transaction(repo, fun, opts) do
+    impl_for(repo).execute_in_transaction(repo, fn -> fun.(repo) end, opts)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Introspection (wrap bare returns in {:ok, _} tuples)
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def list_schemas(repo) do
+    {:ok, impl_for(repo).list_schemas(repo)}
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  @impl true
+  def list_tables(repo, schemas, opts) do
+    include_views? = Keyword.get(opts, :include_views, false)
+    {:ok, impl_for(repo).list_tables(repo, schemas, include_views?)}
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  @impl true
+  def get_table_schema(repo, schema, table) do
+    {:ok, impl_for(repo).get_table_schema(repo, schema, table)}
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  @impl true
+  def resolve_table_schema(repo, table, schemas) do
+    {:ok, impl_for(repo).resolve_table_schema(repo, table, schemas)}
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — SQL Generation (delegate to source impl)
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  defdelegate quote_identifier(identifier), to: Lotus.Sources.Postgres
+
+  @impl true
+  def param_placeholder(index, var, type) do
+    # Delegate based on current module's source type; since this is stateless
+    # and we don't have the repo here, we delegate to Postgres as the default.
+    # The wrap/2 function ensures the correct source_type is set on the struct.
+    Lotus.Sources.Postgres.param_placeholder(index, var, type)
+  end
+
+  @impl true
+  def limit_offset_placeholders(limit_index, offset_index) do
+    Lotus.Sources.Postgres.limit_offset_placeholders(limit_index, offset_index)
+  end
+
+  @impl true
+  def apply_filters(sql, params, filters) do
+    Lotus.Sources.Postgres.apply_filters(sql, params, filters)
+  end
+
+  @impl true
+  def apply_sorts(sql, sorts) do
+    Lotus.Sources.Postgres.apply_sorts(sql, sorts)
+  end
+
+  @impl true
+  def explain_plan(repo, sql, params, opts) do
+    impl_for(repo).explain_plan(repo, sql, params, opts)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Safety & Visibility (delegate to source impl)
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def builtin_denies(repo) do
+    impl_for(repo).builtin_denies(repo)
+  end
+
+  @impl true
+  def builtin_schema_denies(repo) do
+    impl_for(repo).builtin_schema_denies(repo)
+  end
+
+  @impl true
+  def default_schemas(repo) do
+    impl_for(repo).default_schemas(repo)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Lifecycle
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def health_check(repo) do
+    case repo.query("SELECT 1", []) do
+      {:ok, _} -> :ok
+      {:error, err} -> {:error, err}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  @impl true
+  def disconnect(_repo) do
+    # Static repos are managed by the application supervisor.
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Error Handling
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def format_error(error) do
+    impl_for_error(error).format_error(error)
+  end
+
+  @impl true
+  def handled_errors do
+    @impls
+    |> Map.values()
+    |> Enum.flat_map(& &1.handled_errors())
+    |> Enum.uniq()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Callbacks — Source Identity
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def source_type, do: :postgres
+
+  @impl true
+  def supports_feature?(feature) do
+    Lotus.Sources.supports_feature?(:postgres, feature)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp impl_for(repo) do
+    source_mod = repo.__adapter__()
+    Map.get(@impls, source_mod, Lotus.Sources.Default)
+  end
+
+  defp impl_for_error(%{__exception__: true, __struct__: exc_mod}) do
+    Enum.find_value(
+      Map.values(@impls) ++ [Lotus.Sources.Default],
+      Lotus.Sources.Default,
+      fn impl ->
+        if exc_mod in impl.handled_errors(), do: impl, else: false
+      end
+    )
+  end
+
+  defp impl_for_error(_), do: Lotus.Sources.Default
+end

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -97,7 +97,14 @@ defmodule Lotus.Source.Adapters.Ecto do
         case repo.query(sql, params, timeout: timeout) do
           {:ok, %{columns: cols, rows: rows} = raw} ->
             num_rows = Map.get(raw, :num_rows, length(rows || []))
-            %{columns: cols, rows: rows, num_rows: num_rows}
+
+            result =
+              %{columns: cols, rows: rows, num_rows: num_rows}
+              |> maybe_put(:command, Map.get(raw, :command))
+              |> maybe_put(:connection_id, Map.get(raw, :connection_id))
+              |> maybe_put(:messages, Map.get(raw, :messages))
+
+            result
 
           {:error, err} ->
             repo.rollback(impl.format_error(err))
@@ -152,33 +159,32 @@ defmodule Lotus.Source.Adapters.Ecto do
   end
 
   # ---------------------------------------------------------------------------
-  # Callbacks — SQL Generation (delegate to source impl)
+  # Callbacks — SQL Generation (delegate to source impl via state)
   # ---------------------------------------------------------------------------
 
   @impl true
-  defdelegate quote_identifier(identifier), to: Lotus.Sources.Postgres
-
-  @impl true
-  def param_placeholder(index, var, type) do
-    # Delegate based on current module's source type; since this is stateless
-    # and we don't have the repo here, we delegate to Postgres as the default.
-    # The wrap/2 function ensures the correct source_type is set on the struct.
-    Lotus.Sources.Postgres.param_placeholder(index, var, type)
+  def quote_identifier(repo, identifier) do
+    impl_for(repo).quote_identifier(identifier)
   end
 
   @impl true
-  def limit_offset_placeholders(limit_index, offset_index) do
-    Lotus.Sources.Postgres.limit_offset_placeholders(limit_index, offset_index)
+  def param_placeholder(repo, index, var, type) do
+    impl_for(repo).param_placeholder(index, var, type)
   end
 
   @impl true
-  def apply_filters(sql, params, filters) do
-    Lotus.Sources.Postgres.apply_filters(sql, params, filters)
+  def limit_offset_placeholders(repo, limit_index, offset_index) do
+    impl_for(repo).limit_offset_placeholders(limit_index, offset_index)
   end
 
   @impl true
-  def apply_sorts(sql, sorts) do
-    Lotus.Sources.Postgres.apply_sorts(sql, sorts)
+  def apply_filters(repo, sql, params, filters) do
+    impl_for(repo).apply_filters(sql, params, filters)
+  end
+
+  @impl true
+  def apply_sorts(repo, sql, sorts) do
+    impl_for(repo).apply_sorts(sql, sorts)
   end
 
   @impl true
@@ -230,16 +236,13 @@ defmodule Lotus.Source.Adapters.Ecto do
   # ---------------------------------------------------------------------------
 
   @impl true
-  def format_error(error) do
+  def format_error(_repo, error) do
     impl_for_error(error).format_error(error)
   end
 
   @impl true
-  def handled_errors do
-    @impls
-    |> Map.values()
-    |> Enum.flat_map(& &1.handled_errors())
-    |> Enum.uniq()
+  def handled_errors(repo) do
+    impl_for(repo).handled_errors()
   end
 
   # ---------------------------------------------------------------------------
@@ -247,11 +250,12 @@ defmodule Lotus.Source.Adapters.Ecto do
   # ---------------------------------------------------------------------------
 
   @impl true
-  def source_type, do: :postgres
+  def source_type(repo), do: detect_source_type(repo)
 
   @impl true
-  def supports_feature?(feature) do
-    Lotus.Sources.supports_feature?(:postgres, feature)
+  def supports_feature?(repo, feature) do
+    source = detect_source_type(repo)
+    Lotus.Sources.supports_feature?(source, feature)
   end
 
   # ---------------------------------------------------------------------------
@@ -274,4 +278,7 @@ defmodule Lotus.Source.Adapters.Ecto do
   end
 
   defp impl_for_error(_), do: Lotus.Sources.Default
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/lotus/source/resolver.ex
+++ b/lib/lotus/source/resolver.ex
@@ -1,0 +1,22 @@
+defmodule Lotus.Source.Resolver do
+  @moduledoc """
+  Behaviour for resolving named data sources to adapters.
+
+  The default implementation reads from static `data_repos` configuration.
+  Alternative implementations can resolve sources from registries,
+  databases, or external services.
+  """
+
+  @callback resolve(
+              repo_opt :: nil | String.t() | module(),
+              fallback :: nil | String.t() | module()
+            ) :: {:ok, Lotus.Source.Adapter.t()} | {:error, term()}
+
+  @callback list_sources() :: [Lotus.Source.Adapter.t()]
+
+  @callback get_source!(name :: String.t()) :: Lotus.Source.Adapter.t() | no_return()
+
+  @callback list_source_names() :: [String.t()]
+
+  @callback default_source() :: {String.t(), Lotus.Source.Adapter.t()}
+end

--- a/lib/lotus/source/resolvers/static.ex
+++ b/lib/lotus/source/resolvers/static.ex
@@ -1,0 +1,94 @@
+defmodule Lotus.Source.Resolvers.Static do
+  @moduledoc """
+  Default source resolver that reads from static `data_repos` configuration.
+
+  Preserves the resolution priority logic from `Lotus.Sources.resolve!/2`:
+
+    1. `repo_opt` as string name — lookup in data_repos, wrap in adapter
+    2. `repo_opt` as module — reverse lookup (find name for module), wrap in adapter
+    3. `fallback` as string name — lookup
+    4. `fallback` as module — reverse lookup
+    5. Both nil — use `Config.default_data_repo()`
+    6. Not found — `{:error, :not_found}`
+  """
+
+  @behaviour Lotus.Source.Resolver
+
+  alias Lotus.Config
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
+
+  # ---------------------------------------------------------------------------
+  # Callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def resolve(repo_opt, fallback) do
+    cond do
+      is_binary(repo_opt) ->
+        lookup_by_name(repo_opt)
+
+      repo_module?(repo_opt) ->
+        lookup_by_module(repo_opt)
+
+      is_binary(fallback) ->
+        lookup_by_name(fallback)
+
+      repo_module?(fallback) ->
+        lookup_by_module(fallback)
+
+      true ->
+        {:ok, default_adapter()}
+    end
+  end
+
+  @impl true
+  def list_sources do
+    Config.data_repos()
+    |> Enum.map(fn {name, mod} -> EctoAdapter.wrap(name, mod) end)
+  end
+
+  @impl true
+  def get_source!(name) do
+    mod = Config.get_data_repo!(name)
+    EctoAdapter.wrap(name, mod)
+  end
+
+  @impl true
+  def list_source_names do
+    Config.list_data_repo_names()
+  end
+
+  @impl true
+  def default_source do
+    {name, mod} = Config.default_data_repo()
+    {name, EctoAdapter.wrap(name, mod)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp lookup_by_name(name) do
+    case Map.get(Config.data_repos(), name) do
+      nil -> {:error, :not_found}
+      mod -> {:ok, EctoAdapter.wrap(name, mod)}
+    end
+  end
+
+  defp lookup_by_module(mod) do
+    case Enum.find(Config.data_repos(), fn {_name, m} -> m == mod end) do
+      {name, _} -> {:ok, EctoAdapter.wrap(name, mod)}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  defp repo_module?(mod) when is_atom(mod) and not is_nil(mod),
+    do: function_exported?(mod, :__adapter__, 0)
+
+  defp repo_module?(_), do: false
+
+  defp default_adapter do
+    {name, mod} = Config.default_data_repo()
+    EctoAdapter.wrap(name, mod)
+  end
+end

--- a/lib/lotus/sources.ex
+++ b/lib/lotus/sources.ex
@@ -2,41 +2,55 @@ defmodule Lotus.Sources do
   @moduledoc false
 
   alias Lotus.Config
+  alias Lotus.Source.Adapter
 
   @doc """
-  Normalize to `{repo_module, repo_name_string}`.
+  Resolve to an `%Adapter{}` struct.
 
   Accepts:
     * `repo_opt` — configured name (string) or repo module (atom) or nil
     * `q_repo`   — query's stored repo (string or module) or nil
 
-  Falls back to Config.default_data_repo/0.
+  Falls back to the default source. Raises on resolution failure.
   """
-  @spec resolve!(nil | String.t() | module(), nil | String.t() | module()) ::
-          {module(), String.t()}
+  @spec resolve!(nil | String.t() | module(), nil | String.t() | module()) :: Adapter.t()
   def resolve!(repo_opt, q_repo) do
-    cond do
-      is_binary(repo_opt) ->
-        {Config.get_data_repo!(repo_opt), repo_opt}
+    case resolver().resolve(repo_opt, q_repo) do
+      {:ok, %Adapter{} = adapter} ->
+        adapter
 
-      repo_module?(repo_opt) ->
-        {repo_opt, name_from_module!(repo_opt)}
+      {:error, :not_found} ->
+        available = resolver().list_source_names()
+        label = repo_opt || q_repo
 
-      is_binary(q_repo) ->
-        {Config.get_data_repo!(q_repo), q_repo}
-
-      repo_module?(q_repo) ->
-        {q_repo, name_from_module!(q_repo)}
-
-      true ->
-        {name, mod} = Config.default_data_repo()
-        {mod, name}
+        raise ArgumentError,
+              "Data repo '#{label}' not configured. " <>
+                "Available repos: #{inspect(available)}"
     end
   end
 
   @doc """
-  Look up the configured *name* for a repo module, or raise if not configured.
+  Lists all configured source adapters.
   """
+  @spec list_sources() :: [Adapter.t()]
+  def list_sources, do: resolver().list_sources()
+
+  @doc """
+  Gets a source adapter by name. Raises if not found.
+  """
+  @spec get_source!(String.t()) :: Adapter.t()
+  def get_source!(name), do: resolver().get_source!(name)
+
+  @doc """
+  Returns the default source as an `%Adapter{}` struct.
+  """
+  @spec default_source() :: Adapter.t()
+  def default_source do
+    {_name, adapter} = resolver().default_source()
+    adapter
+  end
+
+  @doc false
   @spec name_from_module!(module()) :: String.t()
   def name_from_module!(mod) do
     case Enum.find(Config.data_repos(), fn {_name, m} -> m == mod end) do
@@ -45,20 +59,18 @@ defmodule Lotus.Sources do
 
       nil ->
         raise ArgumentError,
-              "Repo module #{inspect(mod)} isn’t in :lotus, :data_repos. " <>
+              "Repo module #{inspect(mod)} isn't in :lotus, :data_repos. " <>
                 "Configured names: #{inspect(Map.keys(Config.data_repos()))}"
     end
   end
 
-  defp repo_module?(mod) when is_atom(mod),
-    do: function_exported?(mod, :__adapter__, 0)
-
-  defp repo_module?(_), do: false
-
   @doc """
-  Detect the source type from a repository module or name.
+  Detect the source type from an adapter, repository module, or name.
   """
-  @spec source_type(module() | String.t()) :: :postgres | :mysql | :sqlite | :tds | :other
+  @spec source_type(Adapter.t() | module() | String.t()) ::
+          :postgres | :mysql | :sqlite | :tds | :other
+  def source_type(%Adapter{source_type: st}), do: st
+
   def source_type(repo_name) when is_binary(repo_name) do
     repo = Config.get_data_repo!(repo_name)
     source_type(repo)
@@ -99,4 +111,6 @@ defmodule Lotus.Sources do
   def supports_feature?(:tds, :json), do: false
 
   def supports_feature?(_, _), do: false
+
+  defp resolver, do: Config.source_resolver()
 end

--- a/lib/lotus/sources.ex
+++ b/lib/lotus/sources.ex
@@ -68,7 +68,7 @@ defmodule Lotus.Sources do
   Detect the source type from an adapter, repository module, or name.
   """
   @spec source_type(Adapter.t() | module() | String.t()) ::
-          :postgres | :mysql | :sqlite | :tds | :other
+          :postgres | :mysql | :sqlite | :other
   def source_type(%Adapter{source_type: st}), do: st
 
   def source_type(repo_name) when is_binary(repo_name) do
@@ -81,7 +81,6 @@ defmodule Lotus.Sources do
       Ecto.Adapters.Postgres -> :postgres
       Ecto.Adapters.SQLite3 -> :sqlite
       Ecto.Adapters.MyXQL -> :mysql
-      Ecto.Adapters.Tds -> :tds
       _ -> :other
     end
   end
@@ -104,11 +103,6 @@ defmodule Lotus.Sources do
   def supports_feature?(:sqlite, :make_interval), do: false
   def supports_feature?(:sqlite, :arrays), do: false
   def supports_feature?(:sqlite, :json), do: true
-
-  def supports_feature?(:tds, :search_path), do: false
-  def supports_feature?(:tds, :make_interval), do: false
-  def supports_feature?(:tds, :arrays), do: false
-  def supports_feature?(:tds, :json), do: false
 
   def supports_feature?(_, _), do: false
 

--- a/lib/lotus/visibility.ex
+++ b/lib/lotus/visibility.ex
@@ -191,7 +191,7 @@ defmodule Lotus.Visibility do
   """
 
   alias Lotus.Config
-  alias Lotus.Source
+  alias Lotus.Source.Adapter
   alias Lotus.Sources.Default
   alias Lotus.Visibility.Policy
 
@@ -204,7 +204,7 @@ defmodule Lotus.Visibility do
   """
   @spec allowed_schema?(String.t(), String.t() | nil) :: boolean()
   def allowed_schema?(repo_name, schema) do
-    rules = Config.schema_rules_for_repo_name(repo_name)
+    rules = visibility_resolver().schema_rules_for(repo_name)
     builtin = builtin_schema_denies(repo_name)
 
     builtin_denied = schema_deny_hit?(builtin, schema)
@@ -226,7 +226,7 @@ defmodule Lotus.Visibility do
   @spec allowed_relation?(String.t(), {String.t() | nil, String.t()}) :: boolean()
   def allowed_relation?(repo_name, {schema, table}) do
     if allowed_schema?(repo_name, schema) do
-      table_rules = Config.rules_for_repo_name(repo_name)
+      table_rules = visibility_resolver().table_rules_for(repo_name)
       builtin = builtin_table_denies(repo_name)
 
       builtin_denied = deny_hit?(builtin, schema, table)
@@ -276,12 +276,9 @@ defmodule Lotus.Visibility do
   end
 
   defp builtin_schema_denies(repo_name) do
-    repo = Config.data_repos() |> Map.get(repo_name)
-
-    if is_nil(repo) do
-      Default.builtin_schema_denies(nil)
-    else
-      Source.builtin_schema_denies(repo)
+    case resolve_adapter(repo_name) do
+      nil -> Default.builtin_schema_denies(nil)
+      adapter -> Adapter.builtin_schema_denies(adapter)
     end
   end
 
@@ -315,12 +312,16 @@ defmodule Lotus.Visibility do
   # Table-level helpers (existing code)
 
   defp builtin_table_denies(repo_name) do
-    repo = Config.data_repos() |> Map.get(repo_name)
+    case resolve_adapter(repo_name) do
+      nil -> Default.builtin_denies(nil)
+      adapter -> Adapter.builtin_denies(adapter)
+    end
+  end
 
-    if is_nil(repo) do
-      Default.builtin_denies(nil)
-    else
-      Source.builtin_denies(repo)
+  defp resolve_adapter(repo_name) do
+    case Config.source_resolver().resolve(repo_name, nil) do
+      {:ok, %Adapter{} = adapter} -> adapter
+      _ -> nil
     end
   end
 
@@ -385,7 +386,7 @@ defmodule Lotus.Visibility do
   @spec column_policy_for(String.t(), [{String.t() | nil, String.t()}], String.t()) ::
           nil | %{action: atom(), mask: any(), show_in_schema?: boolean()}
   def column_policy_for(repo_name, relations, result_column_name) do
-    rules = Config.column_rules_for_repo_name(repo_name)
+    rules = visibility_resolver().column_rules_for(repo_name)
     rels = relations || []
 
     find_schema_table_column_match(rules, rels, result_column_name) ||
@@ -455,4 +456,6 @@ defmodule Lotus.Visibility do
   defp cv_match?(_, _), do: false
 
   defp normalize_policy(policy), do: Policy.normalize_column_policy(policy)
+
+  defp visibility_resolver, do: Config.visibility_resolver()
 end

--- a/lib/lotus/visibility/resolver.ex
+++ b/lib/lotus/visibility/resolver.ex
@@ -1,0 +1,12 @@
+defmodule Lotus.Visibility.Resolver do
+  @moduledoc """
+  Behaviour for resolving visibility rules for a given data source.
+
+  The default implementation reads from static application configuration.
+  Alternative implementations can load rules from registries or databases.
+  """
+
+  @callback schema_rules_for(source_name :: String.t()) :: keyword()
+  @callback table_rules_for(source_name :: String.t()) :: keyword()
+  @callback column_rules_for(source_name :: String.t()) :: list()
+end

--- a/lib/lotus/visibility/resolvers/static.ex
+++ b/lib/lotus/visibility/resolvers/static.ex
@@ -1,0 +1,56 @@
+defmodule Lotus.Visibility.Resolvers.Static do
+  @moduledoc """
+  Default visibility resolver that reads from static application configuration.
+
+  This resolver wraps the existing static config lookups behind the Visibility
+  Resolver behaviour. It provides backward-compatible access to visibility rules
+  configured via `Lotus.Config`.
+
+  ## Configuration
+
+  To use this resolver (the default), configure visibility rules in your application:
+
+      config :lotus,
+        schema_visibility: %{
+          postgres: [
+            allow: ["public", ~r/^tenant_/],
+            deny: ["legacy"]
+          ]
+        },
+        table_visibility: %{
+          default: [
+            deny: ["user_passwords", "api_keys"]
+          ],
+          postgres: [
+            allow: [
+              {"public", ~r/^dim_/},
+              {"analytics", ~r/.*/}
+            ]
+          ]
+        },
+        column_visibility: %{
+          default: [],
+          postgres: []
+        }
+
+  When no source-specific rules are configured, the resolver falls back to
+  `:default` rules, providing a sensible baseline for all sources.
+  """
+
+  @behaviour Lotus.Visibility.Resolver
+
+  @impl true
+  def schema_rules_for(source_name) do
+    Lotus.Config.schema_rules_for_repo_name(source_name)
+  end
+
+  @impl true
+  def table_rules_for(source_name) do
+    Lotus.Config.rules_for_repo_name(source_name)
+  end
+
+  @impl true
+  def column_rules_for(source_name) do
+    Lotus.Config.column_rules_for_repo_name(source_name)
+  end
+end

--- a/test/lotus/column_visibility_test.exs
+++ b/test/lotus/column_visibility_test.exs
@@ -7,7 +7,8 @@ defmodule Lotus.ColumnVisibilityTest do
 
   setup do
     Mimic.copy(Lotus.Config)
-    Mimic.copy(Lotus.Source)
+    Mimic.copy(Lotus.Source.Adapter)
+    Mimic.copy(Lotus.Sources)
     :ok
   end
 
@@ -103,17 +104,31 @@ defmodule Lotus.ColumnVisibilityTest do
     end
 
     test "get_table_schema annotates visibility and preserves visible columns" do
-      Lotus.Source
-      |> stub(:resolve_table_schema, fn _repo, _table, _schemas -> "public" end)
+      mock_adapter = %Lotus.Source.Adapter{
+        name: "postgres",
+        module: Lotus.Source.Adapters.Ecto,
+        state: Lotus.Test.Repo,
+        source_type: :postgres
+      }
 
-      Lotus.Source
-      |> stub(:get_table_schema, fn _repo, _schema, _table ->
-        [
-          %{name: "id", type: "integer", nullable: false, default: nil, primary_key: true},
-          %{name: "password", type: "text", nullable: true, default: nil, primary_key: false},
-          %{name: "secret", type: "text", nullable: true, default: nil, primary_key: false}
-        ]
+      Lotus.Sources
+      |> stub(:resolve!, fn _repo_opt, _fallback -> mock_adapter end)
+
+      Lotus.Source.Adapter
+      |> stub(:resolve_table_schema, fn _adapter, _table, _schemas -> {:ok, "public"} end)
+
+      Lotus.Source.Adapter
+      |> stub(:get_table_schema, fn _adapter, _schema, _table ->
+        {:ok,
+         [
+           %{name: "id", type: "integer", nullable: false, default: nil, primary_key: true},
+           %{name: "password", type: "text", nullable: true, default: nil, primary_key: false},
+           %{name: "secret", type: "text", nullable: true, default: nil, primary_key: false}
+         ]}
       end)
+
+      Lotus.Source.Adapter
+      |> stub(:default_schemas, fn _adapter -> ["public"] end)
 
       {:ok, cols} = Schema.get_table_schema("postgres", "users", schema: "public")
 

--- a/test/lotus/middleware_test.exs
+++ b/test/lotus/middleware_test.exs
@@ -2,8 +2,11 @@ defmodule Lotus.MiddlewareTest do
   use Lotus.Case, async: false
 
   alias Lotus.{Middleware, Result, Runner}
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
 
   import Lotus.Fixtures
+
+  @pg_adapter EctoAdapter.wrap("postgres", Lotus.Test.Repo)
 
   # --- Middleware modules for testing ---
 
@@ -152,7 +155,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{PassthroughPlug, []}]
       })
 
-      assert {:ok, %Result{}} = Runner.run_sql(Lotus.Test.Repo, "SELECT 1")
+      assert {:ok, %Result{}} = Runner.run_sql(@pg_adapter, "SELECT 1")
     end
 
     test "halting middleware prevents query execution" do
@@ -160,7 +163,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{HaltPlug, [reason: "not allowed"]}]
       })
 
-      assert {:error, "not allowed"} = Runner.run_sql(Lotus.Test.Repo, "SELECT 1")
+      assert {:error, "not allowed"} = Runner.run_sql(@pg_adapter, "SELECT 1")
     end
 
     test "context is passed to before_query middleware" do
@@ -168,7 +171,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{ContextCapturePlug, []}]
       })
 
-      Runner.run_sql(Lotus.Test.Repo, "SELECT 1", [], context: %{user: "alice@example.com"})
+      Runner.run_sql(@pg_adapter, "SELECT 1", [], context: %{user: "alice@example.com"})
 
       assert_received {:middleware_context, %{user: "alice@example.com"}}
     end
@@ -178,7 +181,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{ContextCapturePlug, []}]
       })
 
-      Runner.run_sql(Lotus.Test.Repo, "SELECT 1")
+      Runner.run_sql(@pg_adapter, "SELECT 1")
 
       assert_received {:middleware_context, nil}
     end
@@ -190,7 +193,7 @@ defmodule Lotus.MiddlewareTest do
         after_query: [{PassthroughPlug, []}]
       })
 
-      assert {:ok, %Result{rows: [[1]]}} = Runner.run_sql(Lotus.Test.Repo, "SELECT 1")
+      assert {:ok, %Result{rows: [[1]]}} = Runner.run_sql(@pg_adapter, "SELECT 1")
     end
 
     test "halting middleware in after_query returns error" do
@@ -198,7 +201,7 @@ defmodule Lotus.MiddlewareTest do
         after_query: [{HaltPlug, [reason: "post-query denied"]}]
       })
 
-      assert {:error, "post-query denied"} = Runner.run_sql(Lotus.Test.Repo, "SELECT 1")
+      assert {:error, "post-query denied"} = Runner.run_sql(@pg_adapter, "SELECT 1")
     end
 
     test "context flows to after_query middleware" do
@@ -206,7 +209,7 @@ defmodule Lotus.MiddlewareTest do
         after_query: [{ContextCapturePlug, []}]
       })
 
-      Runner.run_sql(Lotus.Test.Repo, "SELECT 1", [], context: %{role: :admin})
+      Runner.run_sql(@pg_adapter, "SELECT 1", [], context: %{role: :admin})
 
       assert_received {:middleware_context, %{role: :admin}}
     end
@@ -320,12 +323,12 @@ defmodule Lotus.MiddlewareTest do
   describe "backward compatibility" do
     test "no middleware configured has zero overhead" do
       # No compile call - persistent_term is empty
-      assert {:ok, %Result{}} = Runner.run_sql(Lotus.Test.Repo, "SELECT 1")
+      assert {:ok, %Result{}} = Runner.run_sql(@pg_adapter, "SELECT 1")
     end
 
     test "empty middleware map works" do
       Middleware.compile(%{})
-      assert {:ok, %Result{}} = Runner.run_sql(Lotus.Test.Repo, "SELECT 1")
+      assert {:ok, %Result{}} = Runner.run_sql(@pg_adapter, "SELECT 1")
     end
 
     test "existing callers without context work unchanged" do

--- a/test/lotus/preflight_mysql_test.exs
+++ b/test/lotus/preflight_mysql_test.exs
@@ -2,17 +2,18 @@ defmodule Lotus.PreflightMysqlTest do
   use Lotus.Case
   use Mimic
   alias Lotus.Preflight
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
 
   @moduletag :mysql
 
-  @mysql_repo Lotus.Test.MysqlRepo
+  @mysql_adapter EctoAdapter.wrap("mysql", Lotus.Test.MysqlRepo)
 
   describe "MySQL preflight authorization" do
     test "allows queries against regular tables" do
-      assert :ok = Preflight.authorize(@mysql_repo, "mysql", "SELECT 1", [])
+      assert :ok = Preflight.authorize(@mysql_adapter, "SELECT 1", [])
 
       assert :ok =
-               Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM test_users LIMIT 1", [])
+               Preflight.authorize(@mysql_adapter, "SELECT * FROM test_users LIMIT 1", [])
     end
 
     test "allows complex queries with JOINs" do
@@ -25,20 +26,19 @@ defmodule Lotus.PreflightMysqlTest do
         LIMIT 10
       """
 
-      assert :ok = Preflight.authorize(@mysql_repo, "mysql", sql, [])
+      assert :ok = Preflight.authorize(@mysql_adapter, sql, [])
     end
 
     test "allows simple queries" do
       assert :ok =
                Preflight.authorize(
-                 @mysql_repo,
-                 "mysql",
+                 @mysql_adapter,
                  "SELECT * FROM test_posts WHERE user_id IS NOT NULL",
                  []
                )
 
       assert :ok =
-               Preflight.authorize(@mysql_repo, "mysql", "SELECT COUNT(*) FROM test_users", [])
+               Preflight.authorize(@mysql_adapter, "SELECT COUNT(*) FROM test_users", [])
     end
 
     test "allows subqueries and CTEs" do
@@ -48,7 +48,7 @@ defmodule Lotus.PreflightMysqlTest do
         WHERE user_id IN (SELECT id FROM test_users WHERE active = 1)
       """
 
-      assert :ok = Preflight.authorize(@mysql_repo, "mysql", sql, [])
+      assert :ok = Preflight.authorize(@mysql_adapter, sql, [])
 
       # CTE
       sql = """
@@ -61,36 +61,34 @@ defmodule Lotus.PreflightMysqlTest do
         SELECT * FROM user_stats WHERE post_count > 0
       """
 
-      assert :ok = Preflight.authorize(@mysql_repo, "mysql", sql, [])
+      assert :ok = Preflight.authorize(@mysql_adapter, sql, [])
     end
 
     test "handles parameterized queries" do
       assert :ok =
                Preflight.authorize(
-                 @mysql_repo,
-                 "mysql",
+                 @mysql_adapter,
                  "SELECT * FROM test_users WHERE id = ?",
                  [1]
                )
 
       assert :ok =
                Preflight.authorize(
-                 @mysql_repo,
-                 "mysql",
+                 @mysql_adapter,
                  "SELECT * FROM test_posts WHERE user_id = ?",
                  [1]
                )
     end
 
     test "handles syntax errors gracefully" do
-      {:error, _msg} = Preflight.authorize(@mysql_repo, "mysql", "INVALID SQL SYNTAX", [])
+      {:error, _msg} = Preflight.authorize(@mysql_adapter, "INVALID SQL SYNTAX", [])
     end
   end
 
   describe "MySQL builtin deny tests" do
     test "blocks queries against information_schema" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM information_schema.tables", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM information_schema.tables", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "information_schema"
@@ -98,7 +96,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "blocks queries against information_schema columns" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM information_schema.columns", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM information_schema.columns", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "information_schema"
@@ -106,7 +104,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "blocks queries against mysql schema" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM mysql.user", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM mysql.user", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "mysql"
@@ -114,7 +112,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "blocks queries against mysql db table" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM mysql.db", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM mysql.db", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "mysql"
@@ -123,8 +121,7 @@ defmodule Lotus.PreflightMysqlTest do
     test "blocks queries against performance_schema" do
       {:error, msg} =
         Preflight.authorize(
-          @mysql_repo,
-          "mysql",
+          @mysql_adapter,
           "SELECT * FROM performance_schema.events_waits_current",
           []
         )
@@ -135,7 +132,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "blocks queries against performance_schema tables" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM performance_schema.threads", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM performance_schema.threads", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "performance_schema"
@@ -143,7 +140,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "blocks queries against sys schema" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM sys.version", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM sys.version", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "sys"
@@ -151,7 +148,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "blocks queries against sys schema tables" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM sys.host_summary", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM sys.host_summary", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "sys"
@@ -160,8 +157,7 @@ defmodule Lotus.PreflightMysqlTest do
     test "blocks queries against schema_migrations" do
       {:error, msg} =
         Preflight.authorize(
-          @mysql_repo,
-          "mysql",
+          @mysql_adapter,
           "SELECT * FROM lotus_mysql_schema_migrations",
           []
         )
@@ -172,7 +168,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "blocks queries against lotus_queries" do
       {:error, msg} =
-        Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM lotus_queries", [])
+        Preflight.authorize(@mysql_adapter, "SELECT * FROM lotus_queries", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "lotus_queries"
@@ -185,7 +181,7 @@ defmodule Lotus.PreflightMysqlTest do
         JOIN lotus_mysql_schema_migrations sm ON 1=1
       """
 
-      {:error, msg} = Preflight.authorize(@mysql_repo, "mysql", sql, [])
+      {:error, msg} = Preflight.authorize(@mysql_adapter, sql, [])
       assert msg =~ "blocked table"
       assert msg =~ "schema_migrations"
     end
@@ -200,11 +196,11 @@ defmodule Lotus.PreflightMysqlTest do
     end
 
     test "blocks queries against tables matching bare string deny rules" do
-      {:error, msg} = Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM test_users", [])
+      {:error, msg} = Preflight.authorize(@mysql_adapter, "SELECT * FROM test_users", [])
       assert msg =~ "blocked table"
       assert msg =~ "test_users"
 
-      {:error, msg} = Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM test_posts", [])
+      {:error, msg} = Preflight.authorize(@mysql_adapter, "SELECT * FROM test_posts", [])
       assert msg =~ "blocked table"
       assert msg =~ "test_posts"
     end
@@ -216,7 +212,7 @@ defmodule Lotus.PreflightMysqlTest do
         JOIN test_posts tp ON tu.id = tp.user_id
       """
 
-      {:error, msg} = Preflight.authorize(@mysql_repo, "mysql", sql, [])
+      {:error, msg} = Preflight.authorize(@mysql_adapter, sql, [])
       assert msg =~ "blocked table"
       assert msg =~ "test_users"
       assert msg =~ "test_posts"
@@ -224,7 +220,7 @@ defmodule Lotus.PreflightMysqlTest do
 
     test "allows queries against tables not in deny list" do
       # products table is not in the deny list
-      assert :ok = Preflight.authorize(@mysql_repo, "mysql", "SELECT * FROM products LIMIT 1", [])
+      assert :ok = Preflight.authorize(@mysql_adapter, "SELECT * FROM products LIMIT 1", [])
     end
   end
 end

--- a/test/lotus/preflight_postgres_test.exs
+++ b/test/lotus/preflight_postgres_test.exs
@@ -2,15 +2,16 @@ defmodule Lotus.PreflightPostgresTest do
   use Lotus.Case
   use Mimic
   alias Lotus.Preflight
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
 
-  @pg_repo Lotus.Test.Repo
+  @pg_adapter EctoAdapter.wrap("postgres", Lotus.Test.Repo)
 
   describe "PostgreSQL preflight authorization" do
     test "allows queries against regular tables" do
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", "SELECT 1", [])
+      assert :ok = Preflight.authorize(@pg_adapter, "SELECT 1", [])
 
       assert :ok =
-               Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM test_users LIMIT 1", [])
+               Preflight.authorize(@pg_adapter, "SELECT * FROM test_users LIMIT 1", [])
     end
 
     test "allows complex queries with JOINs" do
@@ -22,20 +23,19 @@ defmodule Lotus.PreflightPostgresTest do
         LIMIT 10
       """
 
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", sql, [])
+      assert :ok = Preflight.authorize(@pg_adapter, sql, [])
     end
 
     test "allows simple queries" do
       assert :ok =
                Preflight.authorize(
-                 @pg_repo,
-                 "postgres",
+                 @pg_adapter,
                  "SELECT * FROM test_posts WHERE published = true",
                  []
                )
 
       assert :ok =
-               Preflight.authorize(@pg_repo, "postgres", "SELECT COUNT(*) FROM test_users", [])
+               Preflight.authorize(@pg_adapter, "SELECT COUNT(*) FROM test_users", [])
     end
 
     test "allows subqueries and CTEs" do
@@ -45,7 +45,7 @@ defmodule Lotus.PreflightPostgresTest do
         WHERE id IN (SELECT user_id FROM test_posts WHERE published = true)
       """
 
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", sql, [])
+      assert :ok = Preflight.authorize(@pg_adapter, sql, [])
 
       # CTE
       sql = """
@@ -58,36 +58,34 @@ defmodule Lotus.PreflightPostgresTest do
         SELECT * FROM user_stats WHERE post_count > 0
       """
 
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", sql, [])
+      assert :ok = Preflight.authorize(@pg_adapter, sql, [])
     end
 
     test "handles parameterized queries" do
       assert :ok =
                Preflight.authorize(
-                 @pg_repo,
-                 "postgres",
+                 @pg_adapter,
                  "SELECT * FROM test_users WHERE id = $1",
                  [1]
                )
 
       assert :ok =
                Preflight.authorize(
-                 @pg_repo,
-                 "postgres",
+                 @pg_adapter,
                  "SELECT * FROM test_posts WHERE view_count > $1",
                  [10]
                )
     end
 
     test "handles syntax errors gracefully" do
-      {:error, _msg} = Preflight.authorize(@pg_repo, "postgres", "INVALID SQL SYNTAX", [])
+      {:error, _msg} = Preflight.authorize(@pg_adapter, "INVALID SQL SYNTAX", [])
     end
   end
 
   describe "PostgreSQL builtin deny tests" do
     test "blocks queries against pg_catalog schema" do
       {:error, msg} =
-        Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM pg_catalog.pg_tables", [])
+        Preflight.authorize(@pg_adapter, "SELECT * FROM pg_catalog.pg_tables", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "pg_catalog"
@@ -95,7 +93,7 @@ defmodule Lotus.PreflightPostgresTest do
 
     test "blocks queries against information_schema" do
       {:error, msg} =
-        Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM information_schema.tables", [])
+        Preflight.authorize(@pg_adapter, "SELECT * FROM information_schema.tables", [])
 
       assert msg =~ "blocked table"
       # information_schema queries actually touch pg_catalog tables internally
@@ -104,7 +102,7 @@ defmodule Lotus.PreflightPostgresTest do
 
     test "blocks queries against schema_migrations in public schema" do
       {:error, msg} =
-        Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM public.schema_migrations", [])
+        Preflight.authorize(@pg_adapter, "SELECT * FROM public.schema_migrations", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "schema_migrations"
@@ -112,7 +110,7 @@ defmodule Lotus.PreflightPostgresTest do
 
     test "blocks queries against schema_migrations without schema" do
       {:error, msg} =
-        Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM schema_migrations", [])
+        Preflight.authorize(@pg_adapter, "SELECT * FROM schema_migrations", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "schema_migrations"
@@ -120,14 +118,14 @@ defmodule Lotus.PreflightPostgresTest do
 
     test "blocks queries against lotus_queries in public schema" do
       {:error, msg} =
-        Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM public.lotus_queries", [])
+        Preflight.authorize(@pg_adapter, "SELECT * FROM public.lotus_queries", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "lotus_queries"
     end
 
     test "blocks queries against lotus_queries without schema" do
-      {:error, msg} = Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM lotus_queries", [])
+      {:error, msg} = Preflight.authorize(@pg_adapter, "SELECT * FROM lotus_queries", [])
       assert msg =~ "blocked table"
       assert msg =~ "lotus_queries"
     end
@@ -139,7 +137,7 @@ defmodule Lotus.PreflightPostgresTest do
         JOIN lotus_queries lq ON true
       """
 
-      {:error, msg} = Preflight.authorize(@pg_repo, "postgres", sql, [])
+      {:error, msg} = Preflight.authorize(@pg_adapter, sql, [])
       assert msg =~ "blocked table"
       assert msg =~ "lotus_queries"
     end
@@ -162,14 +160,14 @@ defmodule Lotus.PreflightPostgresTest do
     end
 
     test "blocks queries against tables matching bare string deny rules in public schema" do
-      {:error, msg} = Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM test_posts", [])
+      {:error, msg} = Preflight.authorize(@pg_adapter, "SELECT * FROM test_posts", [])
       assert msg =~ "blocked table"
       assert msg =~ "test_posts"
     end
 
     test "blocks queries against tables matching bare string deny rules with explicit schema" do
       {:error, msg} =
-        Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM public.test_posts", [])
+        Preflight.authorize(@pg_adapter, "SELECT * FROM public.test_posts", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "test_posts"
@@ -182,14 +180,14 @@ defmodule Lotus.PreflightPostgresTest do
         JOIN test_posts p ON u.id = p.user_id
       """
 
-      {:error, msg} = Preflight.authorize(@pg_repo, "postgres", sql, [])
+      {:error, msg} = Preflight.authorize(@pg_adapter, sql, [])
       assert msg =~ "blocked table"
       assert msg =~ "test_posts"
     end
 
     test "allows queries against tables not in deny list" do
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM test_users", [])
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", "SELECT 1", [])
+      assert :ok = Preflight.authorize(@pg_adapter, "SELECT * FROM test_users", [])
+      assert :ok = Preflight.authorize(@pg_adapter, "SELECT 1", [])
     end
   end
 
@@ -209,16 +207,16 @@ defmodule Lotus.PreflightPostgresTest do
     end
 
     test "allows queries against tables matching bare string allow rules" do
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM test_users", [])
+      assert :ok = Preflight.authorize(@pg_adapter, "SELECT * FROM test_users", [])
     end
 
     test "allows queries with explicit schema for allowed tables" do
       assert :ok =
-               Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM public.test_users", [])
+               Preflight.authorize(@pg_adapter, "SELECT * FROM public.test_users", [])
     end
 
     test "blocks queries against tables not in allow list" do
-      {:error, msg} = Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM test_posts", [])
+      {:error, msg} = Preflight.authorize(@pg_adapter, "SELECT * FROM test_posts", [])
       assert msg =~ "blocked table"
       assert msg =~ "test_posts"
     end
@@ -242,14 +240,14 @@ defmodule Lotus.PreflightPostgresTest do
 
     test "tuple with schema only blocks in that specific schema" do
       {:error, msg} =
-        Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM public.test_posts", [])
+        Preflight.authorize(@pg_adapter, "SELECT * FROM public.test_posts", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "test_posts"
     end
 
     test "allows tables not matching any deny rules" do
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", "SELECT * FROM test_users", [])
+      assert :ok = Preflight.authorize(@pg_adapter, "SELECT * FROM test_users", [])
     end
   end
 end

--- a/test/lotus/preflight_sqlite_test.exs
+++ b/test/lotus/preflight_sqlite_test.exs
@@ -2,17 +2,18 @@ defmodule Lotus.PreflightSqliteTest do
   use Lotus.Case
   use Mimic
   alias Lotus.Preflight
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
 
   @moduletag :sqlite
 
-  @sqlite_repo Lotus.Test.SqliteRepo
+  @sqlite_adapter EctoAdapter.wrap("sqlite", Lotus.Test.SqliteRepo)
 
   describe "SQLite preflight authorization" do
     test "allows queries against regular tables" do
-      assert :ok = Preflight.authorize(@sqlite_repo, "sqlite", "SELECT 1", [])
+      assert :ok = Preflight.authorize(@sqlite_adapter, "SELECT 1", [])
 
       assert :ok =
-               Preflight.authorize(@sqlite_repo, "sqlite", "SELECT * FROM products LIMIT 1", [])
+               Preflight.authorize(@sqlite_adapter, "SELECT * FROM products LIMIT 1", [])
     end
 
     test "allows complex queries with JOINs" do
@@ -25,20 +26,19 @@ defmodule Lotus.PreflightSqliteTest do
         LIMIT 10
       """
 
-      assert :ok = Preflight.authorize(@sqlite_repo, "sqlite", sql, [])
+      assert :ok = Preflight.authorize(@sqlite_adapter, sql, [])
     end
 
     test "allows simple queries" do
       assert :ok =
                Preflight.authorize(
-                 @sqlite_repo,
-                 "sqlite",
+                 @sqlite_adapter,
                  "SELECT * FROM orders WHERE status = 'pending'",
                  []
                )
 
       assert :ok =
-               Preflight.authorize(@sqlite_repo, "sqlite", "SELECT COUNT(*) FROM products", [])
+               Preflight.authorize(@sqlite_adapter, "SELECT COUNT(*) FROM products", [])
     end
 
     test "allows subqueries and CTEs" do
@@ -48,7 +48,7 @@ defmodule Lotus.PreflightSqliteTest do
         WHERE id IN (SELECT product_id FROM order_items WHERE quantity > 1)
       """
 
-      assert :ok = Preflight.authorize(@sqlite_repo, "sqlite", sql, [])
+      assert :ok = Preflight.authorize(@sqlite_adapter, sql, [])
 
       # CTE
       sql = """
@@ -61,29 +61,27 @@ defmodule Lotus.PreflightSqliteTest do
         SELECT * FROM product_stats WHERE order_count > 0
       """
 
-      assert :ok = Preflight.authorize(@sqlite_repo, "sqlite", sql, [])
+      assert :ok = Preflight.authorize(@sqlite_adapter, sql, [])
     end
 
     test "handles parameterized queries" do
       assert :ok =
                Preflight.authorize(
-                 @sqlite_repo,
-                 "sqlite",
+                 @sqlite_adapter,
                  "SELECT * FROM products WHERE id = ?",
                  [1]
                )
 
       assert :ok =
                Preflight.authorize(
-                 @sqlite_repo,
-                 "sqlite",
+                 @sqlite_adapter,
                  "SELECT * FROM orders WHERE total_amount > ?",
                  [10.0]
                )
     end
 
     test "handles syntax errors gracefully" do
-      {:error, _msg} = Preflight.authorize(@sqlite_repo, "sqlite", "INVALID SQL SYNTAX", [])
+      {:error, _msg} = Preflight.authorize(@sqlite_adapter, "INVALID SQL SYNTAX", [])
     end
   end
 
@@ -91,8 +89,7 @@ defmodule Lotus.PreflightSqliteTest do
     test "blocks queries against schema_migrations" do
       {:error, msg} =
         Preflight.authorize(
-          @sqlite_repo,
-          "sqlite",
+          @sqlite_adapter,
           "SELECT * FROM lotus_sqlite_schema_migrations",
           []
         )
@@ -103,7 +100,7 @@ defmodule Lotus.PreflightSqliteTest do
 
     test "blocks queries against lotus_queries" do
       {:error, msg} =
-        Preflight.authorize(@sqlite_repo, "sqlite", "SELECT * FROM lotus_queries", [])
+        Preflight.authorize(@sqlite_adapter, "SELECT * FROM lotus_queries", [])
 
       assert msg =~ "blocked table"
       assert msg =~ "lotus_queries"
@@ -116,7 +113,7 @@ defmodule Lotus.PreflightSqliteTest do
         JOIN lotus_sqlite_schema_migrations sm ON 1=1
       """
 
-      {:error, msg} = Preflight.authorize(@sqlite_repo, "sqlite", sql, [])
+      {:error, msg} = Preflight.authorize(@sqlite_adapter, sql, [])
       assert msg =~ "blocked table"
       assert msg =~ "schema_migrations"
     end
@@ -139,11 +136,11 @@ defmodule Lotus.PreflightSqliteTest do
     end
 
     test "blocks queries against tables matching bare string deny rules" do
-      {:error, msg} = Preflight.authorize(@sqlite_repo, "sqlite", "SELECT * FROM products", [])
+      {:error, msg} = Preflight.authorize(@sqlite_adapter, "SELECT * FROM products", [])
       assert msg =~ "blocked table"
       assert msg =~ "products"
 
-      {:error, msg} = Preflight.authorize(@sqlite_repo, "sqlite", "SELECT * FROM order_items", [])
+      {:error, msg} = Preflight.authorize(@sqlite_adapter, "SELECT * FROM order_items", [])
       assert msg =~ "blocked table"
       assert msg =~ "order_items"
     end
@@ -156,14 +153,14 @@ defmodule Lotus.PreflightSqliteTest do
         JOIN products p ON oi.product_id = p.id
       """
 
-      {:error, msg} = Preflight.authorize(@sqlite_repo, "sqlite", sql, [])
+      {:error, msg} = Preflight.authorize(@sqlite_adapter, sql, [])
       assert msg =~ "blocked table"
       assert msg =~ "products"
       assert msg =~ "order_items"
     end
 
     test "allows queries against tables not in deny list" do
-      assert :ok = Preflight.authorize(@sqlite_repo, "sqlite", "SELECT * FROM orders", [])
+      assert :ok = Preflight.authorize(@sqlite_adapter, "SELECT * FROM orders", [])
     end
   end
 end

--- a/test/lotus/preflight_test.exs
+++ b/test/lotus/preflight_test.exs
@@ -2,41 +2,38 @@ defmodule Lotus.PreflightTest do
   use Lotus.Case
   use Mimic
   alias Lotus.Preflight
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
 
-  @pg_repo Lotus.Test.Repo
-  @sqlite_repo Lotus.Test.SqliteRepo
-  @mysql_repo Lotus.Test.MysqlRepo
-
-  describe "error handling" do
-    test "handles invalid repo gracefully" do
-      assert {:error, msg} = Preflight.authorize(@pg_repo, "unknown_repo", "SELECT 1", [])
-      assert msg == "Unknown data repo 'unknown_repo'"
-    end
-  end
+  @pg_adapter EctoAdapter.wrap("postgres", Lotus.Test.Repo)
+  @sqlite_adapter EctoAdapter.wrap("sqlite", Lotus.Test.SqliteRepo)
+  @mysql_adapter EctoAdapter.wrap("mysql", Lotus.Test.MysqlRepo)
 
   describe "adapter detection" do
     test "correctly identifies PostgreSQL adapter" do
-      assert :ok = Preflight.authorize(@pg_repo, "postgres", "SELECT 1", [])
+      assert :ok = Preflight.authorize(@pg_adapter, "SELECT 1", [])
     end
 
     @tag :sqlite
     test "correctly identifies SQLite adapter" do
-      assert :ok = Preflight.authorize(@sqlite_repo, "sqlite", "SELECT 1", [])
+      assert :ok = Preflight.authorize(@sqlite_adapter, "SELECT 1", [])
     end
 
     @tag :mysql
     test "correctly identifies MySQL adapter" do
-      assert :ok = Preflight.authorize(@mysql_repo, "mysql", "SELECT 1", [])
+      assert :ok = Preflight.authorize(@mysql_adapter, "SELECT 1", [])
     end
   end
 
   describe "fallback behavior" do
     test "allows queries for unknown adapters" do
-      defmodule UnknownRepo do
-        def __adapter__, do: Some.Unknown.Adapter
-      end
+      unknown_adapter = %Lotus.Source.Adapter{
+        name: "unknown",
+        module: Lotus.Source.Adapters.Ecto,
+        state: Lotus.Test.Repo,
+        source_type: :other
+      }
 
-      assert :ok = Preflight.authorize(UnknownRepo, "postgres", "SELECT * FROM anything", [])
+      assert :ok = Preflight.authorize(unknown_adapter, "SELECT * FROM anything", [])
     end
   end
 end

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -3,8 +3,12 @@ defmodule Lotus.RunnerTest do
 
   alias Lotus.Fixtures
   alias Lotus.Runner
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
   alias Lotus.Test.Repo
   alias Lotus.Test.SqliteRepo
+
+  @pg_adapter EctoAdapter.wrap("postgres", Repo)
+  @sqlite_adapter EctoAdapter.wrap("sqlite", SqliteRepo)
 
   setup do
     fixtures = Fixtures.setup_test_data()
@@ -14,7 +18,9 @@ defmodule Lotus.RunnerTest do
   describe "run_sql/4 with real tables" do
     test "executes simple SELECT queries", %{users: %{kerouac: kerouac}} do
       result =
-        Runner.run_sql(Repo, "SELECT name, email FROM test_users WHERE id = $1", [kerouac.id])
+        Runner.run_sql(@pg_adapter, "SELECT name, email FROM test_users WHERE id = $1", [
+          kerouac.id
+        ])
 
       assert {:ok, %{columns: ["name", "email"], rows: [["Jack Kerouac", "jack@ontheroad.com"]]}} =
                result
@@ -24,7 +30,7 @@ defmodule Lotus.RunnerTest do
       users: %{kerouac: kerouac, thompson: thompson}
     } do
       sql = "SELECT name, age FROM test_users WHERE id IN ($1, $2) ORDER BY name"
-      result = Runner.run_sql(Repo, sql, [kerouac.id, thompson.id])
+      result = Runner.run_sql(@pg_adapter, sql, [kerouac.id, thompson.id])
 
       assert {:ok,
               %{
@@ -43,7 +49,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY p.view_count DESC
       """
 
-      result = Runner.run_sql(Repo, sql, [kerouac.id])
+      result = Runner.run_sql(@pg_adapter, sql, [kerouac.id])
 
       assert {:ok,
               %{
@@ -65,7 +71,7 @@ defmodule Lotus.RunnerTest do
       WHERE published = true
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -86,7 +92,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY u.name
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -101,7 +107,7 @@ defmodule Lotus.RunnerTest do
 
     test "handles JSON operations", %{users: %{kerouac: kerouac}} do
       sql = "SELECT name, metadata->>'role' as role FROM test_users WHERE id = $1"
-      result = Runner.run_sql(Repo, sql, [kerouac.id])
+      result = Runner.run_sql(@pg_adapter, sql, [kerouac.id])
       assert {:ok, %{columns: ["name", "role"], rows: [["Jack Kerouac", "admin"]]}} = result
     end
 
@@ -109,7 +115,7 @@ defmodule Lotus.RunnerTest do
       sql =
         "SELECT title, array_length(tags, 1) as tag_count FROM test_posts WHERE 'beat' = ANY(tags)"
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:ok, %{columns: ["title", "tag_count"], rows: rows}} = result
       assert length(rows) == 2
     end
@@ -128,7 +134,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM user_posts ORDER BY name
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -146,7 +152,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "email"], rows: rows}} = result
       assert length(rows) == 2
@@ -167,7 +173,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "age_group"], rows: rows}} = result
       assert ["Charles Bukowski", "Senior"] in rows
@@ -178,7 +184,7 @@ defmodule Lotus.RunnerTest do
 
   describe "whitelist validation" do
     test "allows SELECT queries" do
-      result = Runner.run_sql(Repo, "SELECT * FROM test_users LIMIT 1")
+      result = Runner.run_sql(@pg_adapter, "SELECT * FROM test_users LIMIT 1")
       assert {:ok, %{columns: columns, rows: _}} = result
       assert "id" in columns
     end
@@ -189,17 +195,17 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM test
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:ok, %{columns: ["num"], rows: [[1]]}} = result
     end
 
     test "allows VALUES queries" do
-      result = Runner.run_sql(Repo, "VALUES (1, 'a'), (2, 'b')")
+      result = Runner.run_sql(@pg_adapter, "VALUES (1, 'a'), (2, 'b')")
       assert {:ok, %{columns: ["column1", "column2"], rows: [[1, "a"], [2, "b"]]}} = result
     end
 
     test "allows EXPLAIN queries" do
-      result = Runner.run_sql(Repo, "EXPLAIN SELECT * FROM test_users")
+      result = Runner.run_sql(@pg_adapter, "EXPLAIN SELECT * FROM test_users")
       assert {:ok, %{columns: ["QUERY PLAN"], rows: rows}} = result
       refute Enum.empty?(rows)
     end
@@ -207,7 +213,7 @@ defmodule Lotus.RunnerTest do
     test "rejects INSERT statements" do
       result =
         Runner.run_sql(
-          Repo,
+          @pg_adapter,
           "INSERT INTO test_users (name, email) VALUES ('test', 'test@example.com')"
         )
 
@@ -215,98 +221,98 @@ defmodule Lotus.RunnerTest do
     end
 
     test "rejects UPDATE statements" do
-      result = Runner.run_sql(Repo, "UPDATE test_users SET name = 'Updated'")
+      result = Runner.run_sql(@pg_adapter, "UPDATE test_users SET name = 'Updated'")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects DELETE statements" do
-      result = Runner.run_sql(Repo, "DELETE FROM test_users WHERE id = 1")
+      result = Runner.run_sql(@pg_adapter, "DELETE FROM test_users WHERE id = 1")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects DROP statements" do
-      result = Runner.run_sql(Repo, "DROP TABLE test_users")
+      result = Runner.run_sql(@pg_adapter, "DROP TABLE test_users")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects CREATE statements" do
-      result = Runner.run_sql(Repo, "CREATE TABLE new_table (id int)")
+      result = Runner.run_sql(@pg_adapter, "CREATE TABLE new_table (id int)")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects ALTER statements" do
-      result = Runner.run_sql(Repo, "ALTER TABLE test_users ADD COLUMN new_field text")
+      result = Runner.run_sql(@pg_adapter, "ALTER TABLE test_users ADD COLUMN new_field text")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects TRUNCATE statements" do
-      result = Runner.run_sql(Repo, "TRUNCATE test_users")
+      result = Runner.run_sql(@pg_adapter, "TRUNCATE test_users")
       assert {:error, "Only read-only queries are allowed"} = result
     end
   end
 
   describe "deny list validation" do
     test "detects dangerous keywords in string literals" do
-      result = Runner.run_sql(Repo, "SELECT 'DROP TABLE users' as msg")
+      result = Runner.run_sql(@pg_adapter, "SELECT 'DROP TABLE users' as msg")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "detects dangerous keywords case-insensitively" do
-      result = Runner.run_sql(Repo, "SELECT 'InSeRt INTO users' as msg")
+      result = Runner.run_sql(@pg_adapter, "SELECT 'InSeRt INTO users' as msg")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "allows safe strings without dangerous keywords" do
-      result = Runner.run_sql(Repo, "SELECT 'This is a safe message' as msg")
+      result = Runner.run_sql(@pg_adapter, "SELECT 'This is a safe message' as msg")
       assert {:ok, %{columns: ["msg"], rows: [["This is a safe message"]]}} = result
     end
   end
 
   describe "single statement validation" do
     test "rejects multiple statements with semicolon" do
-      result = Runner.run_sql(Repo, "SELECT 1; SELECT 2")
+      result = Runner.run_sql(@pg_adapter, "SELECT 1; SELECT 2")
       assert {:error, "Only a single statement is allowed"} = result
     end
 
     test "allows statement with trailing semicolon" do
-      result = Runner.run_sql(Repo, "SELECT * FROM test_users;")
+      result = Runner.run_sql(@pg_adapter, "SELECT * FROM test_users;")
       assert {:ok, %{columns: columns, rows: rows}} = result
       refute Enum.empty?(columns)
       refute Enum.empty?(rows)
     end
 
     test "allows semicolon in string literals" do
-      result = Runner.run_sql(Repo, "SELECT 'test;value' as text")
+      result = Runner.run_sql(@pg_adapter, "SELECT 'test;value' as text")
       assert {:ok, %{columns: ["text"], rows: [["test;value"]]}} = result
     end
 
     test "allows semicolon in double-quoted identifiers" do
-      result = Runner.run_sql(Repo, ~s[SELECT 'test' as "col;name"])
+      result = Runner.run_sql(@pg_adapter, ~s[SELECT 'test' as "col;name"])
       assert {:ok, %{columns: ["col;name"], rows: [["test"]]}} = result
     end
 
     test "allows semicolon in line comments" do
-      result = Runner.run_sql(Repo, "SELECT 1 as num -- comment with ; semicolon")
+      result = Runner.run_sql(@pg_adapter, "SELECT 1 as num -- comment with ; semicolon")
       assert {:ok, %{columns: ["num"], rows: [[1]]}} = result
     end
 
     test "allows semicolon in block comments" do
-      result = Runner.run_sql(Repo, "SELECT /* comment ; with semicolon */ 1 as num")
+      result = Runner.run_sql(@pg_adapter, "SELECT /* comment ; with semicolon */ 1 as num")
       assert {:ok, %{columns: ["num"], rows: [[1]]}} = result
     end
 
     test "allows semicolon in PostgreSQL dollar-quoted strings" do
-      result = Runner.run_sql(Repo, "SELECT $$test;value$$ as text")
+      result = Runner.run_sql(@pg_adapter, "SELECT $$test;value$$ as text")
       assert {:ok, %{columns: ["text"], rows: [["test;value"]]}} = result
     end
 
     test "allows semicolon in tagged dollar-quoted strings" do
-      result = Runner.run_sql(Repo, "SELECT $tag$test;value$tag$ as text")
+      result = Runner.run_sql(@pg_adapter, "SELECT $tag$test;value$tag$ as text")
       assert {:ok, %{columns: ["text"], rows: [["test;value"]]}} = result
     end
 
     test "still rejects actual multiple statements" do
-      result = Runner.run_sql(Repo, "SELECT 'test;ok' as text; SELECT 2")
+      result = Runner.run_sql(@pg_adapter, "SELECT 'test;ok' as text; SELECT 2")
       assert {:error, "Only a single statement is allowed"} = result
     end
 
@@ -320,7 +326,7 @@ defmodule Lotus.RunnerTest do
       WHERE name = 'Jack Kerouac';
       """
 
-      result = Runner.run_sql(Repo, query)
+      result = Runner.run_sql(@pg_adapter, query)
       assert {:ok, %{columns: columns, rows: rows}} = result
       assert "col;name" in columns
       refute Enum.empty?(rows)
@@ -334,22 +340,24 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM test
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:ok, %{columns: ["id"], rows: [[1]]}} = result
     end
 
     test "respects read_only: false option" do
-      result = Runner.run_sql(Repo, "SELECT COUNT(*) FROM test_users", [], read_only: false)
+      result =
+        Runner.run_sql(@pg_adapter, "SELECT COUNT(*) FROM test_users", [], read_only: false)
+
       assert {:ok, %{columns: ["count"], rows: [[3]]}} = result
     end
 
     test "respects custom statement timeout" do
-      result = Runner.run_sql(Repo, "SELECT 1", [], statement_timeout_ms: 100)
+      result = Runner.run_sql(@pg_adapter, "SELECT 1", [], statement_timeout_ms: 100)
       assert {:ok, %{columns: ["?column?"], rows: [[1]]}} = result
     end
 
     test "respects custom database timeout" do
-      result = Runner.run_sql(Repo, "SELECT COUNT(*) FROM test_users", [], timeout: 1000)
+      result = Runner.run_sql(@pg_adapter, "SELECT COUNT(*) FROM test_users", [], timeout: 1000)
       assert {:ok, %{columns: ["count"], rows: [[3]]}} = result
     end
   end
@@ -360,7 +368,7 @@ defmodule Lotus.RunnerTest do
 
       result =
         Runner.run_sql(
-          Repo,
+          @pg_adapter,
           "INSERT INTO test_users (name, email, age, active, metadata, inserted_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, name, email",
           ["Ada Lovelace", "ada@math.org", 36, true, %{}, now, now],
           read_only: false
@@ -374,7 +382,7 @@ defmodule Lotus.RunnerTest do
     test "UPDATE succeeds with read_only: false and returns affected rows" do
       result =
         Runner.run_sql(
-          Repo,
+          @pg_adapter,
           "UPDATE test_users SET age = age + 1 WHERE active = true RETURNING id, name, age",
           [],
           read_only: false
@@ -387,7 +395,7 @@ defmodule Lotus.RunnerTest do
     test "DELETE succeeds with read_only: false and returns affected rows" do
       result =
         Runner.run_sql(
-          Repo,
+          @pg_adapter,
           "DELETE FROM test_users WHERE active = false RETURNING id",
           [],
           read_only: false
@@ -400,7 +408,7 @@ defmodule Lotus.RunnerTest do
     test "INSERT is still rejected with default opts (no regression)" do
       result =
         Runner.run_sql(
-          Repo,
+          @pg_adapter,
           "INSERT INTO test_users (name, email) VALUES ('test', 'test@example.com')"
         )
 
@@ -410,7 +418,7 @@ defmodule Lotus.RunnerTest do
     test "single-statement validation still enforced with read_only: false" do
       result =
         Runner.run_sql(
-          Repo,
+          @pg_adapter,
           "INSERT INTO test_users (name, email) VALUES ('a', 'a@a.com'); DELETE FROM test_users",
           [],
           read_only: false
@@ -422,14 +430,14 @@ defmodule Lotus.RunnerTest do
 
   describe "error handling" do
     test "handles syntax errors gracefully" do
-      result = Runner.run_sql(Repo, "SELECT * FROM")
+      result = Runner.run_sql(@pg_adapter, "SELECT * FROM")
       assert {:error, msg} = result
       assert msg =~ "SQL syntax error:"
       assert msg =~ "syntax error at end of input" or msg =~ "syntax error at or near"
     end
 
     test "handles invalid table references" do
-      result = Runner.run_sql(Repo, "SELECT * FROM non_existent_table")
+      result = Runner.run_sql(@pg_adapter, "SELECT * FROM non_existent_table")
       assert {:error, msg} = result
       assert msg =~ "SQL error:"
       assert msg =~ "non_existent_table"
@@ -437,7 +445,7 @@ defmodule Lotus.RunnerTest do
 
     test "handles invalid column references", %{users: %{kerouac: kerouac}} do
       result =
-        Runner.run_sql(Repo, "SELECT non_existent_column FROM test_users WHERE id = $1", [
+        Runner.run_sql(@pg_adapter, "SELECT non_existent_column FROM test_users WHERE id = $1", [
           kerouac.id
         ])
 
@@ -447,14 +455,16 @@ defmodule Lotus.RunnerTest do
     end
 
     test "handles type mismatches" do
-      result = Runner.run_sql(Repo, "SELECT * FROM test_users WHERE id = $1", ["not_an_integer"])
+      result =
+        Runner.run_sql(@pg_adapter, "SELECT * FROM test_users WHERE id = $1", ["not_an_integer"])
+
       assert {:error, message} = result
       assert is_binary(message)
       assert message =~ "expected an integer"
     end
 
     test "handles empty result sets" do
-      result = Runner.run_sql(Repo, "SELECT * FROM test_users WHERE id = -999")
+      result = Runner.run_sql(@pg_adapter, "SELECT * FROM test_users WHERE id = -999")
       assert {:ok, %{columns: columns, rows: []}} = result
       assert "id" in columns
     end
@@ -462,19 +472,21 @@ defmodule Lotus.RunnerTest do
     test "handles NULL values" do
       user = Fixtures.insert_user(%{name: "Null Test", email: "null@test.com", age: nil})
 
-      result = Runner.run_sql(Repo, "SELECT name, age FROM test_users WHERE id = $1", [user.id])
+      result =
+        Runner.run_sql(@pg_adapter, "SELECT name, age FROM test_users WHERE id = $1", [user.id])
+
       assert {:ok, %{columns: ["name", "age"], rows: [["Null Test", nil]]}} = result
     end
 
     test "validates SQL string type" do
       assert_raise FunctionClauseError, fn ->
-        Runner.run_sql(Repo, 123, [])
+        Runner.run_sql(@pg_adapter, 123, [])
       end
     end
 
     test "validates params list type" do
       assert_raise FunctionClauseError, fn ->
-        Runner.run_sql(Repo, "SELECT 1", "not_a_list")
+        Runner.run_sql(@pg_adapter, "SELECT 1", "not_a_list")
       end
     end
   end
@@ -491,7 +503,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY rank
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["title", "view_count", "rank"], rows: rows}} = result
       assert length(rows) == 3
@@ -506,7 +518,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "type"], rows: rows}} = result
       assert length(rows) > 3
@@ -522,7 +534,7 @@ defmodule Lotus.RunnerTest do
       LIMIT 1
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "created_date", "year"], rows: [[_, _, year]]}} = result
       assert is_integer(year)
@@ -540,7 +552,7 @@ defmodule Lotus.RunnerTest do
       LIMIT 1
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -563,7 +575,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name"], rows: rows}} = result
       assert ["Jack Kerouac"] in rows
@@ -576,7 +588,7 @@ defmodule Lotus.RunnerTest do
       SELECT DISTINCT active FROM test_users ORDER BY active
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["active"], rows: [[false], [true]]}} = result
     end
@@ -588,7 +600,7 @@ defmodule Lotus.RunnerTest do
       LIMIT 2 OFFSET 1
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name"], rows: rows}} = result
       assert length(rows) == 2
@@ -634,7 +646,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_rows
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -648,7 +660,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM inserted_users
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -662,7 +674,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM updated_users
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -679,7 +691,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_inactive
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -694,7 +706,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM temp_data
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -706,7 +718,7 @@ defmodule Lotus.RunnerTest do
       SELECT 1
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -719,7 +731,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM truncated
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -734,7 +746,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM user_count
       """
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
       assert {:ok, %{columns: ["total"], rows: _}} = result
     end
   end
@@ -750,7 +762,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_rows
       """
 
-      result = Runner.run_sql(SqliteRepo, sql)
+      result = Runner.run_sql(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -765,7 +777,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM inserted_users
       """
 
-      result = Runner.run_sql(SqliteRepo, sql)
+      result = Runner.run_sql(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -780,7 +792,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM updated_users
       """
 
-      result = Runner.run_sql(SqliteRepo, sql)
+      result = Runner.run_sql(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -798,7 +810,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_inactive
       """
 
-      result = Runner.run_sql(SqliteRepo, sql)
+      result = Runner.run_sql(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -814,7 +826,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM temp_data
       """
 
-      result = Runner.run_sql(SqliteRepo, sql)
+      result = Runner.run_sql(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -827,7 +839,7 @@ defmodule Lotus.RunnerTest do
       SELECT 1
       """
 
-      result = Runner.run_sql(SqliteRepo, sql)
+      result = Runner.run_sql(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -843,7 +855,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM user_count
       """
 
-      result = Runner.run_sql(SqliteRepo, sql)
+      result = Runner.run_sql(@sqlite_adapter, sql)
       assert {:ok, %{columns: ["total"], rows: _}} = result
     end
   end
@@ -881,7 +893,7 @@ defmodule Lotus.RunnerTest do
       sql =
         "SELECT id, name, email, age, active, metadata, inserted_at, updated_at FROM test_users"
 
-      result = Runner.run_sql(Repo, sql)
+      result = Runner.run_sql(@pg_adapter, sql)
 
       assert {:ok,
               %Lotus.Result{
@@ -937,7 +949,7 @@ defmodule Lotus.RunnerTest do
 
     test "returns raw UUID binaries in result rows", %{uuid1: uuid1} do
       {:ok, result} =
-        Runner.run_sql(Repo, "SELECT id, name FROM test_uuid_records WHERE name = $1", [
+        Runner.run_sql(@pg_adapter, "SELECT id, name FROM test_uuid_records WHERE name = $1", [
           "Record A"
         ])
 
@@ -953,7 +965,10 @@ defmodule Lotus.RunnerTest do
       uuid2: uuid2
     } do
       {:ok, result} =
-        Runner.run_sql(Repo, "SELECT id, name, ref_id FROM test_uuid_records ORDER BY name")
+        Runner.run_sql(
+          @pg_adapter,
+          "SELECT id, name, ref_id FROM test_uuid_records ORDER BY name"
+        )
 
       # to_encodable normalizes UUIDs to strings
       encodable = Lotus.Result.to_encodable(result)

--- a/test/lotus/source/adapter_test.exs
+++ b/test/lotus/source/adapter_test.exs
@@ -1,0 +1,232 @@
+defmodule Lotus.Source.AdapterTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Source.Adapter
+
+  defmodule MockAdapter do
+    @moduledoc false
+    @behaviour Lotus.Source.Adapter
+
+    # --- Query Execution ---
+    @impl true
+    def execute_query(state, sql, params, _opts) do
+      {:ok, %{columns: ["id"], rows: [[1]], num_rows: 1, sql: sql, params: params, db: state.db}}
+    end
+
+    @impl true
+    def transaction(state, fun, _opts) do
+      {:ok, fun.(state)}
+    end
+
+    # --- Introspection ---
+    @impl true
+    def list_schemas(state) do
+      {:ok, [state.db]}
+    end
+
+    @impl true
+    def list_tables(_state, _schemas, _opts) do
+      {:ok, [{"public", "users"}, {"public", "posts"}]}
+    end
+
+    @impl true
+    def get_table_schema(_state, _schema, _table) do
+      {:ok,
+       [
+         %{name: "id", type: "integer", nullable: false, default: nil, primary_key: true},
+         %{name: "name", type: "varchar(255)", nullable: false, default: nil, primary_key: false}
+       ]}
+    end
+
+    @impl true
+    def resolve_table_schema(_state, _table, _schemas) do
+      {:ok, "public"}
+    end
+
+    # --- SQL Generation ---
+    @impl true
+    def quote_identifier(identifier), do: ~s("#{identifier}")
+
+    @impl true
+    def param_placeholder(index, _var, _type), do: "$#{index}"
+
+    @impl true
+    def limit_offset_placeholders(limit_idx, offset_idx), do: {"$#{limit_idx}", "$#{offset_idx}"}
+
+    @impl true
+    def apply_filters(sql, params, _filters), do: {sql <> " WHERE 1=1", params}
+
+    @impl true
+    def apply_sorts(sql, _sorts), do: sql <> " ORDER BY id"
+
+    @impl true
+    def explain_plan(_state, sql, _params, _opts), do: {:ok, "Seq Scan on #{sql}"}
+
+    # --- Safety & Visibility ---
+    @impl true
+    def builtin_denies(_state), do: [{"pg_catalog", ~r/.*/}]
+
+    @impl true
+    def builtin_schema_denies(_state), do: ["information_schema"]
+
+    @impl true
+    def default_schemas(_state), do: ["public"]
+
+    # --- Lifecycle ---
+    @impl true
+    def health_check(_state), do: :ok
+
+    @impl true
+    def disconnect(_state), do: :ok
+
+    # --- Error Handling ---
+    @impl true
+    def format_error(error), do: "Mock error: #{inspect(error)}"
+
+    @impl true
+    def handled_errors, do: [RuntimeError]
+
+    # --- Source Identity ---
+    @impl true
+    def source_type, do: :postgres
+
+    @impl true
+    def supports_feature?(:json), do: true
+    def supports_feature?(_), do: false
+  end
+
+  describe "struct creation" do
+    test "creates adapter struct with all fields" do
+      adapter = %Adapter{
+        name: "main",
+        module: MockAdapter,
+        state: %{db: "test_db"},
+        source_type: :postgres
+      }
+
+      assert adapter.name == "main"
+      assert adapter.module == MockAdapter
+      assert adapter.state == %{db: "test_db"}
+      assert adapter.source_type == :postgres
+    end
+
+    test "defaults all fields to nil" do
+      adapter = %Adapter{}
+
+      assert adapter.name == nil
+      assert adapter.module == nil
+      assert adapter.state == nil
+      assert adapter.source_type == nil
+    end
+  end
+
+  describe "dispatch helpers" do
+    setup do
+      adapter = %Adapter{
+        name: "main",
+        module: MockAdapter,
+        state: %{db: "test_db"},
+        source_type: :postgres
+      }
+
+      {:ok, adapter: adapter}
+    end
+
+    test "execute_query/4 dispatches to module with state", %{adapter: adapter} do
+      assert {:ok, result} = Adapter.execute_query(adapter, "SELECT 1", [], [])
+      assert result.columns == ["id"]
+      assert result.rows == [[1]]
+      assert result.db == "test_db"
+    end
+
+    test "list_schemas/1 dispatches to module with state", %{adapter: adapter} do
+      assert {:ok, ["test_db"]} = Adapter.list_schemas(adapter)
+    end
+
+    test "list_tables/3 dispatches to module with state", %{adapter: adapter} do
+      assert {:ok, tables} = Adapter.list_tables(adapter, ["public"], [])
+      assert {"public", "users"} in tables
+    end
+
+    test "quote_identifier/2 dispatches without state (stateless)", %{adapter: adapter} do
+      assert ~s("users") == Adapter.quote_identifier(adapter, "users")
+    end
+
+    test "source_type/1 dispatches without state (stateless)", %{adapter: adapter} do
+      assert :postgres == Adapter.source_type(adapter)
+    end
+
+    test "supports_feature?/2 dispatches without state (stateless)", %{adapter: adapter} do
+      assert Adapter.supports_feature?(adapter, :json) == true
+      assert Adapter.supports_feature?(adapter, :arrays) == false
+    end
+
+    test "health_check/1 dispatches to module with state", %{adapter: adapter} do
+      assert :ok = Adapter.health_check(adapter)
+    end
+
+    test "explain_plan/4 dispatches to module with state", %{adapter: adapter} do
+      assert {:ok, plan} = Adapter.explain_plan(adapter, "SELECT 1", [], [])
+      assert plan =~ "Seq Scan"
+    end
+
+    test "get_table_schema/3 dispatches to module with state", %{adapter: adapter} do
+      assert {:ok, columns} = Adapter.get_table_schema(adapter, "public", "users")
+      assert length(columns) == 2
+      assert hd(columns).name == "id"
+    end
+
+    test "resolve_table_schema/3 dispatches to module with state", %{adapter: adapter} do
+      assert {:ok, "public"} = Adapter.resolve_table_schema(adapter, "users", ["public"])
+    end
+
+    test "transaction/3 dispatches to module with state", %{adapter: adapter} do
+      assert {:ok, result} = Adapter.transaction(adapter, fn _state -> :done end, [])
+      assert result == :done
+    end
+
+    test "param_placeholder/4 dispatches without state", %{adapter: adapter} do
+      assert "$1" == Adapter.param_placeholder(adapter, 1, "id", nil)
+    end
+
+    test "limit_offset_placeholders/3 dispatches without state", %{adapter: adapter} do
+      assert {"$1", "$2"} == Adapter.limit_offset_placeholders(adapter, 1, 2)
+    end
+
+    test "apply_filters/4 dispatches without state", %{adapter: adapter} do
+      {sql, params} = Adapter.apply_filters(adapter, "SELECT 1", [], [%{}])
+      assert sql =~ "WHERE 1=1"
+      assert params == []
+    end
+
+    test "apply_sorts/3 dispatches without state", %{adapter: adapter} do
+      sql = Adapter.apply_sorts(adapter, "SELECT 1", [:id])
+      assert sql =~ "ORDER BY id"
+    end
+
+    test "builtin_denies/1 dispatches with state", %{adapter: adapter} do
+      denies = Adapter.builtin_denies(adapter)
+      assert [{"pg_catalog", _}] = denies
+    end
+
+    test "builtin_schema_denies/1 dispatches with state", %{adapter: adapter} do
+      assert ["information_schema"] = Adapter.builtin_schema_denies(adapter)
+    end
+
+    test "default_schemas/1 dispatches with state", %{adapter: adapter} do
+      assert ["public"] = Adapter.default_schemas(adapter)
+    end
+
+    test "disconnect/1 dispatches with state", %{adapter: adapter} do
+      assert :ok = Adapter.disconnect(adapter)
+    end
+
+    test "format_error/2 dispatches without state (stateless)", %{adapter: adapter} do
+      assert "Mock error: :boom" == Adapter.format_error(adapter, :boom)
+    end
+
+    test "handled_errors/1 dispatches without state (stateless)", %{adapter: adapter} do
+      assert [RuntimeError] = Adapter.handled_errors(adapter)
+    end
+  end
+end

--- a/test/lotus/source/adapter_test.exs
+++ b/test/lotus/source/adapter_test.exs
@@ -45,19 +45,20 @@ defmodule Lotus.Source.AdapterTest do
 
     # --- SQL Generation ---
     @impl true
-    def quote_identifier(identifier), do: ~s("#{identifier}")
+    def quote_identifier(_state, identifier), do: ~s("#{identifier}")
 
     @impl true
-    def param_placeholder(index, _var, _type), do: "$#{index}"
+    def param_placeholder(_state, index, _var, _type), do: "$#{index}"
 
     @impl true
-    def limit_offset_placeholders(limit_idx, offset_idx), do: {"$#{limit_idx}", "$#{offset_idx}"}
+    def limit_offset_placeholders(_state, limit_idx, offset_idx),
+      do: {"$#{limit_idx}", "$#{offset_idx}"}
 
     @impl true
-    def apply_filters(sql, params, _filters), do: {sql <> " WHERE 1=1", params}
+    def apply_filters(_state, sql, params, _filters), do: {sql <> " WHERE 1=1", params}
 
     @impl true
-    def apply_sorts(sql, _sorts), do: sql <> " ORDER BY id"
+    def apply_sorts(_state, sql, _sorts), do: sql <> " ORDER BY id"
 
     @impl true
     def explain_plan(_state, sql, _params, _opts), do: {:ok, "Seq Scan on #{sql}"}
@@ -81,18 +82,18 @@ defmodule Lotus.Source.AdapterTest do
 
     # --- Error Handling ---
     @impl true
-    def format_error(error), do: "Mock error: #{inspect(error)}"
+    def format_error(_state, error), do: "Mock error: #{inspect(error)}"
 
     @impl true
-    def handled_errors, do: [RuntimeError]
+    def handled_errors(_state), do: [RuntimeError]
 
     # --- Source Identity ---
     @impl true
-    def source_type, do: :postgres
+    def source_type(_state), do: :postgres
 
     @impl true
-    def supports_feature?(:json), do: true
-    def supports_feature?(_), do: false
+    def supports_feature?(_state, :json), do: true
+    def supports_feature?(_state, _), do: false
   end
 
   describe "struct creation" do
@@ -148,15 +149,15 @@ defmodule Lotus.Source.AdapterTest do
       assert {"public", "users"} in tables
     end
 
-    test "quote_identifier/2 dispatches without state (stateless)", %{adapter: adapter} do
+    test "quote_identifier/2 dispatches with state", %{adapter: adapter} do
       assert ~s("users") == Adapter.quote_identifier(adapter, "users")
     end
 
-    test "source_type/1 dispatches without state (stateless)", %{adapter: adapter} do
+    test "source_type/1 dispatches with state", %{adapter: adapter} do
       assert :postgres == Adapter.source_type(adapter)
     end
 
-    test "supports_feature?/2 dispatches without state (stateless)", %{adapter: adapter} do
+    test "supports_feature?/2 dispatches with state", %{adapter: adapter} do
       assert Adapter.supports_feature?(adapter, :json) == true
       assert Adapter.supports_feature?(adapter, :arrays) == false
     end
@@ -185,21 +186,21 @@ defmodule Lotus.Source.AdapterTest do
       assert result == :done
     end
 
-    test "param_placeholder/4 dispatches without state", %{adapter: adapter} do
+    test "param_placeholder/4 dispatches with state", %{adapter: adapter} do
       assert "$1" == Adapter.param_placeholder(adapter, 1, "id", nil)
     end
 
-    test "limit_offset_placeholders/3 dispatches without state", %{adapter: adapter} do
+    test "limit_offset_placeholders/3 dispatches with state", %{adapter: adapter} do
       assert {"$1", "$2"} == Adapter.limit_offset_placeholders(adapter, 1, 2)
     end
 
-    test "apply_filters/4 dispatches without state", %{adapter: adapter} do
+    test "apply_filters/4 dispatches with state", %{adapter: adapter} do
       {sql, params} = Adapter.apply_filters(adapter, "SELECT 1", [], [%{}])
       assert sql =~ "WHERE 1=1"
       assert params == []
     end
 
-    test "apply_sorts/3 dispatches without state", %{adapter: adapter} do
+    test "apply_sorts/3 dispatches with state", %{adapter: adapter} do
       sql = Adapter.apply_sorts(adapter, "SELECT 1", [:id])
       assert sql =~ "ORDER BY id"
     end
@@ -221,11 +222,11 @@ defmodule Lotus.Source.AdapterTest do
       assert :ok = Adapter.disconnect(adapter)
     end
 
-    test "format_error/2 dispatches without state (stateless)", %{adapter: adapter} do
+    test "format_error/2 dispatches with state", %{adapter: adapter} do
       assert "Mock error: :boom" == Adapter.format_error(adapter, :boom)
     end
 
-    test "handled_errors/1 dispatches without state (stateless)", %{adapter: adapter} do
+    test "handled_errors/1 dispatches with state", %{adapter: adapter} do
       assert [RuntimeError] = Adapter.handled_errors(adapter)
     end
   end

--- a/test/lotus/source/adapters/ecto_test.exs
+++ b/test/lotus/source/adapters/ecto_test.exs
@@ -1,0 +1,197 @@
+defmodule Lotus.Source.Adapters.EctoTest do
+  use Lotus.Case, async: true
+
+  alias Lotus.Source.Adapter
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
+  alias Lotus.Test.Repo
+
+  describe "wrap/2" do
+    test "creates an Adapter struct with correct fields" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert %Adapter{} = adapter
+      assert adapter.name == "main"
+      assert adapter.module == EctoAdapter
+      assert adapter.state == Repo
+      assert adapter.source_type == :postgres
+    end
+  end
+
+  describe "detect_source_type/1" do
+    test "detects Postgres adapter" do
+      assert EctoAdapter.detect_source_type(Repo) == :postgres
+    end
+
+    test "detects SQLite adapter" do
+      assert EctoAdapter.detect_source_type(Lotus.Test.SqliteRepo) == :sqlite
+    end
+
+    test "detects MySQL adapter" do
+      assert EctoAdapter.detect_source_type(Lotus.Test.MysqlRepo) == :mysql
+    end
+  end
+
+  describe "source_type/0" do
+    test "returns the source type from the wrapped repo" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert Adapter.source_type(adapter) == :postgres
+    end
+  end
+
+  describe "supports_feature?/1" do
+    test "postgres supports search_path" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert Adapter.supports_feature?(adapter, :search_path)
+    end
+
+    test "postgres supports json" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert Adapter.supports_feature?(adapter, :json)
+    end
+
+    test "postgres supports arrays" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert Adapter.supports_feature?(adapter, :arrays)
+    end
+
+    test "postgres does not support unknown features" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      refute Adapter.supports_feature?(adapter, :time_travel)
+    end
+  end
+
+  describe "introspection callbacks" do
+    test "list_schemas/1 returns {:ok, _} tuple" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert {:ok, schemas} = Adapter.list_schemas(adapter)
+      assert is_list(schemas)
+      assert "public" in schemas
+    end
+
+    test "list_tables/3 returns {:ok, _} tuple" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert {:ok, tables} = Adapter.list_tables(adapter, ["public"], include_views: false)
+      assert is_list(tables)
+    end
+
+    test "get_table_schema/3 returns {:ok, _} tuple" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert {:ok, columns} = Adapter.get_table_schema(adapter, "public", "lotus_queries")
+      assert is_list(columns)
+    end
+
+    test "resolve_table_schema/3 returns {:ok, _} tuple" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert {:ok, schema} = Adapter.resolve_table_schema(adapter, "lotus_queries", ["public"])
+      assert schema == "public"
+    end
+  end
+
+  describe "SQL generation callbacks" do
+    test "quote_identifier/1 uses Postgres double-quoting" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert ~s("users") == Adapter.quote_identifier(adapter, "users")
+    end
+
+    test "param_placeholder/3 uses Postgres positional params" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert "$1" == Adapter.param_placeholder(adapter, 1, "id", nil)
+    end
+
+    test "limit_offset_placeholders/2 uses Postgres positional params" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert {"$1", "$2"} == Adapter.limit_offset_placeholders(adapter, 1, 2)
+    end
+  end
+
+  describe "safety callbacks" do
+    test "builtin_denies/1 returns deny rules" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      denies = Adapter.builtin_denies(adapter)
+      assert is_list(denies)
+      assert {"pg_catalog", ~r/.*/} in denies
+    end
+
+    test "builtin_schema_denies/1 returns schema deny patterns" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      denies = Adapter.builtin_schema_denies(adapter)
+      assert is_list(denies)
+      assert "pg_catalog" in denies
+    end
+
+    test "default_schemas/1 returns default schemas" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert ["public"] == Adapter.default_schemas(adapter)
+    end
+  end
+
+  describe "lifecycle callbacks" do
+    test "health_check/1 succeeds for running repo" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert :ok = Adapter.health_check(adapter)
+    end
+
+    test "disconnect/1 returns :ok (static repos managed by supervisor)" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert :ok = Adapter.disconnect(adapter)
+    end
+  end
+
+  describe "execute_query/4" do
+    test "executes a simple query and returns result map" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:ok, result} = Adapter.execute_query(adapter, "SELECT 1 AS num", [], [])
+      assert result.columns == ["num"]
+      assert result.rows == [[1]]
+      assert result.num_rows == 1
+    end
+
+    test "returns error for invalid SQL" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:error, _reason} = Adapter.execute_query(adapter, "INVALID SQL", [], [])
+    end
+
+    test "respects search_path option" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:ok, result} =
+               Adapter.execute_query(adapter, "SELECT 1 AS num", [], search_path: "public")
+
+      assert result.columns == ["num"]
+    end
+  end
+
+  describe "transaction/3" do
+    test "executes a function in a transaction" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:ok, result} =
+               Adapter.transaction(
+                 adapter,
+                 fn repo ->
+                   repo.query!("SELECT 42 AS answer")
+                 end,
+                 []
+               )
+
+      assert %{rows: [[42]]} = result
+    end
+  end
+
+  describe "error handling" do
+    test "format_error/1 formats exceptions" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      error = %RuntimeError{message: "boom"}
+      assert is_binary(Adapter.format_error(adapter, error))
+    end
+
+    test "handled_errors/0 returns list of exception modules" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      errors = Adapter.handled_errors(adapter)
+      assert is_list(errors)
+      assert Postgrex.Error in errors
+    end
+  end
+end

--- a/test/lotus/source/resolvers/static_test.exs
+++ b/test/lotus/source/resolvers/static_test.exs
@@ -1,0 +1,142 @@
+defmodule Lotus.Source.Resolvers.StaticTest do
+  use Lotus.Case, async: true
+
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
+  alias Lotus.Source.Resolvers.Static
+
+  describe "resolve/2" do
+    test "repo_opt as string finds adapter by name" do
+      assert {:ok, adapter} = Static.resolve("postgres", nil)
+      assert adapter == EctoAdapter.wrap("postgres", Lotus.Test.Repo)
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
+    end
+
+    test "repo_opt as string finds another adapter by name" do
+      assert {:ok, adapter} = Static.resolve("sqlite", nil)
+      assert adapter == EctoAdapter.wrap("sqlite", Lotus.Test.SqliteRepo)
+    end
+
+    test "repo_opt as module finds adapter by reverse lookup" do
+      assert {:ok, adapter} = Static.resolve(Lotus.Test.Repo, nil)
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
+    end
+
+    test "repo_opt as different module finds adapter by reverse lookup" do
+      assert {:ok, adapter} = Static.resolve(Lotus.Test.SqliteRepo, nil)
+      assert adapter.name == "sqlite"
+      assert adapter.state == Lotus.Test.SqliteRepo
+    end
+
+    test "fallback as string finds adapter by name when repo_opt is nil" do
+      assert {:ok, adapter} = Static.resolve(nil, "mysql")
+      assert adapter.name == "mysql"
+      assert adapter.state == Lotus.Test.MysqlRepo
+    end
+
+    test "fallback as module finds adapter by reverse lookup when repo_opt is nil" do
+      assert {:ok, adapter} = Static.resolve(nil, Lotus.Test.MysqlRepo)
+      assert adapter.name == "mysql"
+      assert adapter.state == Lotus.Test.MysqlRepo
+    end
+
+    test "returns default source when both are nil" do
+      assert {:ok, adapter} = Static.resolve(nil, nil)
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
+    end
+
+    test "repo_opt string takes precedence over fallback" do
+      assert {:ok, adapter} = Static.resolve("sqlite", "mysql")
+      assert adapter.name == "sqlite"
+    end
+
+    test "repo_opt module takes precedence over fallback string" do
+      assert {:ok, adapter} = Static.resolve(Lotus.Test.SqliteRepo, "mysql")
+      assert adapter.name == "sqlite"
+    end
+
+    test "unknown string name returns error" do
+      assert {:error, :not_found} = Static.resolve("unknown", nil)
+    end
+
+    test "unknown string fallback returns error when repo_opt is nil" do
+      assert {:error, :not_found} = Static.resolve(nil, "nonexistent")
+    end
+
+    test "unconfigured module returns error" do
+      defmodule UnknownRepo do
+        def __adapter__, do: Ecto.Adapters.Postgres
+      end
+
+      assert {:error, :not_found} = Static.resolve(UnknownRepo, nil)
+    end
+
+    test "non-repo module in repo_opt falls through to fallback" do
+      assert {:ok, adapter} = Static.resolve(String, "sqlite")
+      assert adapter.name == "sqlite"
+    end
+
+    test "non-repo atoms in both positions fall through to default" do
+      assert {:ok, adapter} = Static.resolve(String, Enum)
+      assert adapter.name == "postgres"
+    end
+
+    test "non-atom, non-string values fall through to default" do
+      assert {:ok, adapter} = Static.resolve(123, :atom)
+      assert adapter.name == "postgres"
+    end
+  end
+
+  describe "list_sources/0" do
+    test "returns all configured repos as adapters" do
+      adapters = Static.list_sources()
+      names = Enum.map(adapters, & &1.name) |> Enum.sort()
+
+      assert "mysql" in names
+      assert "postgres" in names
+      assert "sqlite" in names
+
+      Enum.each(adapters, fn adapter ->
+        assert %Lotus.Source.Adapter{} = adapter
+        assert adapter.module == EctoAdapter
+      end)
+    end
+  end
+
+  describe "get_source!/1" do
+    test "returns adapter for configured name" do
+      adapter = Static.get_source!("postgres")
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
+    end
+
+    test "raises for unknown name" do
+      assert_raise ArgumentError, ~r/Data repo 'unknown' not configured/, fn ->
+        Static.get_source!("unknown")
+      end
+    end
+  end
+
+  describe "list_source_names/0" do
+    test "returns name strings" do
+      names = Static.list_source_names() |> Enum.sort()
+      assert "mysql" in names
+      assert "postgres" in names
+      assert "sqlite" in names
+    end
+  end
+
+  describe "default_source/0" do
+    test "returns the default as {name, adapter} tuple" do
+      {name, adapter} = Static.default_source()
+      assert is_binary(name)
+      assert %Lotus.Source.Adapter{} = adapter
+      assert adapter.name == name
+      # Default is "postgres" per test config
+      assert name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
+    end
+  end
+end

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -227,13 +227,6 @@ defmodule Lotus.SourcesTest do
       assert Sources.supports_feature?(:sqlite, :json) == true
     end
 
-    test "tds features" do
-      assert Sources.supports_feature?(:tds, :search_path) == false
-      assert Sources.supports_feature?(:tds, :make_interval) == false
-      assert Sources.supports_feature?(:tds, :arrays) == false
-      assert Sources.supports_feature?(:tds, :json) == false
-    end
-
     test "unknown source type returns false for all features" do
       assert Sources.supports_feature?(:unknown, :search_path) == false
       assert Sources.supports_feature?(:unknown, :make_interval) == false
@@ -245,7 +238,7 @@ defmodule Lotus.SourcesTest do
       assert Sources.supports_feature?(:postgres, :unknown_feature) == false
       assert Sources.supports_feature?(:mysql, :unknown_feature) == false
       assert Sources.supports_feature?(:sqlite, :unknown_feature) == false
-      assert Sources.supports_feature?(:tds, :unknown_feature) == false
+      assert Sources.supports_feature?(:other, :unknown_feature) == false
     end
   end
 end

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -1,91 +1,105 @@
 defmodule Lotus.SourcesTest do
   use Lotus.Case, async: true
 
+  alias Lotus.Source.Adapter
   alias Lotus.Sources
 
   describe "resolve!/2" do
     test "resolves with string repo_opt" do
-      {repo_module, repo_name} = Sources.resolve!("postgres", nil)
-      assert repo_module == Lotus.Test.Repo
-      assert repo_name == "postgres"
+      adapter = Sources.resolve!("postgres", nil)
+      assert %Adapter{} = adapter
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
+      assert adapter.source_type == :postgres
     end
 
     test "resolves with another string repo_opt" do
-      {repo_module, repo_name} = Sources.resolve!("sqlite", nil)
-      assert repo_module == Lotus.Test.SqliteRepo
-      assert repo_name == "sqlite"
+      adapter = Sources.resolve!("sqlite", nil)
+      assert %Adapter{} = adapter
+      assert adapter.name == "sqlite"
+      assert adapter.state == Lotus.Test.SqliteRepo
     end
 
     test "resolves with module repo_opt" do
-      {repo_module, repo_name} = Sources.resolve!(Lotus.Test.Repo, nil)
-      assert repo_module == Lotus.Test.Repo
-      assert repo_name == "postgres"
+      adapter = Sources.resolve!(Lotus.Test.Repo, nil)
+      assert %Adapter{} = adapter
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
     end
 
     test "resolves with different module repo_opt" do
-      {repo_module, repo_name} = Sources.resolve!(Lotus.Test.SqliteRepo, nil)
-      assert repo_module == Lotus.Test.SqliteRepo
-      assert repo_name == "sqlite"
+      adapter = Sources.resolve!(Lotus.Test.SqliteRepo, nil)
+      assert %Adapter{} = adapter
+      assert adapter.name == "sqlite"
+      assert adapter.state == Lotus.Test.SqliteRepo
     end
 
     test "falls back to string q_repo when repo_opt is nil" do
-      {repo_module, repo_name} = Sources.resolve!(nil, "mysql")
-      assert repo_module == Lotus.Test.MysqlRepo
-      assert repo_name == "mysql"
+      adapter = Sources.resolve!(nil, "mysql")
+      assert %Adapter{} = adapter
+      assert adapter.name == "mysql"
+      assert adapter.state == Lotus.Test.MysqlRepo
     end
 
     test "falls back to module q_repo when repo_opt is nil" do
-      {repo_module, repo_name} = Sources.resolve!(nil, Lotus.Test.MysqlRepo)
-      assert repo_module == Lotus.Test.MysqlRepo
-      assert repo_name == "mysql"
+      adapter = Sources.resolve!(nil, Lotus.Test.MysqlRepo)
+      assert %Adapter{} = adapter
+      assert adapter.name == "mysql"
+      assert adapter.state == Lotus.Test.MysqlRepo
     end
 
     test "falls back to default repo when both are nil" do
-      {repo_module, repo_name} = Sources.resolve!(nil, nil)
-      assert repo_module == Lotus.Test.Repo
-      assert repo_name == "postgres"
+      adapter = Sources.resolve!(nil, nil)
+      assert %Adapter{} = adapter
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
     end
 
     test "repo_opt takes precedence over q_repo" do
-      {repo_module, repo_name} = Sources.resolve!("sqlite", "mysql")
-      assert repo_module == Lotus.Test.SqliteRepo
-      assert repo_name == "sqlite"
+      adapter = Sources.resolve!("sqlite", "mysql")
+      assert %Adapter{} = adapter
+      assert adapter.name == "sqlite"
+      assert adapter.state == Lotus.Test.SqliteRepo
     end
 
     test "repo_opt module takes precedence over q_repo string" do
-      {repo_module, repo_name} = Sources.resolve!(Lotus.Test.SqliteRepo, "mysql")
-      assert repo_module == Lotus.Test.SqliteRepo
-      assert repo_name == "sqlite"
+      adapter = Sources.resolve!(Lotus.Test.SqliteRepo, "mysql")
+      assert %Adapter{} = adapter
+      assert adapter.name == "sqlite"
+      assert adapter.state == Lotus.Test.SqliteRepo
     end
 
     test "raises when string repo_opt is not configured" do
-      assert_raise ArgumentError, ~r/Data repo 'unknown' not configured/, fn ->
+      assert_raise ArgumentError, ~r/not configured/, fn ->
         Sources.resolve!("unknown", nil)
       end
     end
 
     test "raises when string q_repo is not configured and repo_opt is nil" do
-      assert_raise ArgumentError, ~r/Data repo 'nonexistent' not configured/, fn ->
+      assert_raise ArgumentError, ~r/not configured/, fn ->
         Sources.resolve!(nil, "nonexistent")
       end
     end
 
     test "non-repo module in repo_opt falls through to q_repo" do
-      {repo_module, repo_name} = Sources.resolve!(String, "sqlite")
-      assert repo_module == Lotus.Test.SqliteRepo
-      assert repo_name == "sqlite"
+      adapter = Sources.resolve!(String, "sqlite")
+      assert %Adapter{} = adapter
+      assert adapter.name == "sqlite"
+      assert adapter.state == Lotus.Test.SqliteRepo
     end
 
     test "non-repo module in q_repo falls through to default" do
-      {repo_module, repo_name} = Sources.resolve!(String, Enum)
-      assert repo_module == Lotus.Test.Repo
-      assert repo_name == "postgres"
+      adapter = Sources.resolve!(String, Enum)
+      assert %Adapter{} = adapter
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
     end
 
     test "handles invalid types gracefully" do
-      {repo_module, repo_name} = Sources.resolve!(123, :atom)
-      assert repo_module == Lotus.Test.Repo
-      assert repo_name == "postgres"
+      adapter = Sources.resolve!(123, :atom)
+      assert %Adapter{} = adapter
+      assert adapter.name == "postgres"
+      assert adapter.state == Lotus.Test.Repo
     end
   end
 
@@ -132,6 +146,11 @@ defmodule Lotus.SourcesTest do
       assert Sources.source_type(Lotus.Test.MysqlRepo) == :mysql
     end
 
+    test "detects source type from adapter struct" do
+      adapter = Sources.resolve!("postgres", nil)
+      assert Sources.source_type(adapter) == :postgres
+    end
+
     test "raises for unknown repo name" do
       assert_raise ArgumentError, ~r/Data repo 'unknown' not configured/, fn ->
         Sources.source_type("unknown")
@@ -146,6 +165,43 @@ defmodule Lotus.SourcesTest do
       end
 
       assert Sources.source_type(CustomAdapterRepo) == :other
+    end
+  end
+
+  describe "list_sources/0" do
+    test "returns all configured sources as adapters" do
+      adapters = Sources.list_sources()
+      names = Enum.map(adapters, & &1.name) |> Enum.sort()
+
+      assert "mysql" in names
+      assert "postgres" in names
+      assert "sqlite" in names
+
+      Enum.each(adapters, fn adapter ->
+        assert %Adapter{} = adapter
+      end)
+    end
+  end
+
+  describe "get_source!/1" do
+    test "returns adapter for configured name" do
+      adapter = Sources.get_source!("postgres")
+      assert %Adapter{} = adapter
+      assert adapter.name == "postgres"
+    end
+
+    test "raises for unknown name" do
+      assert_raise ArgumentError, ~r/Data repo 'unknown' not configured/, fn ->
+        Sources.get_source!("unknown")
+      end
+    end
+  end
+
+  describe "default_source/0" do
+    test "returns the default source as adapter" do
+      adapter = Sources.default_source()
+      assert %Adapter{} = adapter
+      assert adapter.name == "postgres"
     end
   end
 

--- a/test/lotus/telemetry_test.exs
+++ b/test/lotus/telemetry_test.exs
@@ -3,7 +3,10 @@ defmodule Lotus.TelemetryTest do
 
   alias Lotus.Fixtures
   alias Lotus.Runner
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
   alias Lotus.Test.Repo
+
+  @pg_adapter EctoAdapter.wrap("postgres", Repo)
 
   setup do
     fixtures = Fixtures.setup_test_data()
@@ -24,13 +27,13 @@ defmodule Lotus.TelemetryTest do
         nil
       )
 
-      {:ok, _result} = Runner.run_sql(Repo, "SELECT 1 AS num")
+      {:ok, _result} = Runner.run_sql(@pg_adapter, "SELECT 1 AS num")
 
       assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
-                       %{repo: Repo, sql: "SELECT 1 AS num"}}
+                       %{repo: "postgres", sql: "SELECT 1 AS num"}}
 
       assert_received {:telemetry, [:lotus, :query, :stop], measurements,
-                       %{repo: Repo, sql: "SELECT 1 AS num", result: %Lotus.Result{}}}
+                       %{repo: "postgres", sql: "SELECT 1 AS num", result: %Lotus.Result{}}}
 
       assert is_integer(measurements.duration)
       assert measurements.duration >= 0
@@ -52,13 +55,13 @@ defmodule Lotus.TelemetryTest do
         nil
       )
 
-      {:error, _} = Runner.run_sql(Repo, "DROP TABLE test_users")
+      {:error, _} = Runner.run_sql(@pg_adapter, "DROP TABLE test_users")
 
       assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
-                       %{repo: Repo, sql: "DROP TABLE test_users"}}
+                       %{repo: "postgres", sql: "DROP TABLE test_users"}}
 
       assert_received {:telemetry, [:lotus, :query, :exception], measurements,
-                       %{kind: :error, repo: Repo, sql: "DROP TABLE test_users"}}
+                       %{kind: :error, repo: "postgres", sql: "DROP TABLE test_users"}}
 
       assert is_integer(measurements.duration)
 

--- a/test/lotus/visibility/resolvers/static_test.exs
+++ b/test/lotus/visibility/resolvers/static_test.exs
@@ -1,0 +1,311 @@
+defmodule Lotus.Visibility.Resolvers.StaticTest do
+  use ExUnit.Case
+  use Mimic
+
+  alias Lotus.Visibility.Resolvers.Static
+
+  setup do
+    Mimic.copy(Lotus.Config)
+    :ok
+  end
+
+  describe "schema_rules_for/1" do
+    test "returns schema rules for configured repo name" do
+      schema_rules = [
+        allow: ["public", "analytics"],
+        deny: ["restricted"]
+      ]
+
+      Lotus.Config
+      |> stub(:schema_rules_for_repo_name, fn repo_name ->
+        if repo_name == "postgres", do: schema_rules, else: []
+      end)
+
+      assert Static.schema_rules_for("postgres") == schema_rules
+    end
+
+    test "falls back to default rules for unknown repo names" do
+      default_rules = [allow: ["public"], deny: []]
+
+      Lotus.Config
+      |> stub(:schema_rules_for_repo_name, fn _repo_name -> default_rules end)
+
+      assert Static.schema_rules_for("unknown_repo") == default_rules
+    end
+
+    test "returns empty list when no rules configured" do
+      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> [] end)
+
+      assert Static.schema_rules_for("postgres") == []
+      assert Static.schema_rules_for("mysql") == []
+    end
+
+    test "handles regex patterns in rules" do
+      schema_rules = [
+        allow: [~r/^tenant_/],
+        deny: [~r/^temp_/]
+      ]
+
+      Lotus.Config
+      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
+
+      assert Static.schema_rules_for("postgres") == schema_rules
+    end
+  end
+
+  describe "table_rules_for/1" do
+    test "returns table rules for configured repo name" do
+      table_rules = [
+        allow: [
+          {"public", "users"},
+          {"public", ~r/^dim_/}
+        ],
+        deny: ["api_keys"]
+      ]
+
+      Lotus.Config
+      |> stub(:rules_for_repo_name, fn repo_name ->
+        if repo_name == "postgres", do: table_rules, else: []
+      end)
+
+      assert Static.table_rules_for("postgres") == table_rules
+    end
+
+    test "falls back to default rules for unknown repo names" do
+      default_rules = [allow: [], deny: ["sensitive_data"]]
+
+      Lotus.Config
+      |> stub(:rules_for_repo_name, fn _repo_name -> default_rules end)
+
+      assert Static.table_rules_for("unknown_repo") == default_rules
+    end
+
+    test "returns empty list when no rules configured" do
+      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> [] end)
+
+      assert Static.table_rules_for("postgres") == []
+      assert Static.table_rules_for("mysql") == []
+    end
+
+    test "supports various rule formats" do
+      table_rules = [
+        allow: [
+          "public_table",
+          {"schema", "table"},
+          {nil, "sqlite_table"},
+          {"schema", ~r/^dim_/}
+        ],
+        deny: [~r/^temp_/]
+      ]
+
+      Lotus.Config
+      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
+
+      assert Static.table_rules_for("postgres") == table_rules
+    end
+  end
+
+  describe "column_rules_for/1" do
+    test "returns column rules for configured repo name" do
+      column_rules = [
+        {nil, "passwords", :omit},
+        {"public", "users", "ssn", :mask},
+        {"public", "users", "email", [action: :mask, mask: :sha256]}
+      ]
+
+      Lotus.Config
+      |> stub(:column_rules_for_repo_name, fn repo_name ->
+        if repo_name == "postgres", do: column_rules, else: []
+      end)
+
+      assert Static.column_rules_for("postgres") == column_rules
+    end
+
+    test "falls back to default rules for unknown repo names" do
+      default_rules = [
+        {nil, ~r/^api_/, :omit}
+      ]
+
+      Lotus.Config
+      |> stub(:column_rules_for_repo_name, fn _repo_name -> default_rules end)
+
+      assert Static.column_rules_for("unknown_repo") == default_rules
+    end
+
+    test "returns empty list when no rules configured" do
+      Lotus.Config |> stub(:column_rules_for_repo_name, fn _repo_name -> [] end)
+
+      assert Static.column_rules_for("postgres") == []
+      assert Static.column_rules_for("mysql") == []
+    end
+
+    test "handles complex masking policies" do
+      column_rules = [
+        {nil, "passwords", [action: :mask, mask: :null]},
+        {"public", "credit_cards",
+         [
+           action: :mask,
+           mask: {:partial, keep_last: 4, replacement: "*"},
+           show_in_schema?: false
+         ]},
+        {nil, ~r/^internal_/, :error}
+      ]
+
+      Lotus.Config
+      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+
+      assert Static.column_rules_for("postgres") == column_rules
+    end
+  end
+
+  describe "behaviour compliance" do
+    test "implements Lotus.Visibility.Resolver behaviour" do
+      assert :lists.member(
+               Lotus.Visibility.Resolver,
+               Static.__info__(:attributes) |> Keyword.get(:behaviour, [])
+             )
+    end
+
+    test "has all required callbacks" do
+      required_callbacks = [
+        {:schema_rules_for, 1},
+        {:table_rules_for, 1},
+        {:column_rules_for, 1}
+      ]
+
+      exported_functions = Static.__info__(:functions)
+
+      Enum.each(required_callbacks, fn {name, arity} ->
+        assert {name, arity} in exported_functions,
+               "Missing required callback #{name}/#{arity}"
+      end)
+    end
+  end
+
+  describe "realistic configuration scenarios" do
+    test "typical data warehouse setup" do
+      schema_rules = [
+        allow: ["public", "analytics", ~r/^tenant_/],
+        deny: ["staging"]
+      ]
+
+      table_rules = [
+        allow: [
+          {"public", ~r/^dim_/},
+          {"public", ~r/^fact_/},
+          {"analytics", ~r/.*/}
+        ],
+        deny: [
+          {"public", ~r/^staging_/},
+          {"public", ~r/_temp$/}
+        ]
+      ]
+
+      column_rules = [
+        {nil, "api_keys", :omit},
+        {nil, "passwords", [action: :mask, mask: :null]},
+        {"public", "users", "ssn", :mask}
+      ]
+
+      Lotus.Config
+      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
+      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
+      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+
+      assert Static.schema_rules_for("postgres") == schema_rules
+      assert Static.table_rules_for("postgres") == table_rules
+      assert Static.column_rules_for("postgres") == column_rules
+    end
+
+    test "simple business database with basic deny rules" do
+      schema_rules = [allow: [], deny: []]
+
+      table_rules = [
+        allow: [],
+        deny: [
+          "user_passwords",
+          ~r/^audit_/,
+          ~r/_log$/
+        ]
+      ]
+
+      column_rules = [
+        {nil, "credit_cards", :omit},
+        {nil, "social_security_number", :omit}
+      ]
+
+      Lotus.Config
+      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
+      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
+      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+
+      assert Static.schema_rules_for("postgres") == schema_rules
+      assert Static.table_rules_for("postgres") == table_rules
+      assert Static.column_rules_for("postgres") == column_rules
+    end
+
+    test "multi-database MySQL setup" do
+      schema_rules = [
+        allow: ["app_db", "analytics_db"],
+        deny: ["staging_db", "test_db"]
+      ]
+
+      table_rules = [
+        allow: [
+          {"app_db", ~r/.*/},
+          {"analytics_db", ~r/.*/}
+        ],
+        deny: []
+      ]
+
+      column_rules = []
+
+      Lotus.Config
+      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
+      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
+      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+
+      assert Static.schema_rules_for("mysql") == schema_rules
+      assert Static.table_rules_for("mysql") == table_rules
+      assert Static.column_rules_for("mysql") == column_rules
+    end
+  end
+
+  describe "consistency with Config functions" do
+    test "schema_rules_for delegates directly to Config.schema_rules_for_repo_name" do
+      test_rules = [allow: ["public"], deny: []]
+
+      Lotus.Config
+      |> stub(:schema_rules_for_repo_name, fn repo_name ->
+        if repo_name == "test_repo", do: test_rules, else: []
+      end)
+
+      result = Static.schema_rules_for("test_repo")
+      assert result == test_rules
+    end
+
+    test "table_rules_for delegates directly to Config.rules_for_repo_name" do
+      test_rules = [allow: [{"public", "users"}], deny: []]
+
+      Lotus.Config
+      |> stub(:rules_for_repo_name, fn repo_name ->
+        if repo_name == "test_repo", do: test_rules, else: []
+      end)
+
+      result = Static.table_rules_for("test_repo")
+      assert result == test_rules
+    end
+
+    test "column_rules_for delegates directly to Config.column_rules_for_repo_name" do
+      test_rules = [{nil, "passwords", :omit}]
+
+      Lotus.Config
+      |> stub(:column_rules_for_repo_name, fn repo_name ->
+        if repo_name == "test_repo", do: test_rules, else: []
+      end)
+
+      result = Static.column_rules_for("test_repo")
+      assert result == test_rules
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Lotus currently hardcodes data source resolution to static `data_repos` config mapping string names to Ecto.Repo modules. Every module in the pipeline — Runner, Schema, Visibility, Preflight — takes a raw Ecto.Repo module directly. This makes it impossible to:

- Resolve sources from alternative backends (registries, databases, external services)
- Support non-Ecto data sources (REST APIs, BigQuery, Snowflake, etc.) without rewriting the entire pipeline
- Swap visibility rule providers at runtime

This PR introduces a **pluggable adapter abstraction** that decouples the pipeline from Ecto.Repo and provides extension points for alternative source and visibility resolution.

## Design

### The Adapter (`Lotus.Source.Adapter`)

A behaviour + struct that wraps any data source behind a uniform interface:

```elixir
%Lotus.Source.Adapter{
  name: "primary",                    # string identifier
  module: Lotus.Source.Adapters.Ecto, # behaviour implementation
  state: MyApp.Repo,                  # opaque, adapter-specific state
  source_type: :postgres              # database type for SQL dialect
}
```

**21 callbacks** covering query execution, introspection, SQL generation, safety/visibility, lifecycle, and error handling. Introspection callbacks return `{:ok, _} | {:error, _}` tuples consistently (unlike the bare-value returns in the existing `Lotus.Source` behaviour), so future adapters for unreliable sources can propagate errors cleanly.

### Pluggable Resolvers

Two new behaviours for extension points:

- **`Lotus.Source.Resolver`** (5 callbacks) — resolves source names/modules to adapter structs. Default `Resolvers.Static` reads from `data_repos` config.
- **`Lotus.Visibility.Resolver`** (3 callbacks) — resolves visibility rules per source. Default `Resolvers.Static` reads from static config.

Configured via:
```elixir
config :lotus,
  source_resolver: Lotus.Source.Resolvers.Static,      # default
  visibility_resolver: Lotus.Visibility.Resolvers.Static # default
```

### Default Ecto Adapter

`Lotus.Source.Adapters.Ecto` wraps any Ecto.Repo module transparently by delegating to the existing `Lotus.Sources.Postgres/MySQL/SQLite3/Default` implementations. **Zero change required for existing users** — static `data_repos` config works identically.

## What Changed

### New files (6 modules + tests)

| Module | Purpose |
|--------|---------|
| `Lotus.Source.Adapter` | Behaviour (21 callbacks) + struct + dispatch helpers |
| `Lotus.Source.Resolver` | Behaviour for pluggable source resolution |
| `Lotus.Source.Resolvers.Static` | Default resolver from static config |
| `Lotus.Source.Adapters.Ecto` | Wraps Ecto.Repo in adapter interface |
| `Lotus.Visibility.Resolver` | Behaviour for pluggable visibility rules |
| `Lotus.Visibility.Resolvers.Static` | Default from static config |

### Modified files (pipeline migration)

| Module | Change |
|--------|--------|
| `Config` | Added `:source_resolver` and `:visibility_resolver` keys |
| `Sources` | Delegates to configurable resolver, returns `%Adapter{}` |
| `Lotus` (public API) | Resolves to adapter, passes downstream (public signatures unchanged) |
| `Runner` | Accepts adapter, dispatches through `Adapter.*` callbacks |
| `Visibility` | Delegates rule lookups to visibility resolver, uses adapter for builtin denies |
| `Schema` | Uses adapter for introspection, `effective_schemas`, `get_table_stats`, quoting |
| `Preflight` | Routes all DB operations through adapter interface |
| `Source` | Added adapter-aware dispatch overloads, existing impls unchanged |

### Unchanged

- `Lotus.Sources.Postgres`, `MySQL`, `SQLite3`, `Default` — still the DB-specific implementation layer
- `Middleware`, `Cache`, `Telemetry`, `Supervisor` — unaffected
- **All public API signatures** (`Lotus.run_query/2`, `Lotus.run_sql/3`, `Lotus.list_schemas/2`, etc.)

## Breaking Changes (internal API)

See CHANGELOG for full list. Key changes:

- `Sources.resolve!/2` returns `%Adapter{}` instead of `{module, name}` tuple
- `Runner.run_sql/4` accepts `%Adapter{}` instead of repo module
- `Preflight.authorize` accepts `%Adapter{}` instead of `(repo, repo_name)`
- Source behaviour SQL generation callbacks now take `state` as first argument

These are **internal API** changes. The public `Lotus.*` function signatures are unchanged.

## Testing

- **1589 tests, 0 failures** (up from 1585 — new adapter/resolver tests added)
- All existing tests updated to pass adapter structs where needed
- New test suites: `adapter_test.exs`, `adapters/ecto_test.exs`, `resolvers/static_test.exs`, `visibility/resolvers/static_test.exs`
- Zero warnings with `--warnings-as-errors`

## Documentation

- New guide: `guides/source-adapters.md`
- CHANGELOG updated with Breaking and Added sections
- README updated with brief adapter mention

## How to Review

Recommended review order:

1. **`lib/lotus/source/adapter.ex`** — the core abstraction (behaviour + struct + dispatch)
2. **`lib/lotus/source/resolver.ex`** + **`lib/lotus/visibility/resolver.ex`** — the two extension point behaviours
3. **`lib/lotus/source/adapters/ecto.ex`** — how Ecto.Repo is wrapped (the `impl_for` delegation pattern)
4. **`lib/lotus/source/resolvers/static.ex`** — how the default resolution preserves existing priority logic
5. **`lib/lotus/sources.ex`** — how the existing module delegates to the resolver
6. **`lib/lotus/runner.ex`** + **`lib/lotus/preflight.ex`** — the security-critical pipeline changes
7. **`lib/lotus/schema.ex`** + **`lib/lotus/visibility.ex`** — introspection and visibility migration