### PR TITLE
Fix/code quality issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - **BREAKING:** `Lotus.Source.apply_filters/2` callback is now `apply_filters/3` — accepts `params` list and returns `{sql, params}` tuple. All source adapters (Postgres, MySQL, SQLite3, Default) updated accordingly
 - Removed `FilterInjector.quote_value/1` — no longer needed since values are parameterized
 - **REFACTOR:** Remove duplicated private `Lotus.trim_trailing_semicolon/1` in favor of `Lotus.SQL.Sanitizer.strip_trailing_semicolon/1`, eliminating code duplication and a redundant double-trim in the window pagination path (#155)
+- **REFACTOR:** Extract shared filter → sort → window → cache → execute pipeline from `Lotus.run_sql/3` and `Lotus.execute_query/5` into a single private `execute_with_options/7` helper. `run_sql/3` now reuses `build_cache_tags/3` and `determine_cache_profile/1` instead of inlining the same logic. No public API or behavior changes (#160)
 
 ## [0.16.4] - 2026-03-10
 

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -439,9 +439,14 @@ defmodule Lotus do
 
   defp execute_query(q, sql, params, vars, opts) do
     adapter = Sources.resolve!(Keyword.get(opts, :repo), q.data_repo)
-
     search_path = Keyword.get(opts, :search_path) || q.search_path
-    final_opts = prepare_final_opts(opts, search_path)
+    runner_opts = prepare_final_opts(opts, search_path)
+
+    execute_with_options(adapter, sql, params, opts, runner_opts, vars, q.id)
+  end
+
+  defp execute_with_options(adapter, sql, params, opts, runner_opts, cache_identity, query_id) do
+    search_path = Keyword.get(runner_opts, :search_path)
 
     filters = Keyword.get(opts, :filters, [])
     {sql, params} = Lotus.Source.apply_filters(adapter, sql, params, filters)
@@ -458,12 +463,12 @@ defmodule Lotus do
         Keyword.get(opts, :window)
       )
 
-    key = result_key(sql, cache_bound || vars, adapter.name, search_path)
-    tags = build_cache_tags(q.id, adapter.name, opts)
+    key = result_key(sql, cache_bound || cache_identity, adapter.name, search_path)
+    tags = build_cache_tags(query_id, adapter.name, opts)
     profile = determine_cache_profile(opts)
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      with {:ok, %Result{} = res} <- Runner.run_sql(adapter, sql, params, final_opts) do
+      with {:ok, %Result{} = res} <- Runner.run_sql(adapter, sql, params, runner_opts) do
         {:ok, merge_window_meta(res, window_meta)}
       end
     end)
@@ -479,7 +484,11 @@ defmodule Lotus do
   end
 
   defp build_cache_tags(query_id, repo_name, opts) do
-    base_tags = ["query:#{query_id}", "repo:#{repo_name}"]
+    base_tags =
+      case query_id do
+        nil -> ["repo:#{repo_name}"]
+        id -> ["query:#{id}", "repo:#{repo_name}"]
+      end
 
     case opts[:cache] do
       cache_opts when is_list(cache_opts) -> base_tags ++ Keyword.get(cache_opts, :tags, [])
@@ -587,41 +596,7 @@ defmodule Lotus do
       |> Keyword.delete(:repo)
       |> Keyword.put_new_lazy(:read_only, &Config.read_only?/0)
 
-    search_path = Keyword.get(runner_opts, :search_path)
-
-    filters = Keyword.get(opts, :filters, [])
-    {sql, params} = Lotus.Source.apply_filters(adapter, sql, params, filters)
-
-    sorts = Keyword.get(opts, :sorts, [])
-    sql = Lotus.Source.apply_sorts(adapter, sql, sorts)
-
-    {sql, params, window_meta, cache_bound} =
-      maybe_apply_window(
-        sql,
-        params,
-        adapter,
-        search_path,
-        Keyword.get(opts, :window)
-      )
-
-    key = result_key(sql, cache_bound || params, adapter.name, search_path)
-
-    tags =
-      ["repo:#{adapter.name}"] ++
-        if is_list(opts[:cache]), do: Keyword.get(opts[:cache], :tags, []), else: []
-
-    profile =
-      if is_list(opts[:cache]) do
-        Keyword.get(opts[:cache], :profile, Config.default_cache_profile())
-      else
-        Config.default_cache_profile()
-      end
-
-    exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      with {:ok, %Result{} = res} <- Runner.run_sql(adapter, sql, params, runner_opts) do
-        {:ok, merge_window_meta(res, window_meta)}
-      end
-    end)
+    execute_with_options(adapter, sql, params, opts, runner_opts, params, nil)
   end
 
   @doc """

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -395,21 +395,7 @@ defmodule Lotus.Config do
   Falls back to default rules if repo-specific rules are not configured.
   """
   @spec rules_for_repo_name(String.t()) :: keyword()
