### PR TITLE
Remove duplicated trim_trailing_semicolon in favor of Sanitizer (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - **BREAKING:** `FilterInjector.apply/3` is now `apply/5` — accepts `params` (existing parameter list) and `placeholder_fn` (database-specific placeholder generator), returns `{sql, params}` tuple instead of a plain SQL string
 - **BREAKING:** `Lotus.Source.apply_filters/2` callback is now `apply_filters/3` — accepts `params` list and returns `{sql, params}` tuple. All source adapters (Postgres, MySQL, SQLite3, Default) updated accordingly
 - Removed `FilterInjector.quote_value/1` — no longer needed since values are parameterized
+- **REFACTOR:** Remove duplicated private `Lotus.trim_trailing_semicolon/1` in favor of `Lotus.SQL.Sanitizer.strip_trailing_semicolon/1`, eliminating code duplication and a redundant double-trim in the window pagination path (#155)
 
 ## [0.16.4] - 2026-03-10
 

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -850,8 +850,9 @@ defmodule Lotus do
   defp maybe_apply_window(sql, params, adapter, search_path, window_opts)
        when is_list(window_opts) do
     alias Lotus.Source.Adapter
+    alias Lotus.SQL.Sanitizer
 
-    base_sql = trim_trailing_semicolon(sql)
+    base_sql = Sanitizer.strip_trailing_semicolon(sql)
     limit = resolve_window_limit(window_opts)
     offset = Keyword.get(window_opts, :offset, 0)
     count_mode = Keyword.get(window_opts, :count, :none)
@@ -950,17 +951,4 @@ defmodule Lotus do
 
   defp parse_count_result({:ok, %Result{rows: _}}), do: {:error, :invalid_count}
   defp parse_count_result(other), do: other
-
-  defp trim_trailing_semicolon(sql) do
-    s = String.trim(sql)
-
-    if String.ends_with?(s, ";") do
-      s
-      |> String.trim_trailing()
-      |> String.trim_trailing(";")
-      |> String.trim_trailing()
-    else
-      s
-    end
-  end
 end


### PR DESCRIPTION
Replace the private `Lotus.trim_trailing_semicolon/1` (which also had a redundant double-trim) with the existing `Lotus.SQL.Sanitizer.strip_trailing_semicolon/1` already used by `FilterInjector` and `SortInjector`. Single source of truth for trailing-semicolon stripping in the window pagination path.

Closes #155 