### PR TITLE
feat(telemetry): expose query context in telemetry event metadata (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Per-scope cache invalidation via `Lotus.invalidate_scope/1` (delegates to `Lotus.Cache.invalidate_scope/1`). Selectively clears all cached discovery entries associated with a specific scope without flushing the entire cache. Uses tag-based invalidation — each scoped cache entry is automatically tagged with `"scope:<digest>"` (#195)
 - `Lotus.Cache.KeyBuilder` behaviour for pluggable cache key generation. Defines `discovery_key/2` and `result_key/3` callbacks plus a public `scope_digest/1` utility function. Configure via `cache: %{key_builder: MyApp.KeyBuilder}`. Default implementation (`Lotus.Cache.KeyBuilder.Default`) preserves existing key generation logic (#195)
 - `Lotus.Config.cache_key_builder/0` helper to retrieve the configured key builder module (defaults to `Lotus.Cache.KeyBuilder.Default`)
+- `:context` metadata in query telemetry events (`[:lotus, :query, :start | :stop | :exception]`). The caller-supplied `:context` option is now included in event metadata, enabling per-endpoint attribution, distributed trace correlation, and request ID tagging without wrapping or forking `Runner` (#175)
 
 ### Security
 

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -10,12 +10,17 @@ with monitoring tools like Phoenix LiveDashboard, AppSignal, Datadog, and others
 
 | Event                         | Measurements                   | Metadata                                      |
 |-------------------------------|--------------------------------|-----------------------------------------------|
-| `[:lotus, :query, :start]`    | `system_time`                  | `repo`, `sql`, `params`                       |
-| `[:lotus, :query, :stop]`     | `duration`, `row_count`        | `repo`, `sql`, `params`, `result`             |
-| `[:lotus, :query, :exception]`| `duration`                     | `repo`, `sql`, `params`, `kind`, `reason`, `stacktrace` |
+| `[:lotus, :query, :start]`    | `system_time`                  | `repo`, `sql`, `params`, `context`                       |
+| `[:lotus, :query, :stop]`     | `duration`, `row_count`        | `repo`, `sql`, `params`, `context`, `result`             |
+| `[:lotus, :query, :exception]`| `duration`                     | `repo`, `sql`, `params`, `context`, `kind`, `reason`, `stacktrace` |
 
 Duration is measured in native time units. Use `System.convert_time_unit/3` to
 convert to milliseconds or microseconds.
+
+The `context` field carries whatever value the caller passed as the `:context`
+option to `Lotus.run_sql/3` or `Lotus.run_query/2`. It defaults to `nil` when
+not provided. Typical uses include request IDs, controller names, or
+OpenTelemetry span contexts for trace correlation.
 
 ### Cache Operations
 

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -31,11 +31,10 @@ defmodule Lotus.Runner do
           {:ok, query_result()} | {:error, term()}
   def run_sql(%Adapter{} = adapter, sql, params \\ [], opts \\ [])
       when is_binary(sql) and is_list(params) do
-    telemetry_meta = %{repo: adapter.name, sql: sql, params: params}
+    context = Keyword.get(opts, :context)
+    telemetry_meta = %{repo: adapter.name, sql: sql, params: params, context: context}
     start_time = Telemetry.query_start(telemetry_meta)
     read_only = Keyword.get(opts, :read_only, true)
-
-    context = Keyword.get(opts, :context)
 
     result =
       with :ok <- assert_single_statement(sql),

--- a/lib/lotus/telemetry.ex
+++ b/lib/lotus/telemetry.ex
@@ -21,6 +21,7 @@ defmodule Lotus.Telemetry do
     * `:repo` - The Ecto repo module
     * `:sql` - The SQL statement being executed
     * `:params` - The query parameters
+    * `:context` - The caller-supplied context (or `nil`)
 
   ### `[:lotus, :query, :stop]`
 
@@ -36,6 +37,7 @@ defmodule Lotus.Telemetry do
     * `:repo` - The Ecto repo module
     * `:sql` - The SQL statement that was executed
     * `:params` - The query parameters
+    * `:context` - The caller-supplied context (or `nil`)
     * `:result` - The `Lotus.Result` struct
 
   ### `[:lotus, :query, :exception]`
@@ -51,6 +53,7 @@ defmodule Lotus.Telemetry do
     * `:repo` - The Ecto repo module
     * `:sql` - The SQL statement that was executed
     * `:params` - The query parameters
+    * `:context` - The caller-supplied context (or `nil`)
     * `:kind` - The kind of exception (`:error`, `:exit`, or `:throw`)
     * `:reason` - The exception or error reason
     * `:stacktrace` - The stacktrace

--- a/test/lotus/telemetry_test.exs
+++ b/test/lotus/telemetry_test.exs
@@ -42,6 +42,73 @@ defmodule Lotus.TelemetryTest do
       :telemetry.detach("#{inspect(ref)}")
     end
 
+    test "includes context in start and stop metadata" do
+      ref = make_ref()
+      pid = self()
+      ctx = %{request_id: "req-123", controller: "ReportsController"}
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [[:lotus, :query, :start], [:lotus, :query, :stop]],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:ok, _result} = Runner.run_sql(@pg_adapter, "SELECT 1 AS num", [], context: ctx)
+
+      assert_received {:telemetry, [:lotus, :query, :start], _,
+                       %{repo: "postgres", context: ^ctx}}
+
+      assert_received {:telemetry, [:lotus, :query, :stop], _, %{repo: "postgres", context: ^ctx}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    test "context defaults to nil when not provided" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [[:lotus, :query, :start], [:lotus, :query, :stop]],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:ok, _result} = Runner.run_sql(@pg_adapter, "SELECT 1 AS num")
+
+      assert_received {:telemetry, [:lotus, :query, :start], _, %{context: nil}}
+      assert_received {:telemetry, [:lotus, :query, :stop], _, %{context: nil}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
+    test "includes context in exception metadata" do
+      ref = make_ref()
+      pid = self()
+      ctx = %{request_id: "req-456"}
+
+      :telemetry.attach_many(
+        "#{inspect(ref)}",
+        [[:lotus, :query, :exception]],
+        fn event, measurements, metadata, _ ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      {:error, _} = Runner.run_sql(@pg_adapter, "DROP TABLE test_users", [], context: ctx)
+
+      assert_received {:telemetry, [:lotus, :query, :exception], _,
+                       %{kind: :error, context: ^ctx}}
+
+      :telemetry.detach("#{inspect(ref)}")
+    end
+
     test "emits start and exception events on failed query" do
       ref = make_ref()
       pid = self()


### PR DESCRIPTION
Include the caller-supplied :context option in all query telemetry events (:start, :stop, :exception), enabling per-endpoint attribution, distributed trace correlation, and request ID tagging.

Closes https://github.com/typhoonworks/lotus/issues/175