### PR TITLE
feat(cache): add per-scope cache invalidation and custom key builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Guide: `custom-resolvers.md` documenting the `Lotus.Source.Resolver` and `Lotus.Visibility.Resolver` extension points, including use cases, contract details, `Agent`- and ETS-backed examples, and testing guidance (#176)
 - `:after_discover` middleware event fires after any discovery call (`Lotus.list_schemas/2`, `list_tables/2`, `get_table_schema/3`, `list_relations/2`), alongside the kind-specific `:after_list_*` event. Payload is uniform: `%{kind:, source:, result:, scope:, context:}`. Lets a single middleware module handle every discovery kind by dispatching on `:kind` (#173)
 - `:scope` option on all discovery functions (`list_schemas/2`, `list_tables/2`, `get_table_schema/3`, `list_relations/2`, `get_table_stats/3`). Scope is an opaque term passed to the visibility resolver and hashed into the cache key, enabling context-aware visibility rules (e.g. per-role, per-tenant) with correct per-scope caching. When `nil` (the default), cache keys and behavior are identical to pre-scope versions. Discovery middleware payloads now include `:scope`
+- Per-scope cache invalidation via `Lotus.invalidate_scope/1` (delegates to `Lotus.Cache.invalidate_scope/1`). Selectively clears all cached discovery entries associated with a specific scope without flushing the entire cache. Uses tag-based invalidation — each scoped cache entry is automatically tagged with `"scope:<digest>"` (#195)
+- `Lotus.Cache.KeyBuilder` behaviour for pluggable cache key generation. Defines `discovery_key/2` and `result_key/3` callbacks plus a public `scope_digest/1` utility function. Configure via `cache: %{key_builder: MyApp.KeyBuilder}`. Default implementation (`Lotus.Cache.KeyBuilder.Default`) preserves existing key generation logic (#195)
+- `Lotus.Config.cache_key_builder/0` helper to retrieve the configured key builder module (defaults to `Lotus.Cache.KeyBuilder.Default`)
 
 ### Security
 

--- a/guides/caching.md
+++ b/guides/caching.md
@@ -263,9 +263,54 @@ Lotus generates cache keys based on:
 - **Parameters** - Query parameters and variable values
 - **Repository** - Which database the query targets
 - **Search path** - PostgreSQL schema search path
+- **Scope** - When non-nil, hashed into discovery cache keys
 - **Lotus version** - Ensures cache invalidation across version upgrades
 
 This ensures that different queries, even with slight variations, get separate cache entries.
+
+### Custom Key Builder
+
+The default key generation can be replaced by implementing the `Lotus.Cache.KeyBuilder` behaviour. This is useful when you need to incorporate additional context into cache keys or use a different hashing strategy.
+
+```elixir
+defmodule MyApp.CustomKeyBuilder do
+  @behaviour Lotus.Cache.KeyBuilder
+
+  @impl true
+  def discovery_key(params, scope) do
+    # Add environment to discovery keys
+    env = Application.get_env(:my_app, :env, :prod)
+
+    Lotus.Cache.KeyBuilder.Default.discovery_key(
+      %{params | components: Tuple.append(params.components, env)},
+      scope
+    )
+  end
+
+  @impl true
+  def result_key(sql, bound, opts) do
+    # Delegate to default for result keys
+    Lotus.Cache.KeyBuilder.Default.result_key(sql, bound, opts)
+  end
+end
+```
+
+Configure it in your cache settings:
+
+```elixir
+config :lotus,
+  cache: %{
+    adapter: Lotus.Cache.ETS,
+    key_builder: MyApp.CustomKeyBuilder
+  }
+```
+
+The behaviour defines two callbacks:
+
+- `discovery_key/2` — builds keys for schema introspection cache entries (list_tables, get_table_schema, etc.)
+- `result_key/3` — builds keys for SQL query result cache entries
+
+When no `key_builder` is configured, `Lotus.Cache.KeyBuilder.Default` is used, which preserves the built-in key generation logic.
 
 ## Schema Function Caching
 
@@ -336,6 +381,27 @@ Lotus.Cache.invalidate_tags(["table:public.users"])
 - `"repo:#{repo_name}"` - Repository-specific data
 - `"schema:#{function_name}"` - Function-specific data
 - `"table:#{schema}.#{table}"` - Table-specific data (when applicable)
+- `"scope:<digest>"` - Scope-specific data (when a non-nil `:scope` option is passed)
+
+### Per-Scope Cache Invalidation
+
+When using the `:scope` option on discovery functions, each cached entry is automatically tagged with a scope digest. This lets you invalidate all cached entries for a specific scope without flushing the entire cache:
+
+```elixir
+# Populate cache for different scopes
+{:ok, _} = Lotus.list_tables("postgres", scope: %{tenant_id: 1})
+{:ok, _} = Lotus.list_tables("postgres", scope: %{tenant_id: 2})
+
+# Invalidate only tenant 1's cached entries
+:ok = Lotus.invalidate_scope(%{tenant_id: 1})
+
+# Tenant 2's cache is untouched — this is still a cache hit
+{:ok, _} = Lotus.list_tables("postgres", scope: %{tenant_id: 2})
+```
+
+This is useful when visibility rules change for a specific scope (e.g. a tenant's permissions are updated) and you need to clear stale cache entries without affecting other scopes.
+
+`invalidate_scope/1` accepts any non-nil term and returns `:ok`. Passing `nil` is a no-op (there is no scope tag to invalidate).
 
 ## Working with run_query
 
@@ -368,6 +434,9 @@ Lotus.Cache.invalidate_tags(["user:123"])
 
 # Invalidate multiple tags
 Lotus.Cache.invalidate_tags(["user_data", "reports", "dashboard"])
+
+# Invalidate all cached discovery entries for a specific scope
+Lotus.invalidate_scope(%{tenant_id: 42})
 ```
 
 ### Automatic Tagging
@@ -472,6 +541,9 @@ alter table(:users) do
   add :new_column, :string
 end
 Lotus.Cache.invalidate_tags(["table:public.users"])
+
+# After tenant permissions change — clear only that tenant's cached entries
+Lotus.invalidate_scope(%{tenant_id: tenant.id})
 ```
 
 ## Troubleshooting

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -119,6 +119,7 @@ config :lotus,
     namespace: "myapp_cache",         # Cache namespace (optional)
     max_bytes: 5_000_000,            # Max cache entry size: 5MB (default)
     compress: true,                   # Compress cache entries (default)
+    key_builder: MyApp.KeyBuilder,   # Custom key builder (optional)
     profiles: %{                      # Cache profiles with different TTL strategies
       results: [ttl_ms: 30_000],     # Short-term results (30 seconds)
       options: [ttl_ms: 300_000],    # Medium-term data (5 minutes)  

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -700,6 +700,20 @@ defmodule Lotus do
   """
   def list_relations(repo_or_name, opts \\ []), do: Schema.list_relations(repo_or_name, opts)
 
+  @doc """
+  Invalidates all cached discovery entries associated with the given scope.
+
+  Uses tag-based invalidation — each scoped cache entry is tagged with a
+  scope digest, so this clears only entries for the specified scope without
+  flushing the entire cache.
+
+  ## Examples
+
+      :ok = Lotus.invalidate_scope(%{tenant_id: 42})
+      :ok = Lotus.invalidate_scope(%{role: :admin})
+  """
+  defdelegate invalidate_scope(scope), to: Lotus.Cache
+
   defp cache_mode(nil) do
     case Config.cache_adapter() do
       {:ok, _adapter} -> :use

--- a/lib/lotus/cache.ex
+++ b/lib/lotus/cache.ex
@@ -3,6 +3,7 @@ defmodule Lotus.Cache do
   Lotus cache facade. If no adapter configured, acts as a no-op pass-through.
   """
 
+  alias Lotus.Cache.KeyBuilder
   alias Lotus.{Config, Telemetry}
 
   @type key :: binary()
@@ -75,6 +76,25 @@ defmodule Lotus.Cache do
       {:ok, adapter} -> adapter.delete(ns(key))
       _ -> :ok
     end
+  end
+
+  @doc """
+  Invalidates all cache entries associated with the given scope.
+
+  Uses tag-based invalidation — each scoped cache entry is tagged with
+  `"scope:<digest>"`, so this clears only entries for the specified scope
+  without flushing the entire source cache.
+
+  ## Examples
+
+      Lotus.Cache.invalidate_scope(%{tenant_id: 42})
+      Lotus.Cache.invalidate_scope(%{role: :admin})
+  """
+  @spec invalidate_scope(term()) :: :ok | {:error, term}
+  def invalidate_scope(nil), do: :ok
+
+  def invalidate_scope(scope) do
+    invalidate_tags(["scope:#{KeyBuilder.scope_digest(scope)}"])
   end
 
   @spec invalidate_tags([binary()]) :: :ok | {:error, term}

--- a/lib/lotus/cache/key.ex
+++ b/lib/lotus/cache/key.ex
@@ -3,23 +3,6 @@ defmodule Lotus.Cache.Key do
 
   @spec result(binary(), map() | list(), keyword()) :: binary()
   def result(sql, bound, opts) do
-    repo = Keyword.fetch!(opts, :data_repo)
-    path = Keyword.get(opts, :search_path, "") || ""
-    version = Keyword.get(opts, :lotus_version, Lotus.version())
-
-    digest_input =
-      case bound do
-        %{} = vars -> vars
-        list when is_list(list) -> %{__params__: list}
-      end
-
-    digest =
-      :crypto.hash(
-        :sha256,
-        [sql, ?|, :erlang.term_to_binary(digest_input), ?|, repo, ?|, path, ?|, version]
-      )
-      |> Base.encode16(case: :lower)
-
-    "result:#{repo}:#{digest}"
+    Lotus.Config.cache_key_builder().result_key(sql, bound, opts)
   end
 end

--- a/lib/lotus/cache/key_builder.ex
+++ b/lib/lotus/cache/key_builder.ex
@@ -1,0 +1,93 @@
+defmodule Lotus.Cache.KeyBuilder do
+  @moduledoc """
+  Behaviour for building cache keys in Lotus.
+
+  Implement this behaviour to customize how cache keys are generated for
+  discovery (schema introspection) and result (query execution) caching.
+
+  The default implementation (`Lotus.Cache.KeyBuilder.Default`) preserves
+  the existing key generation logic.
+
+  ## Configuration
+
+      config :lotus,
+        cache: %{
+          adapter: Lotus.Cache.ETS,
+          key_builder: MyApp.CustomKeyBuilder
+        }
+
+  ## Example
+
+      defmodule MyApp.CustomKeyBuilder do
+        @behaviour Lotus.Cache.KeyBuilder
+
+        @impl true
+        def discovery_key(params, scope) do
+          # Custom key logic for discovery cache entries
+          Lotus.Cache.KeyBuilder.Default.discovery_key(params, scope)
+        end
+
+        @impl true
+        def result_key(sql, bound, opts) do
+          # Custom key logic for result cache entries
+          Lotus.Cache.KeyBuilder.Default.result_key(sql, bound, opts)
+        end
+      end
+  """
+
+  @type discovery_params :: %{
+          kind: atom(),
+          source_name: binary(),
+          components: tuple(),
+          version: binary()
+        }
+
+  @doc """
+  Builds a cache key for discovery (schema introspection) entries.
+
+  ## Parameters
+
+  - `params` - A map containing:
+    - `:kind` - The discovery operation (e.g. `:list_schemas`, `:list_tables`)
+    - `:source_name` - The data source name
+    - `:components` - A tuple of additional key components specific to the kind
+    - `:version` - The Lotus version string
+  - `scope` - The scope term, or `nil` if no scope is set
+  """
+  @callback discovery_key(params :: discovery_params(), scope :: term() | nil) :: binary()
+
+  @doc """
+  Builds a cache key for query result entries.
+
+  ## Parameters
+
+  - `sql` - The SQL query string
+  - `bound` - Bound parameters (map or list)
+  - `opts` - Options including `:data_repo`, `:search_path`, `:lotus_version`
+  """
+  @callback result_key(sql :: binary(), bound :: map() | list(), opts :: keyword()) :: binary()
+
+  @doc """
+  Computes a 16-character hex digest for the given scope term.
+
+  Returns an empty string when `scope` is `nil`. Used for building
+  scope-specific cache keys and tags.
+
+  ## Examples
+
+      iex> Lotus.Cache.KeyBuilder.scope_digest(nil)
+      ""
+
+      iex> digest = Lotus.Cache.KeyBuilder.scope_digest(%{tenant_id: 42})
+      iex> is_binary(digest) and byte_size(digest) == 16
+      true
+  """
+  @spec scope_digest(term()) :: binary()
+  def scope_digest(nil), do: ""
+
+  def scope_digest(scope) do
+    :crypto.hash(:sha256, :erlang.term_to_binary(scope))
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 16)
+  end
+end

--- a/lib/lotus/cache/key_builder/default.ex
+++ b/lib/lotus/cache/key_builder/default.ex
@@ -1,0 +1,57 @@
+defmodule Lotus.Cache.KeyBuilder.Default do
+  @moduledoc """
+  Default cache key builder for Lotus.
+
+  Preserves the original key generation logic that was previously inline
+  in `Lotus.Schema` and `Lotus.Cache.Key`.
+  """
+
+  alias Lotus.Cache.KeyBuilder
+
+  @behaviour KeyBuilder
+
+  @impl true
+  def discovery_key(
+        %{kind: kind, source_name: source_name, components: components, version: version},
+        scope
+      ) do
+    digest =
+      :crypto.hash(
+        :sha256,
+        :erlang.term_to_binary(
+          List.to_tuple([source_name | Tuple.to_list(components)] ++ [version])
+        )
+      )
+      |> Base.encode16(case: :lower)
+
+    scope_part =
+      case KeyBuilder.scope_digest(scope) do
+        "" -> ""
+        d -> ":#{d}"
+      end
+
+    "schema:#{kind}:#{source_name}:#{digest}#{scope_part}"
+  end
+
+  @impl true
+  def result_key(sql, bound, opts) do
+    repo = Keyword.fetch!(opts, :data_repo)
+    path = Keyword.get(opts, :search_path, "") || ""
+    version = Keyword.get(opts, :lotus_version, Lotus.version())
+
+    digest_input =
+      case bound do
+        %{} = vars -> vars
+        list when is_list(list) -> %{__params__: list}
+      end
+
+    digest =
+      :crypto.hash(
+        :sha256,
+        [sql, ?|, :erlang.term_to_binary(digest_input), ?|, repo, ?|, path, ?|, version]
+      )
+      |> Base.encode16(case: :lower)
+
+    "result:#{repo}:#{digest}"
+  end
+end

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -95,7 +95,8 @@ defmodule Lotus.Config do
           max_bytes: non_neg_integer(),
           lock_timeout: non_neg_integer(),
           default_ttl_ms: non_neg_integer(),
-          default_profile: atom()
+          default_profile: atom(),
+          key_builder: module()
         }
 
   @schema [
@@ -487,6 +488,19 @@ defmodule Lotus.Config do
           nil -> :error
           mod when is_atom(mod) -> {:ok, mod}
         end
+    end
+  end
+
+  @doc """
+  Returns the configured cache key builder module.
+
+  Falls back to `Lotus.Cache.KeyBuilder.Default` when not configured.
+  """
+  @spec cache_key_builder() :: module()
+  def cache_key_builder do
+    case cache_config() do
+      nil -> Lotus.Cache.KeyBuilder.Default
+      config -> config[:key_builder] || Lotus.Cache.KeyBuilder.Default
     end
   end
 

--- a/lib/lotus/schema.ex
+++ b/lib/lotus/schema.ex
@@ -46,6 +46,7 @@ defmodule Lotus.Schema do
   - **SQLite**: Returns table names as strings (schema-less)
   """
 
+  alias Lotus.Cache.KeyBuilder
   alias Lotus.{Config, Middleware, Sources, Telemetry, Visibility}
   alias Lotus.Source.Adapter
   alias Lotus.Visibility.Policy
@@ -87,7 +88,7 @@ defmodule Lotus.Schema do
     start_time = Telemetry.schema_introspection_start(:list_schemas, adapter.name)
 
     key = schema_key(:list_schemas, adapter.name, scope)
-    tags = ["repo:#{adapter.name}", "schema:list_schemas"]
+    tags = ["repo:#{adapter.name}", "schema:list_schemas"] ++ scope_tags(scope)
 
     profile =
       if is_list(opts[:cache]) do
@@ -195,7 +196,7 @@ defmodule Lotus.Schema do
               scope
             )
 
-          tags = ["repo:#{adapter.name}", "schema:list_tables"]
+          tags = ["repo:#{adapter.name}", "schema:list_tables"] ++ scope_tags(scope)
 
           profile =
             if is_list(opts[:cache]) do
@@ -350,11 +351,12 @@ defmodule Lotus.Schema do
   defp get_table_schema_cached(adapter, table_name, resolved_schema, scope, opts) do
     key = schema_key(:get_table_schema, adapter.name, resolved_schema, table_name, scope)
 
-    tags = [
-      "repo:#{adapter.name}",
-      "schema:get_table_schema",
-      "table:#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}"
-    ]
+    tags =
+      [
+        "repo:#{adapter.name}",
+        "schema:get_table_schema",
+        "table:#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}"
+      ] ++ scope_tags(scope)
 
     profile =
       if is_list(opts[:cache]) do
@@ -468,11 +470,12 @@ defmodule Lotus.Schema do
   defp get_table_stats_cached(adapter, table_name, resolved_schema, scope, opts) do
     key = schema_key(:get_table_stats, adapter.name, resolved_schema, table_name, scope)
 
-    tags = [
-      "repo:#{adapter.name}",
-      "schema:get_table_stats",
-      "table:#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}"
-    ]
+    tags =
+      [
+        "repo:#{adapter.name}",
+        "schema:get_table_stats",
+        "table:#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}"
+      ] ++ scope_tags(scope)
 
     profile =
       if is_list(opts[:cache]) do
@@ -554,7 +557,7 @@ defmodule Lotus.Schema do
         scope
       )
 
-    tags = ["repo:#{adapter.name}", "schema:list_relations"]
+    tags = ["repo:#{adapter.name}", "schema:list_relations"] ++ scope_tags(scope)
 
     profile =
       if is_list(opts[:cache]) do
@@ -789,82 +792,27 @@ defmodule Lotus.Schema do
     end
   end
 
-  defp schema_key(:list_tables, repo_name, search_path, include_views, scope) do
-    digest =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({repo_name, search_path, include_views, Lotus.version()})
-      )
-      |> Base.encode16(case: :lower)
-
-    "schema:list_tables:#{repo_name}:#{digest}#{scope_digest(scope)}"
+  defp schema_key(kind, repo_name, scope) do
+    key_builder().discovery_key(
+      %{kind: kind, source_name: repo_name, components: {}, version: Lotus.version()},
+      scope
+    )
   end
 
-  defp schema_key(:list_relations, repo_name, search_path, include_views, scope) do
-    digest =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({repo_name, search_path, include_views, Lotus.version()})
-      )
-      |> Base.encode16(case: :lower)
-
-    "schema:list_relations:#{repo_name}:#{digest}#{scope_digest(scope)}"
+  defp schema_key(kind, repo_name, comp1, comp2, scope) do
+    key_builder().discovery_key(
+      %{kind: kind, source_name: repo_name, components: {comp1, comp2}, version: Lotus.version()},
+      scope
+    )
   end
 
-  defp schema_key(:get_table_schema, repo_name, resolved_schema, table_name, scope) do
-    digest =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({repo_name, resolved_schema, table_name, Lotus.version()})
-      )
-      |> Base.encode16(case: :lower)
+  defp scope_tags(nil), do: []
 
-    "schema:get_table_schema:#{repo_name}:#{digest}#{scope_digest(scope)}"
+  defp scope_tags(scope) do
+    ["scope:#{KeyBuilder.scope_digest(scope)}"]
   end
 
-  defp schema_key(:get_table_stats, repo_name, resolved_schema, table_name, scope) do
-    digest =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({repo_name, resolved_schema, table_name, Lotus.version()})
-      )
-      |> Base.encode16(case: :lower)
-
-    "schema:get_table_stats:#{repo_name}:#{digest}#{scope_digest(scope)}"
-  end
-
-  defp schema_key(:resolve_table_schema, repo_name, search_key, table, _scope) do
-    digest =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({repo_name, search_key, table, Lotus.version()})
-      )
-      |> Base.encode16(case: :lower)
-
-    "schema:resolve_table_schema:#{repo_name}:#{digest}"
-  end
-
-  defp schema_key(:list_schemas, repo_name, scope) do
-    digest =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({repo_name, Lotus.version()})
-      )
-      |> Base.encode16(case: :lower)
-
-    "schema:list_schemas:#{repo_name}:#{digest}#{scope_digest(scope)}"
-  end
-
-  defp scope_digest(nil), do: ""
-
-  defp scope_digest(scope) do
-    hash =
-      :crypto.hash(:sha256, :erlang.term_to_binary(scope))
-      |> Base.encode16(case: :lower)
-      |> binary_part(0, 16)
-
-    ":#{hash}"
-  end
+  defp key_builder, do: Config.cache_key_builder()
 
   defp result_status({:ok, _}), do: :ok
   defp result_status({:error, _}), do: :error

--- a/test/lotus/cache/key_builder_test.exs
+++ b/test/lotus/cache/key_builder_test.exs
@@ -1,0 +1,138 @@
+defmodule Lotus.Cache.KeyBuilderTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Cache.KeyBuilder
+  alias Lotus.Cache.KeyBuilder.Default
+
+  describe "scope_digest/1" do
+    test "returns empty string for nil" do
+      assert KeyBuilder.scope_digest(nil) == ""
+    end
+
+    test "returns 16-character hex digest for non-nil scope" do
+      digest = KeyBuilder.scope_digest(%{tenant_id: 42})
+      assert is_binary(digest)
+      assert byte_size(digest) == 16
+      assert Regex.match?(~r/^[0-9a-f]{16}$/, digest)
+    end
+
+    test "produces consistent digests for the same scope" do
+      scope = %{role: :admin}
+      assert KeyBuilder.scope_digest(scope) == KeyBuilder.scope_digest(scope)
+    end
+
+    test "produces different digests for different scopes" do
+      digest_a = KeyBuilder.scope_digest(%{tenant_id: 1})
+      digest_b = KeyBuilder.scope_digest(%{tenant_id: 2})
+      refute digest_a == digest_b
+    end
+  end
+
+  describe "Default.discovery_key/2" do
+    test "builds key without scope suffix for nil scope" do
+      key =
+        Default.discovery_key(
+          %{kind: :list_schemas, source_name: "pg", components: {}, version: "1.0.0"},
+          nil
+        )
+
+      assert String.starts_with?(key, "schema:list_schemas:pg:")
+      refute String.contains?(key, "::" <> "")
+    end
+
+    test "builds key with scope suffix for non-nil scope" do
+      scope = %{tenant_id: 42}
+
+      key =
+        Default.discovery_key(
+          %{
+            kind: :list_tables,
+            source_name: "pg",
+            components: {"public", false},
+            version: "1.0.0"
+          },
+          scope
+        )
+
+      assert String.starts_with?(key, "schema:list_tables:pg:")
+      assert String.ends_with?(key, ":#{KeyBuilder.scope_digest(scope)}")
+    end
+
+    test "different components produce different keys" do
+      params_a = %{
+        kind: :list_tables,
+        source_name: "pg",
+        components: {"public", false},
+        version: "1.0.0"
+      }
+
+      params_b = %{
+        kind: :list_tables,
+        source_name: "pg",
+        components: {"reporting", false},
+        version: "1.0.0"
+      }
+
+      key_a = Default.discovery_key(params_a, nil)
+      key_b = Default.discovery_key(params_b, nil)
+
+      refute key_a == key_b
+    end
+
+    test "different kinds produce different keys" do
+      params_a = %{
+        kind: :list_tables,
+        source_name: "pg",
+        components: {"public", false},
+        version: "1.0.0"
+      }
+
+      params_b = %{
+        kind: :list_relations,
+        source_name: "pg",
+        components: {"public", false},
+        version: "1.0.0"
+      }
+
+      key_a = Default.discovery_key(params_a, nil)
+      key_b = Default.discovery_key(params_b, nil)
+
+      refute key_a == key_b
+    end
+  end
+
+  describe "Default.result_key/3" do
+    test "builds result key from SQL, params, and opts" do
+      key =
+        Default.result_key(
+          "SELECT * FROM users",
+          %{id: 1},
+          data_repo: "primary",
+          search_path: "public",
+          lotus_version: "1.0.0"
+        )
+
+      assert String.starts_with?(key, "result:primary:")
+    end
+
+    test "different SQL produces different keys" do
+      opts = [data_repo: "primary", search_path: "", lotus_version: "1.0.0"]
+      key_a = Default.result_key("SELECT 1", %{}, opts)
+      key_b = Default.result_key("SELECT 2", %{}, opts)
+
+      refute key_a == key_b
+    end
+
+    test "handles list params" do
+      key =
+        Default.result_key(
+          "SELECT * FROM users WHERE id = $1",
+          [42],
+          data_repo: "primary",
+          lotus_version: "1.0.0"
+        )
+
+      assert String.starts_with?(key, "result:primary:")
+    end
+  end
+end

--- a/test/lotus/cache/scope_invalidation_test.exs
+++ b/test/lotus/cache/scope_invalidation_test.exs
@@ -1,0 +1,85 @@
+defmodule Lotus.Cache.ScopeInvalidationTest do
+  use Lotus.CacheCase
+  use Mimic
+
+  alias Lotus.Cache
+  alias Lotus.Cache.KeyBuilder
+  alias Lotus.Config
+
+  setup :verify_on_exit!
+
+  setup do
+    Mimic.copy(Lotus.Config)
+
+    Config
+    |> stub(:cache_adapter, fn -> {:ok, Lotus.Cache.ETS} end)
+    |> stub(:cache_namespace, fn -> "test_scope" end)
+
+    :ok
+  end
+
+  describe "invalidate_scope/1" do
+    test "clears entries tagged with the given scope" do
+      scope_a = %{tenant_id: 1}
+      tag = "scope:#{KeyBuilder.scope_digest(scope_a)}"
+
+      Cache.put("key_a", "value_a", 5000, tags: [tag])
+
+      assert Cache.get("key_a") == {:ok, "value_a"}
+
+      assert :ok = Cache.invalidate_scope(scope_a)
+
+      assert Cache.get("key_a") == :miss
+    end
+
+    test "does not affect entries for a different scope" do
+      scope_a = %{tenant_id: 1}
+      scope_b = %{tenant_id: 2}
+      tag_a = "scope:#{KeyBuilder.scope_digest(scope_a)}"
+      tag_b = "scope:#{KeyBuilder.scope_digest(scope_b)}"
+
+      Cache.put("key_a", "value_a", 5000, tags: [tag_a])
+      Cache.put("key_b", "value_b", 5000, tags: [tag_b])
+
+      assert :ok = Cache.invalidate_scope(scope_a)
+
+      assert Cache.get("key_a") == :miss
+      assert Cache.get("key_b") == {:ok, "value_b"}
+    end
+
+    test "does not affect nil-scope entries" do
+      scope_a = %{tenant_id: 1}
+      tag_a = "scope:#{KeyBuilder.scope_digest(scope_a)}"
+
+      Cache.put("scoped_key", "scoped_value", 5000, tags: [tag_a])
+      Cache.put("unscoped_key", "unscoped_value", 5000, tags: ["repo:test"])
+
+      assert :ok = Cache.invalidate_scope(scope_a)
+
+      assert Cache.get("scoped_key") == :miss
+      assert Cache.get("unscoped_key") == {:ok, "unscoped_value"}
+    end
+
+    test "handles multiple entries for the same scope" do
+      scope = %{role: :admin}
+      tag = "scope:#{KeyBuilder.scope_digest(scope)}"
+
+      Cache.put("admin_key_1", "v1", 5000, tags: [tag, "schema:list_schemas"])
+      Cache.put("admin_key_2", "v2", 5000, tags: [tag, "schema:list_tables"])
+      Cache.put("admin_key_3", "v3", 5000, tags: [tag, "schema:list_relations"])
+
+      assert :ok = Cache.invalidate_scope(scope)
+
+      assert Cache.get("admin_key_1") == :miss
+      assert Cache.get("admin_key_2") == :miss
+      assert Cache.get("admin_key_3") == :miss
+    end
+
+    test "returns :ok when cache is disabled" do
+      Config
+      |> stub(:cache_adapter, fn -> :error end)
+
+      assert :ok = Cache.invalidate_scope(%{tenant_id: 1})
+    end
+  end
+end


### PR DESCRIPTION
Add two features to the cache layer:

1. Per-scope invalidation — discovery cache entries are now tagged with "scope:<digest>" when a non-nil scope is passed. Call Lotus.invalidate_scope/1 to selectively clear entries for one scope without flushing the entire cache.

2. Custom key builder — new Lotus.Cache.KeyBuilder behaviour with discovery_key/2 and result_key/3 callbacks. Configure via cache: %{key_builder: MyModule}. Default implementation preserves existing key generation exactly.

Consolidates scope_digest/1 into a single public function on Lotus.Cache.KeyBuilder, eliminating duplicate implementations across Schema, Cache, and KeyBuilder.Default.

Closes #195