### PR TITLE
Reuse prepare_variables/2 in can_run?/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Removed `FilterInjector.quote_value/1` — no longer needed since values are parameterized
 - **REFACTOR:** Remove duplicated private `Lotus.trim_trailing_semicolon/1` in favor of `Lotus.SQL.Sanitizer.strip_trailing_semicolon/1`, eliminating code duplication and a redundant double-trim in the window pagination path (#155)
 - **REFACTOR:** Extract shared filter → sort → window → cache → execute pipeline from `Lotus.run_sql/3` and `Lotus.execute_query/5` into a single private `execute_with_options/7` helper. `run_sql/3` now reuses `build_cache_tags/3` and `determine_cache_profile/1` instead of inlining the same logic. No public API or behavior changes (#160)
+- **REFACTOR:** `Lotus.can_run?/2` now reuses the private `prepare_variables/2` helper instead of duplicating the default-merge logic inline. No behavior change (#156)
 
 ## [0.16.4] - 2026-03-10
 

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -532,15 +532,7 @@ defmodule Lotus do
   def can_run?(query, opts \\ [])
 
   def can_run?(%Query{} = q, opts) do
-    supplied_vars = Keyword.get(opts, :vars, %{}) || %{}
-
-    defaults =
-      q.variables
-      |> Enum.filter(& &1.default)
-      |> Map.new(fn v -> {v.name, v.default} end)
-
-    vars = Map.merge(defaults, supplied_vars)
-
+    vars = prepare_variables(q, opts)
     match?({:ok, _, _}, Query.to_sql_params(q, vars))
   end
 


### PR DESCRIPTION
Eliminates duplicated default-merge logic between can_run?/2 and prepare_variables/2. Behavior preserved.

Closes #156