-  def rules_for_repo_name(repo_name) do
-    config = load!()
-    visibility_config = config[:table_visibility] || %{}
-
-    repo_key = String.to_existing_atom(repo_name)
-
-    # Try repo-specific rules first, then default
-    visibility_config[repo_key] || visibility_config[:default] || []
-  rescue
-    ArgumentError ->
-      # If repo_name can't be converted to existing atom, use default
-      config = load!()
-      visibility_config = config[:table_visibility] || %{}
-      visibility_config[:default] || []
-  end
+  def rules_for_repo_name(repo_name), do: visibility_rules_for(:table_visibility, repo_name)
 
   @doc """
   Returns schema visibility rules for a specific repository.
@@ -417,19 +403,8 @@ defmodule Lotus.Config do
   Falls back to default rules if repo-specific rules are not configured.
   """
   @spec schema_rules_for_repo_name(String.t()) :: keyword()
-  def schema_rules_for_repo_name(repo_name) do
-    config = load!()
-    visibility_config = config[:schema_visibility] || %{}
-
-    repo_key = String.to_existing_atom(repo_name)
-
-    visibility_config[repo_key] || visibility_config[:default] || []
-  rescue
-    ArgumentError ->
-      config = load!()
-      visibility_config = config[:schema_visibility] || %{}
-      visibility_config[:default] || []
-  end
+  def schema_rules_for_repo_name(repo_name),
+    do: visibility_rules_for(:schema_visibility, repo_name)
 
   @doc """
   Returns column visibility rules for a specific repository.
@@ -437,18 +412,17 @@ defmodule Lotus.Config do
   Falls back to default rules if repo-specific rules are not configured.
   """
   @spec column_rules_for_repo_name(String.t()) :: list()
-  def column_rules_for_repo_name(repo_name) do
-    config = load!()
-    visibility_config = config[:column_visibility] || %{}
+  def column_rules_for_repo_name(repo_name),
+    do: visibility_rules_for(:column_visibility, repo_name)
 
-    repo_key = String.to_existing_atom(repo_name)
+  # Shared lookup for repo-keyed visibility maps. Matches the repo name
+  # string against map keys via `to_string/1`, then falls back to the
+  # `:default` entry, then to an empty list.
+  defp visibility_rules_for(key, repo_name) do
+    visibility_config = load!()[key] || %{}
+    repo_key = Enum.find(Map.keys(visibility_config), &(to_string(&1) == repo_name))
 
-    visibility_config[repo_key] || visibility_config[:default] || []
-  rescue
-    ArgumentError ->
-      config = load!()
-      visibility_config = config[:column_visibility] || %{}
-      visibility_config[:default] || []
+    (repo_key && visibility_config[repo_key]) || visibility_config[:default] || []
   end
 
   @doc """

--- a/lib/lotus/supervisor.ex
+++ b/lib/lotus/supervisor.ex
@@ -1,6 +1,27 @@
 defmodule Lotus.Supervisor do
   @moduledoc """
   Top-level supervisor for Lotus.
