### PR TITLE
Add :preload option to list_dashboards/1 and list_dashboards_by/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Added
 
+- `:preload` option on `Lotus.Dashboards.list_dashboards/1` and `list_dashboards_by/1` for eager-loading associations (e.g. `:cards`) in a single query. Fixes N+1 patterns in callers that need card counts or card lists alongside the dashboard list (see typhoonworks/lotus_web#103).
 - Pluggable source adapter abstraction (`Lotus.Source.Adapter`) — behaviour and struct wrapping data sources behind a uniform callback interface with consistent `{:ok, _} | {:error, _}` return types
 - `Lotus.Source.Resolver` behaviour for configurable source resolution
 - `Lotus.Visibility.Resolver` behaviour for configurable visibility rule resolution
@@ -27,6 +28,7 @@
 
 ### Fixed
 
+- **FIX:** Propagate `Repo.transaction/1` errors from `Dashboards.reorder_dashboard_cards/2` instead of unconditionally returning `:ok`. Spec updated to `:ok | {:error, term()}` (#157)
 - **FIX:** Use `Task.Supervisor` instead of bare `Task.async` for dashboard card execution, ensuring proper OTP supervision and fault tolerance. Added `Lotus.TaskSupervisor` to the supervision tree.
 - **PERF:** Cache validated `Lotus.Config` in `:persistent_term` to avoid repeated `NimbleOptions.validate/2` on every accessor call. Config is eagerly validated once at boot from `Lotus.Supervisor.init/1`; a new `Lotus.Config.reload!/0` refreshes the cached value when the application environment changes (e.g. in tests) (#154)
 - **DOCS:** Clarify in the installation and caching guides that Lotus's supervisor starts automatically with the `:lotus` OTP application — consumers do not need to add `Lotus` to their own supervision tree to enable caching

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -182,8 +182,12 @@ defmodule Lotus do
 
   @doc """
   Lists all dashboards.
+
+  ## Options
+
+    * `:preload` - A list of associations to preload (e.g., `[:cards]`)
   """
-  defdelegate list_dashboards(), to: Dashboards
+  defdelegate list_dashboards(opts \\ []), to: Dashboards
 
   @doc """
   Lists dashboards with optional filtering.

--- a/lib/lotus/dashboards.ex
+++ b/lib/lotus/dashboards.ex
@@ -39,10 +39,25 @@ defmodule Lotus.Dashboards do
   Lists all dashboards.
 
   Returns dashboards ordered by name.
+
+  ## Options
+
+    * `:preload` - A list of associations to preload (e.g., `[:cards]`)
+
+  ## Examples
+
+      iex> list_dashboards()
+      [%Dashboard{}, ...]
+
+      iex> list_dashboards(preload: [:cards])
+      [%Dashboard{cards: [%DashboardCard{}, ...]}, ...]
+
   """
-  @spec list_dashboards() :: [Dashboard.t()]
-  def list_dashboards do
-    from(d in Dashboard, order_by: [asc: d.name])
+  @spec list_dashboards(keyword()) :: [Dashboard.t()]
+  def list_dashboards(opts \\ []) do
+    preloads = Keyword.get(opts, :preload, [])
+
+    from(d in Dashboard, order_by: [asc: d.name], preload: ^preloads)
     |> Lotus.repo().all()
   end
 
@@ -52,16 +67,21 @@ defmodule Lotus.Dashboards do
   ## Options
 
     * `:search` - Search term to match against dashboard names (case insensitive)
+    * `:preload` - A list of associations to preload (e.g., `[:cards]`)
 
   ## Examples
 
       iex> list_dashboards_by(search: "sales")
       [%Dashboard{name: "Sales Overview"}, ...]
 
+      iex> list_dashboards_by(search: "sales", preload: [:cards])
+      [%Dashboard{name: "Sales Overview", cards: [...]}, ...]
+
   """
   @spec list_dashboards_by(keyword()) :: [Dashboard.t()]
   def list_dashboards_by(opts \\ []) do
-    q = from(d in Dashboard, order_by: [asc: d.name])
+    preloads = Keyword.get(opts, :preload, [])
+    q = from(d in Dashboard, order_by: [asc: d.name], preload: ^preloads)
 
     q =
       case Keyword.get(opts, :search) do
@@ -337,23 +357,24 @@ defmodule Lotus.Dashboards do
       :ok
 
   """
-  @spec reorder_dashboard_cards(Dashboard.t() | id(), [id()]) :: :ok
+  @spec reorder_dashboard_cards(Dashboard.t() | id(), [id()]) :: :ok | {:error, term()}
   def reorder_dashboard_cards(%Dashboard{id: id}, card_ids),
     do: reorder_dashboard_cards(id, card_ids)
 
   def reorder_dashboard_cards(dashboard_id, card_ids) when is_list(card_ids) do
-    Lotus.repo().transaction(fn ->
-      card_ids
-      |> Enum.with_index()
-      |> Enum.each(fn {card_id, position} ->
-        from(c in DashboardCard,
-          where: c.id == ^card_id and c.dashboard_id == ^dashboard_id
-        )
-        |> Lotus.repo().update_all(set: [position: position])
-      end)
-    end)
-
-    :ok
+    case Lotus.repo().transaction(fn ->
+           card_ids
+           |> Enum.with_index()
+           |> Enum.each(fn {card_id, position} ->
+             from(c in DashboardCard,
+               where: c.id == ^card_id and c.dashboard_id == ^dashboard_id
+             )
+             |> Lotus.repo().update_all(set: [position: position])
+           end)
+         end) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   # ── Filter CRUD ────────────────────────────────────────────────────────────

--- a/test/lotus/dashboards_test.exs
+++ b/test/lotus/dashboards_test.exs
@@ -12,7 +12,7 @@ defmodule Lotus.DashboardsTest do
     DashboardFilter
   }
 
-  describe "list_dashboards/0" do
+  describe "list_dashboards/1" do
     test "returns empty list when no dashboards exist" do
       assert [] == Dashboards.list_dashboards()
     end
@@ -28,6 +28,25 @@ defmodule Lotus.DashboardsTest do
 
       assert [%{name: "Alpha Dashboard"}, %{name: "Middle Dashboard"}, %{name: "Zebra Dashboard"}] =
                dashboards
+    end
+
+    test "does not preload :cards by default" do
+      dashboard = dashboard_fixture()
+      dashboard_card_fixture(dashboard)
+
+      [result] = Dashboards.list_dashboards()
+
+      assert %Ecto.Association.NotLoaded{} = result.cards
+    end
+
+    test "preloads :cards when requested" do
+      dashboard = dashboard_fixture()
+      dashboard_card_fixture(dashboard, %{position: 0})
+      dashboard_card_fixture(dashboard, %{position: 1})
+
+      [result] = Dashboards.list_dashboards(preload: [:cards])
+
+      assert [%DashboardCard{}, %DashboardCard{}] = result.cards
     end
   end
 
@@ -51,6 +70,25 @@ defmodule Lotus.DashboardsTest do
 
       results = Dashboards.list_dashboards_by([])
       assert length(results) == 2
+    end
+
+    test "does not preload :cards by default" do
+      dashboard = dashboard_fixture()
+      dashboard_card_fixture(dashboard)
+
+      [result] = Dashboards.list_dashboards_by([])
+
+      assert %Ecto.Association.NotLoaded{} = result.cards
+    end
+
+    test "preloads :cards when requested" do
+      dashboard = dashboard_fixture(%{name: "Preload Me"})
+      dashboard_card_fixture(dashboard, %{position: 0})
+      dashboard_card_fixture(dashboard, %{position: 1})
+
+      [result] = Dashboards.list_dashboards_by(search: "Preload", preload: [:cards])
+
+      assert [%DashboardCard{}, %DashboardCard{}] = result.cards
     end
   end
 
@@ -567,6 +605,14 @@ defmodule Lotus.DashboardsTest do
     test "delegates list_dashboards/0" do
       dashboard_fixture(%{name: "Delegated"})
       assert [%{name: "Delegated"}] = Lotus.list_dashboards()
+    end
+
+    test "delegates list_dashboards/1 with :preload option" do
+      dashboard = dashboard_fixture(%{name: "Delegated Preload"})
+      dashboard_card_fixture(dashboard)
+
+      assert [%Dashboard{cards: [%DashboardCard{} | _]}] =
+               Lotus.list_dashboards(preload: [:cards])
     end
 
     test "delegates create_dashboard/1" do


### PR DESCRIPTION
Adds a `:preload` option to `Lotus.Dashboards.list_dashboards/1` and `list_dashboards_by/1`, mirroring the existing `list_dashboard_cards/2` pattern. Eager-loads associations (e.g. `:cards`) in a single query, fixing N+1 patterns in callers that need card counts or card lists alongside the dashboard list (see typhoonworks/lotus_web#103).

Also propagates transaction errors out of `reorder_dashboard_cards/2` rather than swallowing them with a bare `:ok`.

Closes https://github.com/typhoonworks/lotus/issues/157