### PR TITLE
feat(middleware): catch exceptions in middleware pipeline (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Per-scope cache invalidation via `Lotus.invalidate_scope/1` (delegates to `Lotus.Cache.invalidate_scope/1`). Selectively clears all cached discovery entries associated with a specific scope without flushing the entire cache. Uses tag-based invalidation — each scoped cache entry is automatically tagged with `"scope:<digest>"` (#195)
 - `Lotus.Cache.KeyBuilder` behaviour for pluggable cache key generation. Defines `discovery_key/2` and `result_key/3` callbacks plus a public `scope_digest/1` utility function. Configure via `cache: %{key_builder: MyApp.KeyBuilder}`. Default implementation (`Lotus.Cache.KeyBuilder.Default`) preserves existing key generation logic (#195)
 - `Lotus.Config.cache_key_builder/0` helper to retrieve the configured key builder module (defaults to `Lotus.Cache.KeyBuilder.Default`)
+- Middleware exception safety: raised exceptions inside middleware `call/2` are now caught and surfaced as `{:error, exception}` instead of propagating uncaught. The `rescue` is scoped to the individual `call/2` invocation so subsequent middleware never runs (#177)
 - `:context` metadata in query telemetry events (`[:lotus, :query, :start | :stop | :exception]`). The caller-supplied `:context` option is now included in event metadata, enabling per-endpoint attribution, distributed trace correlation, and request ID tagging without wrapping or forking `Runner` (#175)
 
 ### Security

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -125,7 +125,14 @@ defmodule Lotus.Middleware do
   defp run_pipeline([], payload), do: {:cont, payload}
 
   defp run_pipeline([{mod, compiled_opts} | rest], payload) do
-    case mod.call(payload, compiled_opts) do
+    result =
+      try do
+        mod.call(payload, compiled_opts)
+      rescue
+        e -> {:halt, e}
+      end
+
+    case result do
       {:cont, new_payload} -> run_pipeline(rest, new_payload)
       {:halt, reason} -> {:halt, reason}
     end

--- a/test/lotus/middleware_test.exs
+++ b/test/lotus/middleware_test.exs
@@ -98,6 +98,14 @@ defmodule Lotus.MiddlewareTest do
     end
   end
 
+  defmodule RaisingPlug do
+    def init(opts), do: opts
+
+    def call(_payload, opts) do
+      raise Keyword.fetch!(opts, :message)
+    end
+  end
+
   defmodule ScopeCapturePlug do
     def init(opts), do: opts
 
@@ -195,6 +203,15 @@ defmodule Lotus.MiddlewareTest do
 
       assert_received {:middleware_context, :test_user}
     end
+
+    test "raised exception returns {:halt, exception}" do
+      Middleware.compile(%{
+        before_query: [{RaisingPlug, [message: "pipeline boom"]}]
+      })
+
+      assert {:halt, %RuntimeError{message: "pipeline boom"}} =
+               Middleware.run(:before_query, %{sql: "SELECT 1", context: nil})
+    end
   end
 
   describe "before_query integration" do
@@ -232,6 +249,17 @@ defmodule Lotus.MiddlewareTest do
       Runner.run_sql(@pg_adapter, "SELECT 1")
 
       assert_received {:middleware_context, nil}
+    end
+
+    test "halting before_query does not run after_query middleware" do
+      Middleware.compile(%{
+        before_query: [{HaltPlug, [reason: "denied"]}],
+        after_query: [{CountingPlug, []}]
+      })
+
+      assert {:error, "denied"} = Runner.run_sql(@pg_adapter, "SELECT 1")
+
+      refute_received :middleware_ran
     end
   end
 
@@ -504,6 +532,40 @@ defmodule Lotus.MiddlewareTest do
 
       assert_received {:middleware_context, %{tenant: "acme"}}
       assert_received {:middleware_context, %{tenant: "globex"}}
+    end
+  end
+
+  describe "exception inside middleware" do
+    test "raised exception in before_query middleware surfaces as {:error, _}" do
+      Middleware.compile(%{
+        before_query: [{RaisingPlug, [message: "boom"]}]
+      })
+
+      assert {:error, %RuntimeError{message: "boom"}} =
+               Runner.run_sql(@pg_adapter, "SELECT 1")
+    end
+
+    test "exception stops subsequent middleware from running" do
+      Middleware.compile(%{
+        before_query: [
+          {RaisingPlug, [message: "crash"]},
+          {ContextCapturePlug, []}
+        ]
+      })
+
+      assert {:error, %RuntimeError{message: "crash"}} =
+               Runner.run_sql(@pg_adapter, "SELECT 1")
+
+      refute_received {:middleware_context, _}
+    end
+
+    test "raised exception in after_query middleware surfaces as {:error, _}" do
+      Middleware.compile(%{
+        after_query: [{RaisingPlug, [message: "post-query crash"]}]
+      })
+
+      assert {:error, %RuntimeError{message: "post-query crash"}} =
+               Runner.run_sql(@pg_adapter, "SELECT 1")
     end
   end
 


### PR DESCRIPTION
Raised exceptions inside middleware `call/2` are now rescued and surfaced as `{:error, exception}` instead of propagating uncaught. The rescue is scoped to the individual `call/2` invocation so subsequent middleware never runs after an exception.

Adds integration tests for exception handling and documents that halted `:before_query` pipelines do not trigger `:after_query`.

Closes https://github.com/typhoonworks/lotus/issues/177