+
+  ## Configuration paths
+
+  Lotus can be started in two ways, and each resolves configuration differently:
+
+    * **As an OTP application** (via `Lotus.Application`) — the supervisor is
+      started with no opts, so `middleware` and `cache` are read from the
+      application environment (`Lotus.Config.middleware/0` and
+      `Lotus.Config.cache_config/0`). This is the default when `:lotus` is
+      started automatically as a dependency via its OTP application callback.
+
+    * **Embedded in a host supervision tree** (via `child_spec/1`) — opts
+      passed to `child_spec/1` (e.g. `middleware:`, `cache:`, `name:`) are
+      forwarded to `start_link/1` and override the application environment
+      values for that instance. This is the path to use when running multiple
+      Lotus instances or when you want per-instance configuration without
+      touching the application environment.
+
+  In both cases, opts passed directly to `start_link/1` take precedence over
+  application environment config; the `Application.start/2` path simply does
+  not pass any opts through.
   """
 
   use Supervisor

--- a/test/lotus/config_test.exs
+++ b/test/lotus/config_test.exs
@@ -3,14 +3,18 @@ defmodule Lotus.ConfigTest do
 
   alias Lotus.Config
 
+  @preserved_keys [:cache, :table_visibility, :schema_visibility, :column_visibility]
+
   setup do
-    original = Application.get_env(:lotus, :cache)
+    originals = Map.new(@preserved_keys, &{&1, Application.get_env(:lotus, &1)})
 
     on_exit(fn ->
-      if is_nil(original) do
-        Application.delete_env(:lotus, :cache)
-      else
-        Application.put_env(:lotus, :cache, original)
+      for {key, value} <- originals do
+        if is_nil(value) do
+          Application.delete_env(:lotus, key)
+        else
+          Application.put_env(:lotus, key, value)
+        end
       end
 
       Config.reload!()
@@ -44,5 +48,91 @@ defmodule Lotus.ConfigTest do
 
       assert Config.cache_namespace() == "my_app:v3"
     end
+  end
+
+  describe "visibility rules lookups" do
+    @variants [
+      {:rules_for_repo_name, :table_visibility},
+      {:schema_rules_for_repo_name, :schema_visibility},
+      {:column_rules_for_repo_name, :column_visibility}
+    ]
+
+    test "returns repo-specific rules when repo_name matches a configured key" do
+      rules = [deny: ["secret_table"]]
+
+      for {fun, key} <- @variants do
+        put_visibility(key, %{postgres: rules})
+
+        assert apply(Config, fun, ["postgres"]) == rules,
+               "#{fun} did not return repo-specific rules"
+      end
+    end
+
+    test "returns an empty list when the repo-specific value is an empty list" do
+      for {fun, key} <- @variants do
+        put_visibility(key, %{postgres: [], default: [deny: ["should_not_see"]]})
+
+        assert apply(Config, fun, ["postgres"]) == [],
+               "#{fun} did not return empty list for empty repo-specific value"
+      end
+    end
+
+    test "falls through to :default when the repo-specific value is nil" do
+      default_rules = [deny: ["default_rule"]]
+
+      for {fun, key} <- @variants do
+        put_visibility(key, %{postgres: nil, default: default_rules})
+
+        assert apply(Config, fun, ["postgres"]) == default_rules,
+               "#{fun} did not fall through to :default for nil repo-specific value"
+      end
+    end
+
+    test "returns :default rules when repo_name has no match and :default is present" do
+      default_rules = [deny: ["default_rule"]]
+
+      for {fun, key} <- @variants do
+        put_visibility(key, %{other_repo: [deny: ["other"]], default: default_rules})
+
+        assert apply(Config, fun, ["postgres"]) == default_rules,
+               "#{fun} did not fall through to :default"
+      end
+    end
+
+    test "returns an empty list when repo_name has no match and :default is absent" do
+      for {fun, key} <- @variants do
+        put_visibility(key, %{other_repo: [deny: ["other"]]})
+
+        assert apply(Config, fun, ["postgres"]) == [],
+               "#{fun} did not return [] when no match and no :default"
+      end
+    end
+
+    test "returns an empty list when the visibility map is missing entirely" do
+      for {fun, key} <- @variants do
+        Application.delete_env(:lotus, key)
+        Config.reload!()
+
+        assert apply(Config, fun, ["postgres"]) == [],
+               "#{fun} did not return [] when visibility map is missing"
+      end
+    end
+
+    test "returns :default rules for an arbitrary repo_name string with no matching key" do
+      unknown = "lotus_config_test_unknown_#{System.unique_integer([:positive])}"
+      default_rules = [deny: ["secret"]]
+
+      for {fun, key} <- @variants do
+        put_visibility(key, %{postgres: [deny: ["should_not_match"]], default: default_rules})
+
+        assert apply(Config, fun, [unknown]) == default_rules,
+               "#{fun} did not return :default rules for unknown repo_name"
+      end
+    end
+  end
+
+  defp put_visibility(key, value) do
+    Application.put_env(:lotus, key, value)
+    Config.reload!()
   end
 end


### PR DESCRIPTION
## Summary

Three code-quality improvements bundled together:

- **Refactor visibility rule lookups in `Lotus.Config`** — replaces the `String.to_existing_atom/1` + `rescue ArgumentError` pattern in `rules_for_repo_name/1`, `schema_rules_for_repo_name/1`, and `column_rules_for_repo_name/1` with a shared private helper that matches repo names via `to_string/1`. Avoids exceptions for control flow and removes the duplicated `load!()` call in the rescue branch. Adds direct unit tests for repo-specific hits, empty/nil values, `:default` fallback, and unknown repo names.
- **Extract shared execution pipeline from `run_sql/3` and `execute_query/5`** — both paths duplicated a six-step pipeline (filter → sort → window → cache key → tags/profile → `exec_with_cache`). Extracted into a private `execute_with_options/7` helper; `build_cache_tags/3` now handles a `nil` query id so `run_sql/3` can reuse it. No public API or behavior changes.
- **Document opts propagation between `Application.start/2` and `child_spec/1`** — adds a `## Configuration paths` section to `Lotus.Supervisor` explaining how opts flow (or don't) through each startup path.

Closes #158
Closes #160
Closes #162

## Test plan

- [x] `mix test` passes
- [x] New `Lotus.ConfigTest` cases cover visibility lookup variants
- [x] No public API changes in `Lotus.run_sql/3` or `Lotus.execute_query/5`