### PR TITLE
refactor: rename data_repo/data_repos to data_source/data_sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed `data_repos` config key to `data_sources` (old key still works with deprecation warning)
+- Renamed `default_repo` config key to `default_source` (old key still works with deprecation warning)
+- Renamed public functions: `data_repos/0` → `data_sources/0`, `get_data_repo!/1` → `get_data_source!/1`, `list_data_repo_names/0` → `list_data_source_names/0`, `default_data_repo/0` → `default_data_source/0`, `rules_for_repo_name/1` → `rules_for_source_name/1` (and schema/column variants)
+- Renamed `data_repo` field in `Lotus.Storage.Query` to `data_source` (DB column unchanged)
+- Renamed `@type repo` in `Lotus.Source` to `@type source_module`
+
+### Deprecated
+
+- `:data_repos` config key — use `:data_sources` instead (will be removed in v1.0)
+- `:default_repo` config key — use `:default_source` instead (will be removed in v1.0)
+- `Lotus.data_repos/0` — use `Lotus.data_sources/0` (will be removed in v1.0)
+- `Lotus.get_data_repo!/1` — use `Lotus.get_data_source!/1` (will be removed in v1.0)
+- `Lotus.list_data_repo_names/0` — use `Lotus.list_data_source_names/0` (will be removed in v1.0)
+- `Lotus.default_data_repo/0` — use `Lotus.default_data_source/0` (will be removed in v1.0)
+- `Lotus.Config.rules_for_repo_name/1` — use `Lotus.Config.rules_for_source_name/1` (will be removed in v1.0)
+- `Lotus.Config.schema_rules_for_repo_name/1` — use `Lotus.Config.schema_rules_for_source_name/1` (will be removed in v1.0)
+- `Lotus.Config.column_rules_for_repo_name/1` — use `Lotus.Config.column_rules_for_source_name/1` (will be removed in v1.0)
+
 ### Fixed
 
 - `get_table_schema/3` and `get_table_stats/3` now propagate adapter errors (e.g. permission denied, connection errors) instead of masking them as "Table not found" (#189)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,8 +2,8 @@ import Config
 
 config :lotus,
   ecto_repo: Lotus.Test.Repo,
-  default_repo: "postgres",
-  data_repos: %{
+  default_source: "postgres",
+  data_sources: %{
     "postgres" => Lotus.Test.Repo,
     "mysql" => Lotus.Test.MysqlRepo,
     "sqlite" => Lotus.Test.SqliteRepo

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,8 +2,8 @@ import Config
 
 config :lotus,
   ecto_repo: Lotus.Test.Repo,
-  default_repo: "postgres",
-  data_repos: %{
+  default_source: "postgres",
+  data_sources: %{
     "postgres" => Lotus.Test.Repo,
     "sqlite" => Lotus.Test.SqliteRepo,
     "mysql" => Lotus.Test.MysqlRepo

--- a/guides/advanced-variables.md
+++ b/guides/advanced-variables.md
@@ -629,7 +629,7 @@ WHERE last_activity >= NOW() - INTERVAL '7 {{unit}}'
   variables: [
     %{name: "days", type: :number, label: "Days Back", default: "30"}
   ],
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 
 # Execute with different time ranges
@@ -664,7 +664,7 @@ WHERE last_activity >= NOW() - INTERVAL '7 {{unit}}'
     %{name: "unit", type: :text, label: "Time Unit", default: "months",
       widget: :select, static_options: ["days", "weeks", "months", "years"]}
   ],
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 ```
 
@@ -689,7 +689,7 @@ WHERE last_activity >= NOW() - INTERVAL '7 {{unit}}'
         "1 month", "3 months", "6 months", "1 year"
       ]}
   ],
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 ```
 
@@ -703,7 +703,7 @@ For MySQL and SQLite databases, interval transformations are safely ignored sinc
   name: "PostgreSQL Time Query",
   statement: "SELECT * FROM events WHERE created_at >= NOW() - INTERVAL '{{days}} days'",
   variables: [%{name: "days", type: :number, default: "7"}],
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 
 # MySQL equivalent (no transformation needed)
@@ -711,7 +711,7 @@ For MySQL and SQLite databases, interval transformations are safely ignored sinc
   name: "MySQL Time Query",
   statement: "SELECT * FROM events WHERE created_at >= NOW() - INTERVAL {{days}} DAY",
   variables: [%{name: "days", type: :number, default: "7"}],
-  data_repo: "mysql"
+  data_source: "mysql"
 })
 
 # SQLite equivalent (no transformation needed)
@@ -719,6 +719,6 @@ For MySQL and SQLite databases, interval transformations are safely ignored sinc
   name: "SQLite Time Query",
   statement: "SELECT * FROM events WHERE created_at >= datetime('now', '-' || {{days}} || ' days')",
   variables: [%{name: "days", type: :number, default: "7"}],
-  data_repo: "sqlite"
+  data_source: "sqlite"
 })
 ```

--- a/guides/caching.md
+++ b/guides/caching.md
@@ -25,7 +25,7 @@ Lotus ships with built-in cache profiles (`:results`, `:schema`, `:options`) tha
 # config/config.exs
 config :lotus,
   ecto_repo: MyApp.Repo,
-  data_repos: %{
+  data_sources: %{
     "main" => MyApp.Repo
   },
   cache: %{

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -9,8 +9,8 @@ Lotus configuration is typically placed in your `config/config.exs` file:
 ```elixir
 config :lotus,
   ecto_repo: MyApp.Repo,        # Repository for Lotus query storage
-  default_repo: "main",         # Default repository for query execution
-  data_repos: %{                # Repositories for executing queries
+  default_source: "main",       # Default data source for query execution
+  data_sources: %{              # Data sources for executing queries
     "main" => MyApp.Repo,
     "analytics" => MyApp.AnalyticsRepo
   },
@@ -35,15 +35,17 @@ config :lotus,
 
 **Type**: `module()`
 
-#### `data_repos` (required)
+#### `data_sources` (required)
 
-A map of repositories where queries can be executed against actual data. This powerful feature allows Lotus to work with multiple databases simultaneously, supporting PostgreSQL, MySQL, and SQLite.
+A map of data sources where queries can be executed against actual data. This powerful feature allows Lotus to work with multiple databases simultaneously, supporting PostgreSQL, MySQL, and SQLite.
 
 Keys are friendly names that you use when executing queries, values are Ecto repository modules.
 
+> **Deprecation note**: The old `:data_repos` config key is deprecated but still works. Please migrate to `:data_sources`.
+
 ```elixir
 config :lotus,
-  data_repos: %{
+  data_sources: %{
     "main" => MyApp.Repo,           # Can be the same as ecto_repo
     "analytics" => MyApp.AnalyticsRepo,
     "reporting" => MyApp.ReportingRepo,
@@ -54,26 +56,28 @@ config :lotus,
 
 **Type**: `%{String.t() => module()}`
 
-#### `default_repo` (required when multiple data_repos)
+#### `default_source` (required when multiple data_sources)
 
-When you have multiple data repositories configured, you must specify which one to use by default when no explicit repository is provided in query execution.
+When you have multiple data sources configured, you must specify which one to use by default when no explicit source is provided in query execution.
+
+> **Deprecation note**: The old `:default_repo` config key is deprecated but still works. Please migrate to `:default_source`.
 
 ```elixir
 config :lotus,
-  default_repo: "main",  # Must match a key in data_repos
-  data_repos: %{
+  default_source: "main",  # Must match a key in data_sources
+  data_sources: %{
     "main" => MyApp.Repo,
     "analytics" => MyApp.AnalyticsRepo
   }
 ```
 
 **Type**: `String.t()`
-**Default**: Not required if only one data repository is configured
+**Default**: Not required if only one data source is configured
 
 **Behavior**:
-- **Single repo**: When only one data repository is configured, it's automatically used as the default
-- **Multiple repos**: You must configure `default_repo` to specify which one to use when no repo is explicitly provided
-- **No repos**: Raises an error if no data repositories are configured
+- **Single source**: When only one data source is configured, it's automatically used as the default
+- **Multiple sources**: You must configure `default_source` to specify which one to use when no source is explicitly provided
+- **No sources**: Raises an error if no data sources are configured
 
 **Usage Examples:**
 
@@ -84,27 +88,27 @@ Lotus.run_sql("SELECT COUNT(*) FROM users", [], repo: "analytics")
 # Execute against a repository module directly
 Lotus.run_sql("SELECT COUNT(*) FROM users", [], repo: MyApp.AnalyticsRepo)
 
-# When no repo is specified, uses the configured default_repo
-Lotus.run_sql("SELECT COUNT(*) FROM users")  # Uses "main" repo from default_repo config
+# When no repo is specified, uses the configured default_source
+Lotus.run_sql("SELECT COUNT(*) FROM users")  # Uses "main" from default_source config
 ```
 
-**Repository Management:**
+**Data Source Management:**
 
 ```elixir
-# List all configured data repository names
-repo_names = Lotus.list_data_repo_names()
+# List all configured data source names
+source_names = Lotus.list_data_source_names()
 # ["analytics", "main", "reporting", "sqlite_data"]
 
-# Get all configured repositories
-all_repos = Lotus.data_repos()
+# Get all configured data sources
+all_sources = Lotus.data_sources()
 # %{"analytics" => MyApp.AnalyticsRepo, "main" => MyApp.Repo, ...}
 
-# Get a specific repository by name (raises if not found)
-repo = Lotus.get_data_repo!("analytics")
+# Get a specific data source by name (raises if not found)
+source = Lotus.get_data_source!("analytics")
 # MyApp.AnalyticsRepo
 ```
 
-> **Note**: The `ecto_repo` can also be included in `data_repos` if you want to run queries against the same database where Lotus stores its data. This is common in single-database applications.
+> **Note**: The `ecto_repo` can also be included in `data_sources` if you want to run queries against the same database where Lotus stores its data. This is common in single-database applications.
 
 ### Optional Features
 
@@ -330,11 +334,11 @@ Lotus automatically blocks access to sensitive system tables:
 
 **Per-Repository Rules:**
 
-You can configure different visibility rules for each data repository:
+You can configure different visibility rules for each data source:
 
 ```elixir
 config :lotus,
-  data_repos: %{
+  data_sources: %{
     "public" => MyApp.PublicRepo,
     "finance" => MyApp.FinanceRepo
   },
@@ -357,7 +361,7 @@ config :lotus,
 
 #### `source_resolver`
 
-Configures the module responsible for turning repo names or modules into `%Lotus.Source.Adapter{}` structs at query time. The default static resolver reads from `data_repos` and is suitable for most applications.
+Configures the module responsible for turning repo names or modules into `%Lotus.Source.Adapter{}` structs at query time. The default static resolver reads from `data_sources` and is suitable for most applications.
 
 ```elixir
 config :lotus,
@@ -461,7 +465,7 @@ Configure Lotus to use your read-only repository for data queries:
 # config/config.exs
 config :lotus,
   ecto_repo: MyApp.Repo,           # Use regular repo for storing Lotus queries
-  data_repos: %{
+  data_sources: %{
     "main" => MyApp.ReadOnlyRepo,  # Use read-only repo for data queries
     "analytics" => MyApp.AnalyticsReadOnlyRepo
   }
@@ -476,7 +480,7 @@ config :my_app, MyApp.ReadOnlyRepo,
 
 ### How It Interacts with Lotus
 
-When a data repo is configured with Ecto's `read_only: true`:
+When a data source is configured with Ecto's `read_only: true`:
 
 1. **Ecto blocks writes first** — the repo rejects INSERT/UPDATE/DELETE before Lotus is involved
 2. **Lotus's `read_only: false` has no effect** — even if you pass it, the repo won't execute writes
@@ -593,8 +597,8 @@ You can mix PostgreSQL, MySQL, and SQLite repositories:
 ```elixir
 config :lotus,
   ecto_repo: MyApp.Repo,          # PostgreSQL for storage
-  default_repo: "postgres",       # Default repository for queries
-  data_repos: %{
+  default_source: "postgres",     # Default data source for queries
+  data_sources: %{
     "postgres" => MyApp.Repo,     # PostgreSQL data
     "mysql" => MyApp.MySQLRepo,   # MySQL data
     "sqlite" => MyApp.SqliteRepo, # SQLite data

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -82,7 +82,7 @@ Everything lives under `lib/lotus/`. The library is roughly split into a public 
 
 - [`Lotus`](../lib/lotus.ex) — Top-level facade. `run_query/2`, `run_sql/3`, `create_query/1`, schema helpers, and dashboard helpers all entry through here.
 - [`Lotus.Supervisor`](../lib/lotus/supervisor.ex) — Boots the configured cache adapter, starts a `Task.Supervisor` (used by dashboard card execution), and compiles the middleware pipeline.
-- [`Lotus.Config`](../lib/lotus/config.ex) — Validates and caches application configuration (data repos, cache profiles, visibility rules, AI settings, middleware, etc.).
+- [`Lotus.Config`](../lib/lotus/config.ex) — Validates and caches application configuration (data sources, cache profiles, visibility rules, AI settings, middleware, etc.).
 - [`Lotus.Telemetry`](../lib/lotus/telemetry.ex) — Emits `:telemetry` events for query execution, schema introspection, and cache hits/misses.
 
 **Query pipeline**
@@ -241,7 +241,7 @@ Lotus has four pluggable extension points. Each is a behaviour plus a default im
 Design notes for adapter authors:
 
 - **Source adapters** carry state in the `%Adapter{}` struct itself (e.g. an Ecto repo module) so the runner never closes over the raw connection. Every introspection callback returns `{:ok, _} | {:error, _}`.
-- **Source resolvers** let you replace the static `data_repos` list with a dynamic registry (database-backed tenants, feature-flagged sources, etc.).
+- **Source resolvers** let you replace the static `data_sources` list with a dynamic registry (database-backed tenants, feature-flagged sources, etc.).
 - **Visibility resolvers** let you compute schema/table/column policies from external sources instead of config — useful when rules live in a multi-tenant database.
 - **Cache adapters** must implement `get_or_store/4`, `put/4`, and `invalidate_tags/1`. ETS is the zero-dependency option; Cachex is recommended when you need distributed caching or richer stats.
 
@@ -495,8 +495,8 @@ mix test --only sqlite
 # Test table visibility across adapters
 mix test test/lotus/visibility_test.exs
 
-# Test data repo functionality
-mix test test/lotus/data_repo_test.exs
+# Test data source functionality
+mix test test/lotus/data_source_test.exs
 ```
 
 ### Caching Features

--- a/guides/custom-resolvers.md
+++ b/guides/custom-resolvers.md
@@ -13,7 +13,7 @@ The default static resolvers load configuration at compile time and cache it in 
 
 ### Custom `Source.Resolver`
 
-- Sources are registered at runtime (not via `config :lotus, data_repos: ...`).
+- Sources are registered at runtime (not via `config :lotus, data_sources: ...`).
 - Data sources live in a database, registry service, or admin UI.
 - Per-tenant sources must be added or removed without restarts.
 - Each environment (dev/staging/prod) needs a different resolution strategy.
@@ -41,7 +41,7 @@ config :lotus,
   visibility_resolver: MyApp.VisibilityResolver
 ```
 
-When omitted, the defaults read from `:data_repos`, `:schema_visibility`, `:table_visibility`, and `:column_visibility` — the same behaviour Lotus has always had.
+When omitted, the defaults read from `:data_sources`, `:schema_visibility`, `:table_visibility`, and `:column_visibility` — the same behaviour Lotus has always had.
 
 > ### Note {: .info}
 >
@@ -80,11 +80,11 @@ A source resolver turns query options (`repo_opt`, `fallback`) into `%Lotus.Sour
 
 The default resolver (`Lotus.Source.Resolvers.Static`) follows this priority inside `resolve/2`:
 
-1. `repo_opt` as string name — lookup in `data_repos`, wrap in adapter
+1. `repo_opt` as string name — lookup in `data_sources`, wrap in adapter
 2. `repo_opt` as module — reverse lookup (find name for module), wrap in adapter
 3. `fallback` as string name — lookup
 4. `fallback` as module — reverse lookup
-5. Both `nil` — use the configured `default_repo`
+5. Both `nil` — use the configured `default_source`
 6. Not found — `{:error, :not_found}`
 
 Custom implementations are free to adopt a different priority but should accept the same arguments so the public API (`Lotus.run_sql/3`, `Lotus.run_query/2`, etc.) continues to work without changes.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -96,9 +96,9 @@ IO.inspect(result.rows)
 # ]
 ```
 
-## Working with Multiple Data Repositories
+## Working with Multiple Data Sources
 
-Lotus supports PostgreSQL, MySQL, and SQLite databases. If you have configured multiple data repositories, you can execute queries against specific databases:
+Lotus supports PostgreSQL, MySQL, and SQLite databases. If you have configured multiple data sources, you can execute queries against specific databases:
 
 ```elixir
 # Execute against a specific repository by name
@@ -115,15 +115,15 @@ Lotus supports PostgreSQL, MySQL, and SQLite databases. If you have configured m
   repo: MyApp.MySQLRepo
 )
 
-# List all available data repositories
-repo_names = Lotus.list_data_repo_names()
-IO.inspect(repo_names)
+# List all available data sources
+source_names = Lotus.list_data_source_names()
+IO.inspect(source_names)
 # ["postgres", "mysql", "sqlite", "analytics"]
 ```
 
-### Storing Queries with Specific Data Repositories
+### Storing Queries with Specific Data Sources
 
-You can store queries with a specific data repository, so they automatically execute against the correct database:
+You can store queries with a specific data source, so they automatically execute against the correct database:
 
 ```elixir
 # Create a query that will run against the analytics database
@@ -133,31 +133,31 @@ You can store queries with a specific data repository, so they automatically exe
     sql: "SELECT COUNT(*) FROM page_views WHERE date = $1",
     params: [Date.utc_today()]
   },
-  data_repo: "analytics"
+  data_source: "analytics"
 })
 
 # Create a query for the main database
 {:ok, user_query} = Lotus.create_query(%{
   name: "Active Users",
   statement: "SELECT COUNT(*) FROM users WHERE active = true",
-  data_repo: "main"
+  data_source: "main"
 })
 
-# Execute queries - they automatically use their stored data_repo
+# Execute queries - they automatically use their stored data_source
 {:ok, analytics_result} = Lotus.run_query(analytics_query)
 {:ok, user_result} = Lotus.run_query(user_query)
 ```
 
 ### Runtime Repository Override
 
-You can override the stored data repository at execution time:
+You can override the stored data source at execution time:
 
 ```elixir
-# Query was saved with data_repo: "analytics"
+# Query was saved with data_source: "analytics"
 {:ok, query} = Lotus.create_query(%{
   name: "User Count",
   statement: "SELECT COUNT(*) FROM users",
-  data_repo: "analytics"
+  data_source: "analytics"
 })
 
 # Execute against the stored repository
@@ -167,27 +167,27 @@ You can override the stored data repository at execution time:
 {:ok, result} = Lotus.run_query(query, repo: "main")
 ```
 
-### Default Repository Behavior
+### Default Data Source Behavior
 
-If you don't specify a `data_repo` when creating a query, it will use the configured `default_repo` when executed:
+If you don't specify a `data_source` when creating a query, it will use the configured `default_source` when executed:
 
 ```elixir
-# Configuration with default_repo
+# Configuration with default_source
 config :lotus,
-  default_repo: "main",
-  data_repos: %{
+  default_source: "main",
+  data_sources: %{
     "main" => MyApp.Repo,
     "analytics" => MyApp.AnalyticsRepo
   }
 
-# Query without specific data_repo
+# Query without specific data_source
 {:ok, query} = Lotus.create_query(%{
   name: "Generic Query",
   statement: "SELECT 1"
-  # No data_repo specified
+  # No data_source specified
 })
 
-# Will use the "main" repository (from default_repo config)
+# Will use the "main" data source (from default_source config)
 {:ok, result} = Lotus.run_query(query)
 ```
 
@@ -413,7 +413,7 @@ You can save a `search_path` with your queries to make them automatically resolv
     params: []
   },
   search_path: "reporting, public",
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 
 # Execute - automatically uses the stored search_path
@@ -452,7 +452,7 @@ Here are common patterns for using `search_path`:
   variables: [
     %{name: "is_active", type: :text, label: "Is Active", default: "true"}
   ],
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 
 # Execute for different tenants by overriding search_path
@@ -478,7 +478,7 @@ Here are common patterns for using `search_path`:
     """
   },
   search_path: "reporting, public",
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 
 # Use the same query structure for different contexts
@@ -505,7 +505,7 @@ Here are common patterns for using `search_path`:
     """
   },
   search_path: "public, analytics",  # users in public, events in analytics
-  data_repo: "postgres"
+  data_source: "postgres"
 })
 ```
 

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -30,8 +30,8 @@ Add Lotus configuration to your `config/config.exs`:
 ```elixir
 config :lotus,
   ecto_repo: MyApp.Repo,        # Where Lotus stores queries
-  default_repo: "main",         # Default repo for queries (required with multiple repos)
-  data_repos: %{                # Where queries execute
+  default_source: "main",       # Default data source for queries (required with multiple sources)
+  data_sources: %{              # Where queries execute
     "main" => MyApp.Repo,
     "analytics" => MyApp.AnalyticsRepo
   }
@@ -40,8 +40,8 @@ config :lotus,
 ### Configuration Options
 
 - `ecto_repo` (required): Repository where Lotus stores saved queries
-- `data_repos` (required): Map of repositories where queries can be executed
-- `default_repo`: Default repository name to use when none specified (required with multiple repos)
+- `data_sources` (required): Map of data sources where queries can be executed
+- `default_source`: Default data source name to use when none specified (required with multiple sources)
 - `unique_names`: Whether to enforce unique query names (default: `true`)
 - `table_visibility`: Rules controlling which tables can be accessed (optional)
 
@@ -85,7 +85,7 @@ To enable caching, just add a `:cache` entry to your Lotus configuration:
 # config/config.exs
 config :lotus,
   ecto_repo: MyApp.Repo,
-  data_repos: %{"main" => MyApp.Repo},
+  data_sources: %{"main" => MyApp.Repo},
   cache: %{
     adapter: Lotus.Cache.ETS,
     namespace: "myapp_lotus"
@@ -151,8 +151,8 @@ You can use different database types for storage and data:
 ```elixir
 config :lotus,
   ecto_repo: MyApp.Repo,          # PostgreSQL for Lotus storage
-  default_repo: "postgres",       # Default repository for queries
-  data_repos: %{
+  default_source: "postgres",     # Default data source for queries
+  data_sources: %{
     "postgres" => MyApp.Repo,     # PostgreSQL data
     "mysql" => MyApp.MySQLRepo,   # MySQL data
     "sqlite" => MyApp.SqliteRepo  # SQLite data

--- a/guides/schema-introspection.md
+++ b/guides/schema-introspection.md
@@ -413,7 +413,7 @@ defmodule MyApp.QueryBuilder do
         Lotus.create_query(%{
           name: "Count #{schema_name}.#{table_name}",
           query: %{sql: sql},
-          data_repo: repo_name,
+          data_source: repo_name,
           search_path: schema_name
         })
         

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -30,13 +30,13 @@ Runner / Preflight / Schema  ──▶  Adapter.execute_query(adapter, sql, para
 
 ## Default Behaviour
 
-If you are using Ecto repos and static configuration, no changes are needed. The default source resolver (`Lotus.Source.Resolvers.Static`) reads your existing `data_repos` config and wraps each repo in `Lotus.Source.Adapters.Ecto` automatically. Your existing configuration continues to work as before:
+If you are using Ecto repos and static configuration, no changes are needed. The default source resolver (`Lotus.Source.Resolvers.Static`) reads your existing `data_sources` config and wraps each repo in `Lotus.Source.Adapters.Ecto` automatically. Your existing configuration continues to work as before:
 
 ```elixir
 config :lotus,
   ecto_repo: MyApp.Repo,
-  default_repo: "main",
-  data_repos: %{
+  default_source: "main",
+  data_sources: %{
     "main" => MyApp.Repo,
     "analytics" => MyApp.AnalyticsRepo
   }

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -86,33 +86,51 @@ defmodule Lotus do
   def repo, do: Config.repo!()
 
   @doc """
-  Returns all configured data repositories.
+  Returns all configured data sources.
   """
-  def data_repos, do: Config.data_repos()
+  def data_sources, do: Config.data_sources()
 
   @doc """
-  Gets a data repository by name.
+  Gets a data source by name.
 
-  Raises if the repository is not configured.
+  Raises if the source is not configured.
   """
-  def get_data_repo!(name), do: Config.get_data_repo!(name)
+  def get_data_source!(name), do: Config.get_data_source!(name)
 
   @doc """
-  Lists the names of all configured data repositories.
+  Lists the names of all configured data sources.
 
   Useful for building UI dropdowns.
   """
-  def list_data_repo_names, do: Config.list_data_repo_names()
+  def list_data_source_names, do: Config.list_data_source_names()
 
   @doc """
-  Returns the default data repository as a {name, module} tuple.
+  Returns the default data source as a {name, module} tuple.
 
-  - If there's only one data repo configured, returns it
-  - If multiple repos are configured and default_repo is set, returns that repo
-  - If multiple repos are configured without default_repo, raises an error
-  - If no data repos are configured, raises an error
+  - If there's only one data source configured, returns it
+  - If multiple sources are configured and default_source is set, returns that source
+  - If multiple sources are configured without default_source, raises an error
+  - If no data sources are configured, raises an error
   """
-  def default_data_repo, do: Config.default_data_repo()
+  def default_data_source, do: Config.default_data_source()
+
+  # ── Deprecated aliases ──────────────────────────────────────────────────────
+
+  @doc false
+  @deprecated "Use data_sources/0 instead. Will be removed in v1.0"
+  def data_repos, do: data_sources()
+
+  @doc false
+  @deprecated "Use get_data_source!/1 instead. Will be removed in v1.0"
+  def get_data_repo!(name), do: get_data_source!(name)
+
+  @doc false
+  @deprecated "Use list_data_source_names/0 instead. Will be removed in v1.0"
+  def list_data_repo_names, do: list_data_source_names()
+
+  @doc false
+  @deprecated "Use default_data_source/0 instead. Will be removed in v1.0"
+  def default_data_repo, do: default_data_source()
 
   @doc """
   Lists all saved queries.
@@ -438,7 +456,7 @@ defmodule Lotus do
   end
 
   defp execute_query(q, sql, params, vars, opts) do
-    adapter = Sources.resolve!(Keyword.get(opts, :repo), q.data_repo)
+    adapter = Sources.resolve!(Keyword.get(opts, :repo), q.data_source)
     search_path = Keyword.get(opts, :search_path) || q.search_path
     runner_opts = prepare_final_opts(opts, search_path)
 
@@ -843,7 +861,7 @@ defmodule Lotus do
     Key.result(
       sql,
       bound_vars_map,
-      [data_repo: repo_name, search_path: search_path, lotus_version: Lotus.version()],
+      [data_source: repo_name, search_path: search_path, lotus_version: Lotus.version()],
       scope
     )
   end

--- a/lib/lotus/ai/actions/list_data_sources.ex
+++ b/lib/lotus/ai/actions/list_data_sources.ex
@@ -22,7 +22,7 @@ defmodule Lotus.AI.Actions.ListDataSources do
 
   @impl true
   def run(_params, _context) do
-    names = Lotus.list_data_repo_names()
+    names = Lotus.list_data_source_names()
 
     sources =
       Enum.map(names, fn name ->

--- a/lib/lotus/ai/query_optimizer.ex
+++ b/lib/lotus/ai/query_optimizer.ex
@@ -53,7 +53,7 @@ defmodule Lotus.AI.QueryOptimizer do
     temperature = Keyword.get(opts, :temperature, 0.1)
 
     database_type = Lotus.Sources.source_type(data_source)
-    repo = Lotus.Config.get_data_repo!(data_source)
+    repo = Lotus.Config.get_data_source!(data_source)
 
     execution_plan = get_execution_plan(repo, sql, params, search_path: search_path)
 

--- a/lib/lotus/cache/key_builder.ex
+++ b/lib/lotus/cache/key_builder.ex
@@ -63,7 +63,7 @@ defmodule Lotus.Cache.KeyBuilder do
 
   - `sql` - The SQL query string
   - `bound` - Bound parameters (map or list)
-  - `opts` - Options including `:data_repo`, `:search_path`, `:lotus_version`
+  - `opts` - Options including `:data_source`, `:search_path`, `:lotus_version`
   - `scope` - The scope term, or `nil` if no scope is set
   """
   @callback result_key(

--- a/lib/lotus/cache/key_builder/default.ex
+++ b/lib/lotus/cache/key_builder/default.ex
@@ -35,7 +35,7 @@ defmodule Lotus.Cache.KeyBuilder.Default do
 
   @impl true
   def result_key(sql, bound, opts, scope) do
-    repo = Keyword.fetch!(opts, :data_repo)
+    repo = Keyword.fetch!(opts, :data_source)
     path = Keyword.get(opts, :search_path, "") || ""
     version = Keyword.get(opts, :lotus_version, Lotus.version())
 

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -12,16 +12,19 @@ defmodule Lotus.Config do
       config :lotus,
         ecto_repo: MyApp.Repo  # Where Lotus stores its query definitions
 
-  ## Data Repositories Configuration
+  ## Data Sources Configuration
 
-  Configure named data repositories that Lotus can execute queries against:
+  Configure named data sources that Lotus can execute queries against:
 
       config :lotus,
-        data_repos: %{
+        data_sources: %{
           "primary" => MyApp.Repo,
           "analytics" => MyApp.AnalyticsRepo,
           "warehouse" => MyApp.WarehouseRepo
         }
+
+  > **Deprecation**: The `:data_repos` config key still works but emits a warning.
+  > Use `:data_sources` in new code.
 
   ## Visibility Configuration
 
@@ -68,17 +71,19 @@ defmodule Lotus.Config do
   ## Optional Configuration
 
       config :lotus,
-        default_repo: "primary",       # Default data repo for queries
+        default_source: "primary",     # Default data source for queries
         unique_names: false,           # Defaults to true
         read_only: false               # Defaults to true; set to false to allow writes
   """
+
+  require Logger
 
   @type t :: %{
           ecto_repo: module(),
           read_only: boolean(),
           unique_names: boolean(),
-          data_repos: %{String.t() => module()},
-          default_repo: String.t() | nil,
+          data_sources: %{String.t() => module()},
+          default_source: String.t() | nil,
           default_page_size: pos_integer() | nil,
           table_visibility: map(),
           column_visibility: map(),
@@ -111,17 +116,17 @@ defmodule Lotus.Config do
       doc:
         "When true (default), blocks write operations (INSERT, UPDATE, DELETE, DDL) at the application level. Set to false to allow write queries."
     ],
-    data_repos: [
+    data_sources: [
       type: {:map, :string, :atom},
       default: %{},
       doc:
-        "Named data repositories that can be used for query execution. Keys are strings, values are repo modules."
+        "Named data sources that can be used for query execution. Keys are strings, values are repo modules."
     ],
-    default_repo: [
+    default_source: [
       type: :string,
       required: false,
       doc:
-        "The default data repository name to use when no repo is specified. Required when multiple data_repos are configured."
+        "The default data source name to use when no source is specified. Required when multiple data_sources are configured."
     ],
     default_page_size: [
       type: {:or, [:pos_integer, nil]},
@@ -295,7 +300,9 @@ defmodule Lotus.Config do
       :read_only,
       :unique_names,
       :data_repos,
+      :data_sources,
       :default_repo,
+      :default_source,
       :default_page_size,
       :table_visibility,
       :column_visibility,
@@ -306,6 +313,34 @@ defmodule Lotus.Config do
       :visibility_resolver,
       :middleware
     ])
+    |> normalize_deprecated_keys()
+  end
+
+  defp normalize_deprecated_keys(opts) do
+    opts
+    |> normalize_key(:data_repos, :data_sources)
+    |> normalize_key(:default_repo, :default_source)
+  end
+
+  defp normalize_key(opts, old_key, new_key) do
+    has_old = Keyword.has_key?(opts, old_key)
+    has_new = Keyword.has_key?(opts, new_key)
+
+    cond do
+      has_old and has_new ->
+        raise ArgumentError,
+              "Cannot configure both :#{old_key} and :#{new_key}. " <>
+                "Use :#{new_key} only — :#{old_key} is deprecated."
+
+      has_old ->
+        Logger.warning("Lotus config :#{old_key} is deprecated. Use :#{new_key} instead.")
+
+        value = Keyword.fetch!(opts, old_key)
+        opts |> Keyword.delete(old_key) |> Keyword.put(new_key, value)
+
+      true ->
+        opts
+    end
   end
 
   @doc """
@@ -327,103 +362,142 @@ defmodule Lotus.Config do
   def read_only?, do: load!()[:read_only]
 
   @doc """
-  Returns the configured data repositories.
+  Returns the configured data sources.
   """
-  @spec data_repos() :: %{String.t() => module()}
-  def data_repos, do: load!()[:data_repos]
+  @spec data_sources() :: %{String.t() => module()}
+  def data_sources, do: load!()[:data_sources]
 
   @doc """
-  Gets a data repository by name.
+  Gets a data source by name.
 
-  Returns the repo module or raises if not found.
+  Returns the source module or raises if not found.
   """
-  @spec get_data_repo!(String.t()) :: module()
-  def get_data_repo!(name) do
-    case Map.get(data_repos(), name) do
+  @spec get_data_source!(String.t()) :: module()
+  def get_data_source!(name) do
+    case Map.get(data_sources(), name) do
       nil ->
         raise ArgumentError,
-              "Data repo '#{name}' not configured. Available repos: #{inspect(Map.keys(data_repos()))}"
+              "Data source '#{name}' not configured. " <>
+                "Available sources: #{inspect(Map.keys(data_sources()))}"
 
-      repo ->
-        repo
+      source ->
+        source
     end
   end
 
   @doc """
-  Lists the names of all configured data repositories.
+  Lists the names of all configured data sources.
   """
-  @spec list_data_repo_names() :: [String.t()]
-  def list_data_repo_names, do: Map.keys(data_repos())
+  @spec list_data_source_names() :: [String.t()]
+  def list_data_source_names, do: Map.keys(data_sources())
 
   @doc """
-  Returns the default data repository as a {name, module} tuple.
+  Returns the default data source as a {name, module} tuple.
 
-  - If default_repo is configured, returns that repo
-  - If default_repo is not configured, returns the first available repo
-  - If no data repos are configured, raises an error
+  - If default_source is configured, returns that source
+  - If default_source is not configured, returns the first available source
+  - If no data sources are configured, raises an error
   """
-  @spec default_data_repo() :: {String.t(), module()}
-  def default_data_repo do
-    repos = data_repos()
+  @spec default_data_source() :: {String.t(), module()}
+  def default_data_source do
+    sources = data_sources()
 
-    case :maps.size(repos) do
+    case :maps.size(sources) do
       0 ->
         raise ArgumentError, """
-        No data repository available for query execution.
+        No data source available for query execution.
 
-        Please configure at least one data repository:
+        Please configure at least one data source:
 
             config :lotus,
-              data_repos: %{
+              data_sources: %{
                 "primary" => MyApp.Repo
               }
         """
 
       _ ->
-        case load!()[:default_repo] do
+        case load!()[:default_source] do
           nil ->
-            Enum.at(repos, 0)
+            Enum.at(sources, 0)
 
           default_name ->
-            {default_name, get_data_repo!(default_name)}
+            {default_name, get_data_source!(default_name)}
         end
     end
   end
 
   @doc """
-  Returns table visibility rules for a specific repository.
+  Returns table visibility rules for a specific source.
 
-  Falls back to default rules if repo-specific rules are not configured.
+  Falls back to default rules if source-specific rules are not configured.
   """
+  @spec rules_for_source_name(String.t()) :: keyword()
+  def rules_for_source_name(source_name),
+    do: visibility_rules_for(:table_visibility, source_name)
+
+  @doc """
+  Returns schema visibility rules for a specific source.
+
+  Falls back to default rules if source-specific rules are not configured.
+  """
+  @spec schema_rules_for_source_name(String.t()) :: keyword()
+  def schema_rules_for_source_name(source_name),
+    do: visibility_rules_for(:schema_visibility, source_name)
+
+  @doc """
+  Returns column visibility rules for a specific source.
+
+  Falls back to default rules if source-specific rules are not configured.
+  """
+  @spec column_rules_for_source_name(String.t()) :: list()
+  def column_rules_for_source_name(source_name),
+    do: visibility_rules_for(:column_visibility, source_name)
+
+  # ── Deprecated aliases ──────────────────────────────────────────────────────
+
+  @doc false
+  @deprecated "Use data_sources/0 instead. Will be removed in v1.0"
+  @spec data_repos() :: %{String.t() => module()}
+  def data_repos, do: data_sources()
+
+  @doc false
+  @deprecated "Use get_data_source!/1 instead. Will be removed in v1.0"
+  @spec get_data_repo!(String.t()) :: module()
+  def get_data_repo!(name), do: get_data_source!(name)
+
+  @doc false
+  @deprecated "Use list_data_source_names/0 instead. Will be removed in v1.0"
+  @spec list_data_repo_names() :: [String.t()]
+  def list_data_repo_names, do: list_data_source_names()
+
+  @doc false
+  @deprecated "Use default_data_source/0 instead. Will be removed in v1.0"
+  @spec default_data_repo() :: {String.t(), module()}
+  def default_data_repo, do: default_data_source()
+
+  @doc false
+  @deprecated "Use rules_for_source_name/1 instead. Will be removed in v1.0"
   @spec rules_for_repo_name(String.t()) :: keyword()
-  def rules_for_repo_name(repo_name), do: visibility_rules_for(:table_visibility, repo_name)
+  def rules_for_repo_name(name), do: rules_for_source_name(name)
 
-  @doc """
-  Returns schema visibility rules for a specific repository.
-
-  Falls back to default rules if repo-specific rules are not configured.
-  """
+  @doc false
+  @deprecated "Use schema_rules_for_source_name/1 instead. Will be removed in v1.0"
   @spec schema_rules_for_repo_name(String.t()) :: keyword()
-  def schema_rules_for_repo_name(repo_name),
-    do: visibility_rules_for(:schema_visibility, repo_name)
+  def schema_rules_for_repo_name(name), do: schema_rules_for_source_name(name)
 
-  @doc """
-  Returns column visibility rules for a specific repository.
-
-  Falls back to default rules if repo-specific rules are not configured.
-  """
+  @doc false
+  @deprecated "Use column_rules_for_source_name/1 instead. Will be removed in v1.0"
   @spec column_rules_for_repo_name(String.t()) :: list()
-  def column_rules_for_repo_name(repo_name),
-    do: visibility_rules_for(:column_visibility, repo_name)
+  def column_rules_for_repo_name(name), do: column_rules_for_source_name(name)
 
-  # Shared lookup for repo-keyed visibility maps. Matches the repo name
+  # Shared lookup for source-keyed visibility maps. Matches the source name
   # string against map keys via `to_string/1`, then falls back to the
   # `:default` entry, then to an empty list.
-  defp visibility_rules_for(key, repo_name) do
+  defp visibility_rules_for(key, source_name) do
     visibility_config = load!()[key] || %{}
-    repo_key = Enum.find(Map.keys(visibility_config), &(to_string(&1) == repo_name))
+    source_key = Enum.find(Map.keys(visibility_config), &(to_string(&1) == source_name))
 
-    (repo_key && visibility_config[repo_key]) || visibility_config[:default] || []
+    (source_key && visibility_config[source_key]) || visibility_config[:default] || []
   end
 
   @doc """

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -7,7 +7,9 @@ defmodule Lotus.Source do
 
   alias Lotus.Source.Adapter
 
-  @type repo :: Ecto.Repo.t()
+  @type source_module :: Ecto.Repo.t()
+
+  @typep repo :: source_module()
 
   @callback execute_in_transaction(repo, (-> any()), keyword()) :: {:ok, any()} | {:error, any()}
   @callback set_statement_timeout(repo, non_neg_integer()) :: :ok | no_return()
@@ -315,7 +317,7 @@ defmodule Lotus.Source do
   @spec param_placeholder(repo | String.t() | nil, pos_integer(), String.t(), atom() | nil) ::
           String.t()
   def param_placeholder(repo_or_name, index, var, type) when is_integer(index) and index > 0 do
-    impl_for(resolve_repo!(repo_or_name)).param_placeholder(index, var, type)
+    impl_for(resolve_source!(repo_or_name)).param_placeholder(index, var, type)
   end
 
   @doc """
@@ -331,17 +333,17 @@ defmodule Lotus.Source do
   def limit_offset_placeholders(repo_or_name, limit_index, offset_index)
       when is_integer(limit_index) and limit_index > 0 and is_integer(offset_index) and
              offset_index > 0 do
-    impl_for(resolve_repo!(repo_or_name)).limit_offset_placeholders(limit_index, offset_index)
+    impl_for(resolve_source!(repo_or_name)).limit_offset_placeholders(limit_index, offset_index)
   end
 
-  defp resolve_repo!(repo) when is_atom(repo) and not is_nil(repo), do: repo
+  defp resolve_source!(source) when is_atom(source) and not is_nil(source), do: source
 
-  defp resolve_repo!(repo_name) when is_binary(repo_name) do
-    Lotus.Config.get_data_repo!(repo_name)
+  defp resolve_source!(source_name) when is_binary(source_name) do
+    Lotus.Config.get_data_source!(source_name)
   end
 
-  defp resolve_repo!(nil) do
-    {_name, mod} = Lotus.Config.default_data_repo()
+  defp resolve_source!(nil) do
+    {_name, mod} = Lotus.Config.default_data_source()
     mod
   end
 
@@ -433,7 +435,7 @@ defmodule Lotus.Source do
   """
   @spec quote_identifier(repo | String.t() | nil, String.t()) :: String.t()
   def quote_identifier(repo_or_name, identifier) do
-    impl_for(resolve_repo!(repo_or_name)).quote_identifier(identifier)
+    impl_for(resolve_source!(repo_or_name)).quote_identifier(identifier)
   end
 
   @doc """
@@ -449,7 +451,7 @@ defmodule Lotus.Source do
   end
 
   def apply_filters(repo_or_name, sql, params, filters) do
-    impl_for(resolve_repo!(repo_or_name)).apply_filters(sql, params, filters)
+    impl_for(resolve_source!(repo_or_name)).apply_filters(sql, params, filters)
   end
 
   @doc """
@@ -465,6 +467,6 @@ defmodule Lotus.Source do
   end
 
   def apply_sorts(repo_or_name, sql, sorts) do
-    impl_for(resolve_repo!(repo_or_name)).apply_sorts(sql, sorts)
+    impl_for(resolve_source!(repo_or_name)).apply_sorts(sql, sorts)
   end
 end

--- a/lib/lotus/source/resolver.ex
+++ b/lib/lotus/source/resolver.ex
@@ -3,7 +3,7 @@ defmodule Lotus.Source.Resolver do
   Behaviour for resolving named data sources to adapters.
 
   This is a **supported extension point**. The default implementation
-  (`Lotus.Source.Resolvers.Static`) reads from static `data_repos`
+  (`Lotus.Source.Resolvers.Static`) reads from static `data_sources`
   configuration, which is all most applications need. Alternative
   implementations can resolve sources from registries, databases, or
   external services — for example to register sources at runtime, to
@@ -20,7 +20,7 @@ defmodule Lotus.Source.Resolver do
   """
 
   @callback resolve(
-              repo_opt :: nil | String.t() | module(),
+              source_opt :: nil | String.t() | module(),
               fallback :: nil | String.t() | module()
             ) :: {:ok, Lotus.Source.Adapter.t()} | {:error, term()}
 

--- a/lib/lotus/source/resolvers/static.ex
+++ b/lib/lotus/source/resolvers/static.ex
@@ -1,14 +1,14 @@
 defmodule Lotus.Source.Resolvers.Static do
   @moduledoc """
-  Default source resolver that reads from static `data_repos` configuration.
+  Default source resolver that reads from static `data_sources` configuration.
 
   Preserves the resolution priority logic from `Lotus.Sources.resolve!/2`:
 
-    1. `repo_opt` as string name — lookup in data_repos, wrap in adapter
-    2. `repo_opt` as module — reverse lookup (find name for module), wrap in adapter
+    1. `source_opt` as string name — lookup in data_sources, wrap in adapter
+    2. `source_opt` as module — reverse lookup (find name for module), wrap in adapter
     3. `fallback` as string name — lookup
     4. `fallback` as module — reverse lookup
-    5. Both nil — use `Config.default_data_repo()`
+    5. Both nil — use `Config.default_data_source()`
     6. Not found — `{:error, :not_found}`
   """
 
@@ -22,18 +22,18 @@ defmodule Lotus.Source.Resolvers.Static do
   # ---------------------------------------------------------------------------
 
   @impl true
-  def resolve(repo_opt, fallback) do
+  def resolve(source_opt, fallback) do
     cond do
-      is_binary(repo_opt) ->
-        lookup_by_name(repo_opt)
+      is_binary(source_opt) ->
+        lookup_by_name(source_opt)
 
-      repo_module?(repo_opt) ->
-        lookup_by_module(repo_opt)
+      source_module?(source_opt) ->
+        lookup_by_module(source_opt)
 
       is_binary(fallback) ->
         lookup_by_name(fallback)
 
-      repo_module?(fallback) ->
+      source_module?(fallback) ->
         lookup_by_module(fallback)
 
       true ->
@@ -43,24 +43,24 @@ defmodule Lotus.Source.Resolvers.Static do
 
   @impl true
   def list_sources do
-    Config.data_repos()
+    Config.data_sources()
     |> Enum.map(fn {name, mod} -> EctoAdapter.wrap(name, mod) end)
   end
 
   @impl true
   def get_source!(name) do
-    mod = Config.get_data_repo!(name)
+    mod = Config.get_data_source!(name)
     EctoAdapter.wrap(name, mod)
   end
 
   @impl true
   def list_source_names do
-    Config.list_data_repo_names()
+    Config.list_data_source_names()
   end
 
   @impl true
   def default_source do
-    {name, mod} = Config.default_data_repo()
+    {name, mod} = Config.default_data_source()
     {name, EctoAdapter.wrap(name, mod)}
   end
 
@@ -69,26 +69,26 @@ defmodule Lotus.Source.Resolvers.Static do
   # ---------------------------------------------------------------------------
 
   defp lookup_by_name(name) do
-    case Map.get(Config.data_repos(), name) do
+    case Map.get(Config.data_sources(), name) do
       nil -> {:error, :not_found}
       mod -> {:ok, EctoAdapter.wrap(name, mod)}
     end
   end
 
   defp lookup_by_module(mod) do
-    case Enum.find(Config.data_repos(), fn {_name, m} -> m == mod end) do
+    case Enum.find(Config.data_sources(), fn {_name, m} -> m == mod end) do
       {name, _} -> {:ok, EctoAdapter.wrap(name, mod)}
       nil -> {:error, :not_found}
     end
   end
 
-  defp repo_module?(mod) when is_atom(mod) and not is_nil(mod),
+  defp source_module?(mod) when is_atom(mod) and not is_nil(mod),
     do: function_exported?(mod, :__adapter__, 0)
 
-  defp repo_module?(_), do: false
+  defp source_module?(_), do: false
 
   defp default_adapter do
-    {name, mod} = Config.default_data_repo()
+    {name, mod} = Config.default_data_source()
     EctoAdapter.wrap(name, mod)
   end
 end

--- a/lib/lotus/sources.ex
+++ b/lib/lotus/sources.ex
@@ -8,24 +8,24 @@ defmodule Lotus.Sources do
   Resolve to an `%Adapter{}` struct.
 
   Accepts:
-    * `repo_opt` — configured name (string) or repo module (atom) or nil
-    * `q_repo`   — query's stored repo (string or module) or nil
+    * `source_opt` — configured name (string) or source module (atom) or nil
+    * `q_source`   — query's stored source (string or module) or nil
 
   Falls back to the default source. Raises on resolution failure.
   """
   @spec resolve!(nil | String.t() | module(), nil | String.t() | module()) :: Adapter.t()
-  def resolve!(repo_opt, q_repo) do
-    case resolver().resolve(repo_opt, q_repo) do
+  def resolve!(source_opt, q_source) do
+    case resolver().resolve(source_opt, q_source) do
       {:ok, %Adapter{} = adapter} ->
         adapter
 
       {:error, :not_found} ->
         available = resolver().list_source_names()
-        label = repo_opt || q_repo
+        label = source_opt || q_source
 
         raise ArgumentError,
-              "Data repo '#{label}' not configured. " <>
-                "Available repos: #{inspect(available)}"
+              "Data source '#{label}' not configured. " <>
+                "Available sources: #{inspect(available)}"
     end
   end
 
@@ -53,14 +53,14 @@ defmodule Lotus.Sources do
   @doc false
   @spec name_from_module!(module()) :: String.t()
   def name_from_module!(mod) do
-    case Enum.find(Config.data_repos(), fn {_name, m} -> m == mod end) do
+    case Enum.find(Config.data_sources(), fn {_name, m} -> m == mod end) do
       {name, _} ->
         name
 
       nil ->
         raise ArgumentError,
-              "Repo module #{inspect(mod)} isn't in :lotus, :data_repos. " <>
-                "Configured names: #{inspect(Map.keys(Config.data_repos()))}"
+              "Source module #{inspect(mod)} isn't in :lotus, :data_sources. " <>
+                "Configured names: #{inspect(Map.keys(Config.data_sources()))}"
     end
   end
 
@@ -72,7 +72,7 @@ defmodule Lotus.Sources do
   def source_type(%Adapter{source_type: st}), do: st
 
   def source_type(repo_name) when is_binary(repo_name) do
-    repo = Config.get_data_repo!(repo_name)
+    repo = Config.get_data_source!(repo_name)
     source_type(repo)
   end
 

--- a/lib/lotus/sql/validator.ex
+++ b/lib/lotus/sql/validator.ex
@@ -35,7 +35,7 @@ defmodule Lotus.SQL.Validator do
       |> OptionalClause.strip_brackets()
       |> Variables.neutralize("NULL")
 
-    repo = Lotus.Config.get_data_repo!(data_source)
+    repo = Lotus.Config.get_data_source!(data_source)
 
     case Lotus.Source.explain_plan(repo, neutralized) do
       {:ok, _plan} -> :ok

--- a/lib/lotus/storage/query.ex
+++ b/lib/lotus/storage/query.ex
@@ -24,7 +24,7 @@ defmodule Lotus.Storage.Query do
           description: String.t() | nil,
           statement: String.t(),
           variables: [QueryVariable.t()],
-          data_repo: String.t() | nil,
+          data_source: String.t() | nil,
           search_path: String.t() | nil,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
@@ -42,7 +42,7 @@ defmodule Lotus.Storage.Query do
              :description,
              :statement,
              :variables,
-             :data_repo,
+             :data_source,
              :search_path,
              :inserted_at,
              :updated_at
@@ -52,7 +52,7 @@ defmodule Lotus.Storage.Query do
     field(:name, :string)
     field(:description, :string)
     field(:statement, :string)
-    field(:data_repo, :string)
+    field(:data_source, :string, source: :data_repo)
     field(:search_path, :string)
 
     embeds_many(:variables, QueryVariable, on_replace: :delete)
@@ -61,7 +61,7 @@ defmodule Lotus.Storage.Query do
   end
 
   @required ~w(name statement)a
-  @permitted ~w(name description statement data_repo search_path)a
+  @permitted ~w(name description statement data_source search_path)a
 
   def new(attrs), do: changeset(%__MODULE__{}, attrs)
   def update(query, attrs), do: changeset(query, attrs)
@@ -73,7 +73,7 @@ defmodule Lotus.Storage.Query do
     |> validate_required(@required)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_statement()
-    |> validate_data_repo()
+    |> validate_data_source()
     |> validate_search_path()
     |> maybe_add_unique_constraint()
   end
@@ -90,8 +90,8 @@ defmodule Lotus.Storage.Query do
   @spec to_sql_params(t(), map()) ::
           {:ok, String.t(), [term()]} | {:error, String.t()}
   def to_sql_params(%__MODULE__{statement: sql, variables: vars} = q, supplied_vars \\ %{}) do
-    repo = get_repo(q.data_repo)
-    source_type = get_source_type(q.data_repo)
+    repo = get_repo(q.data_source)
+    source_type = get_source_type(q.data_source)
     source_module = get_source_module(repo)
 
     # Process optional clauses before transformation
@@ -197,7 +197,7 @@ defmodule Lotus.Storage.Query do
           Enum.reduce_while(values, init, fn v, {:ok, {phs, cvs, i}} ->
             case determine_type_and_cast(v, manual_type, binding) do
               {:ok, {final_type, casted}} ->
-                ph = Lotus.Source.param_placeholder(q.data_repo, i, var, final_type)
+                ph = Lotus.Source.param_placeholder(q.data_source, i, var, final_type)
                 {:cont, {:ok, {[ph | phs], [casted | cvs], i + 1}}}
 
               {:error, _} = err ->
@@ -217,7 +217,7 @@ defmodule Lotus.Storage.Query do
 
   defp substitute_scalar_variable(var, value, manual_type, binding, q, acc_sql, acc_params, idx) do
     with {:ok, {final_type, casted_value}} <- determine_type_and_cast(value, manual_type, binding) do
-      placeholder = Lotus.Source.param_placeholder(q.data_repo, idx, var, final_type)
+      placeholder = Lotus.Source.param_placeholder(q.data_source, idx, var, final_type)
       new_sql = String.replace(acc_sql, "{{#{var}}}", placeholder, global: false)
       {:ok, {new_sql, acc_params ++ [casted_value], idx + 1}}
     end
@@ -259,15 +259,15 @@ defmodule Lotus.Storage.Query do
   end
 
   defp get_repo(nil) do
-    {_name, repo} = Config.default_data_repo()
+    {_name, repo} = Config.default_data_source()
     repo
   end
 
-  defp get_repo(repo_name) when is_binary(repo_name) do
-    Config.data_repos()
-    |> Map.get(repo_name)
+  defp get_repo(source_name) when is_binary(source_name) do
+    Config.data_sources()
+    |> Map.get(source_name)
     |> case do
-      nil -> raise ArgumentError, "Unknown data repo: #{repo_name}"
+      nil -> raise ArgumentError, "Unknown data source: #{source_name}"
       repo -> repo
     end
   end
@@ -275,7 +275,7 @@ defmodule Lotus.Storage.Query do
   defp get_repo(repo) when is_atom(repo), do: repo
 
   defp get_source_type(nil) do
-    {_name, repo} = Config.default_data_repo()
+    {_name, repo} = Config.default_data_source()
     Sources.source_type(repo)
   end
 
@@ -460,27 +460,27 @@ defmodule Lotus.Storage.Query do
     end
   end
 
-  defp validate_data_repo(changeset) do
-    case get_change(changeset, :data_repo) do
+  defp validate_data_source(changeset) do
+    case get_change(changeset, :data_source) do
       nil ->
         changeset
 
       "" ->
-        put_change(changeset, :data_repo, nil)
+        put_change(changeset, :data_source, nil)
 
-      repo_name when is_binary(repo_name) ->
-        if repo_name in Map.keys(Config.data_repos()) do
+      source_name when is_binary(source_name) ->
+        if source_name in Map.keys(Config.data_sources()) do
           changeset
         else
           add_error(
             changeset,
-            :data_repo,
-            "must be one of: #{Enum.join(Map.keys(Config.data_repos()), ", ")}"
+            :data_source,
+            "must be one of: #{Enum.join(Map.keys(Config.data_sources()), ", ")}"
           )
         end
 
       _ ->
-        add_error(changeset, :data_repo, "must be a string")
+        add_error(changeset, :data_source, "must be a string")
     end
   end
 

--- a/lib/lotus/visibility.ex
+++ b/lib/lotus/visibility.ex
@@ -380,7 +380,7 @@ defmodule Lotus.Visibility do
   Resolves the column policy for a given result column name in the context of
   accessed relations and repo.
 
-  Rules are taken from `Lotus.Config.column_rules_for_repo_name/1` and support patterns
+  Rules are taken from `Lotus.Config.column_rules_for_source_name/1` and support patterns
   on schema, table, and column names. Returns a normalized policy map or nil.
   """
   @spec column_policy_for(String.t(), [{String.t() | nil, String.t()}], String.t(), term()) ::

--- a/lib/lotus/visibility/resolvers/static.ex
+++ b/lib/lotus/visibility/resolvers/static.ex
@@ -41,16 +41,16 @@ defmodule Lotus.Visibility.Resolvers.Static do
 
   @impl true
   def schema_rules_for(source_name, _scope) do
-    Lotus.Config.schema_rules_for_repo_name(source_name)
+    Lotus.Config.schema_rules_for_source_name(source_name)
   end
 
   @impl true
   def table_rules_for(source_name, _scope) do
-    Lotus.Config.rules_for_repo_name(source_name)
+    Lotus.Config.rules_for_source_name(source_name)
   end
 
   @impl true
   def column_rules_for(source_name, _scope) do
-    Lotus.Config.column_rules_for_repo_name(source_name)
+    Lotus.Config.column_rules_for_source_name(source_name)
   end
 end

--- a/test/integration/caching_test.exs
+++ b/test/integration/caching_test.exs
@@ -213,7 +213,7 @@ defmodule Lotus.Integration.CachingTest do
       query = %Query{
         statement: "SELECT name FROM test_users WHERE id = {{user_id}}",
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result1} = Lotus.run_query(query, vars: %{"user_id" => user.id})
@@ -230,7 +230,7 @@ defmodule Lotus.Integration.CachingTest do
       query = %Query{
         statement: "SELECT name FROM test_users WHERE id = {{user_id}}",
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result1} = Lotus.run_query(query, vars: %{"user_id" => user.id})
@@ -252,7 +252,7 @@ defmodule Lotus.Integration.CachingTest do
       query = %Query{
         statement: "SELECT name FROM test_users WHERE id = {{user_id}}",
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result1} = Lotus.run_query(query, vars: %{"user_id" => user.id})
@@ -280,7 +280,7 @@ defmodule Lotus.Integration.CachingTest do
       query = %Query{
         statement: "SELECT name FROM test_users WHERE id = {{user_id}}",
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, _result} =

--- a/test/integration/mysql/interval_query_test.exs
+++ b/test/integration/mysql/interval_query_test.exs
@@ -48,7 +48,7 @@ defmodule Lotus.Integration.Mysql.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: "mysql"
+        data_source: "mysql"
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})
@@ -70,7 +70,7 @@ defmodule Lotus.Integration.Mysql.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: "mysql"
+        data_source: "mysql"
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})
@@ -89,7 +89,7 @@ defmodule Lotus.Integration.Mysql.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: "mysql"
+        data_source: "mysql"
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})

--- a/test/integration/mysql/quoted_vars_test.exs
+++ b/test/integration/mysql/quoted_vars_test.exs
@@ -24,7 +24,7 @@ defmodule Lotus.Integration.Mysql.QuotedVarsTest do
         WHERE name = '{{name}}'
         """,
         variables: [%{name: "name", type: :text, default: nil}],
-        data_repo: "mysql"
+        data_source: "mysql"
       }
 
       result = Lotus.run_query(query, vars: %{"name" => "John Doe"})
@@ -43,7 +43,7 @@ defmodule Lotus.Integration.Mysql.QuotedVarsTest do
         ORDER BY name
         """,
         variables: [%{name: "q", type: :text, default: nil}],
-        data_repo: "mysql"
+        data_source: "mysql"
       }
 
       result = Lotus.run_query(query, vars: %{"q" => "John"})

--- a/test/integration/mysql/window_pagination_test.exs
+++ b/test/integration/mysql/window_pagination_test.exs
@@ -69,7 +69,7 @@ defmodule Lotus.Integration.Mysql.WindowPaginationTest do
         ORDER BY name
         """,
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result} =
@@ -89,7 +89,7 @@ defmodule Lotus.Integration.Mysql.WindowPaginationTest do
         ORDER BY name
         """,
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result} =

--- a/test/integration/postgres/interval_query_test.exs
+++ b/test/integration/postgres/interval_query_test.exs
@@ -48,7 +48,7 @@ defmodule Lotus.Integration.Postgres.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})
@@ -69,7 +69,7 @@ defmodule Lotus.Integration.Postgres.IntervalQueryTest do
           AND published_at IS NOT NULL
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 1})
@@ -86,7 +86,7 @@ defmodule Lotus.Integration.Postgres.IntervalQueryTest do
           AND published_at IS NOT NULL
         """,
         variables: [%{name: "unit", type: :text, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"unit" => "days"})
@@ -106,7 +106,7 @@ defmodule Lotus.Integration.Postgres.IntervalQueryTest do
           %{name: "days", type: :number, default: nil},
           %{name: "unit", type: :text, default: nil}
         ],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7, "unit" => "days"})
@@ -125,7 +125,7 @@ defmodule Lotus.Integration.Postgres.IntervalQueryTest do
         variables: [
           %{name: "interval", type: :text, default: nil}
         ],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"interval" => "7 days"})
@@ -143,7 +143,7 @@ defmodule Lotus.Integration.Postgres.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})
@@ -162,7 +162,7 @@ defmodule Lotus.Integration.Postgres.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})

--- a/test/integration/postgres/quoted_vars_test.exs
+++ b/test/integration/postgres/quoted_vars_test.exs
@@ -24,7 +24,7 @@ defmodule Lotus.Integration.Postgres.QuotedVarsTest do
         WHERE name = '{{name}}'
         """,
         variables: [%{name: "name", type: :text, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"name" => "John Doe"})
@@ -42,7 +42,7 @@ defmodule Lotus.Integration.Postgres.QuotedVarsTest do
         WHERE email = '{{email}}'
         """,
         variables: [%{name: "email", type: :text, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"email" => "jane@example.com"})
@@ -60,7 +60,7 @@ defmodule Lotus.Integration.Postgres.QuotedVarsTest do
         WHERE id = '{{user_id}}'::int
         """,
         variables: [%{name: "user_id", type: :number, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"user_id" => john_id})
@@ -79,7 +79,7 @@ defmodule Lotus.Integration.Postgres.QuotedVarsTest do
         ORDER BY name
         """,
         variables: [%{name: "q", type: :text, default: nil}],
-        data_repo: nil
+        data_source: nil
       }
 
       result = Lotus.run_query(query, vars: %{"q" => "John"})

--- a/test/integration/postgres/window_pagination_test.exs
+++ b/test/integration/postgres/window_pagination_test.exs
@@ -72,7 +72,7 @@ defmodule Lotus.Integration.Postgres.WindowPaginationTest do
         ORDER BY name
         """,
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result} =
@@ -92,7 +92,7 @@ defmodule Lotus.Integration.Postgres.WindowPaginationTest do
         ORDER BY name
         """,
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result} =

--- a/test/integration/sqlite/interval_query_test.exs
+++ b/test/integration/sqlite/interval_query_test.exs
@@ -48,7 +48,7 @@ defmodule Lotus.Integration.Sqlite.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})
@@ -67,7 +67,7 @@ defmodule Lotus.Integration.Sqlite.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "days", type: :number, default: nil}],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7})
@@ -89,7 +89,7 @@ defmodule Lotus.Integration.Sqlite.IntervalQueryTest do
         ORDER BY published_at DESC
         """,
         variables: [%{name: "unit", type: :text, default: nil}],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       result = Lotus.run_query(query, vars: %{"unit" => "days"})
@@ -114,7 +114,7 @@ defmodule Lotus.Integration.Sqlite.IntervalQueryTest do
           %{name: "days", type: :number, default: nil},
           %{name: "unit", type: :text, default: nil}
         ],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       result = Lotus.run_query(query, vars: %{"days" => 7, "unit" => "days"})

--- a/test/integration/sqlite/quoted_vars_test.exs
+++ b/test/integration/sqlite/quoted_vars_test.exs
@@ -24,7 +24,7 @@ defmodule Lotus.Integration.Sqlite.QuotedVarsTest do
         WHERE name = '{{name}}'
         """,
         variables: [%{name: "name", type: :text, default: nil}],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       result = Lotus.run_query(query, vars: %{"name" => "John Doe"})
@@ -43,7 +43,7 @@ defmodule Lotus.Integration.Sqlite.QuotedVarsTest do
         ORDER BY name
         """,
         variables: [%{name: "q", type: :text, default: nil}],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       result = Lotus.run_query(query, vars: %{"q" => "John"})

--- a/test/integration/sqlite/window_pagination_test.exs
+++ b/test/integration/sqlite/window_pagination_test.exs
@@ -69,7 +69,7 @@ defmodule Lotus.Integration.Sqlite.WindowPaginationTest do
         ORDER BY name
         """,
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result} =
@@ -89,7 +89,7 @@ defmodule Lotus.Integration.Sqlite.WindowPaginationTest do
         ORDER BY name
         """,
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       assert {:ok, result} =

--- a/test/integration/stream_to_csv_test.exs
+++ b/test/integration/stream_to_csv_test.exs
@@ -31,7 +31,7 @@ defmodule Lotus.Integration.StreamtToCSVTest do
         ORDER BY name
         """,
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       stream = Export.stream_csv(q, repo: "postgres", page_size: 2)

--- a/test/lotus/ai/actions/list_data_sources_test.exs
+++ b/test/lotus/ai/actions/list_data_sources_test.exs
@@ -10,7 +10,7 @@ defmodule Lotus.AI.Actions.ListDataSourcesTest do
 
   describe "run/2" do
     test "returns available data sources with types" do
-      stub(Lotus, :list_data_repo_names, fn -> ["primary", "analytics"] end)
+      stub(Lotus, :list_data_source_names, fn -> ["primary", "analytics"] end)
 
       stub(Lotus.Sources, :source_type, fn
         "primary" -> :postgres
@@ -26,7 +26,7 @@ defmodule Lotus.AI.Actions.ListDataSourcesTest do
     end
 
     test "returns empty list when no data sources configured" do
-      stub(Lotus, :list_data_repo_names, fn -> [] end)
+      stub(Lotus, :list_data_source_names, fn -> [] end)
 
       assert {:ok, result} = ListDataSources.run(%{}, %{})
       assert result.data_sources == []

--- a/test/lotus/ai/query_explainer_test.exs
+++ b/test/lotus/ai/query_explainer_test.exs
@@ -10,7 +10,7 @@ defmodule Lotus.AI.QueryExplainerTest do
       Mimic.copy(Lotus.Config)
 
       stub(Lotus.Sources, :source_type, fn _ -> :postgres end)
-      stub(Lotus.Config, :get_data_repo!, fn "postgres" -> Lotus.Test.Repo end)
+      stub(Lotus.Config, :get_data_source!, fn "postgres" -> Lotus.Test.Repo end)
 
       :ok
     end

--- a/test/lotus/ai/query_optimizer_test.exs
+++ b/test/lotus/ai/query_optimizer_test.exs
@@ -12,7 +12,7 @@ defmodule Lotus.AI.QueryOptimizerTest do
 
       stub(Lotus.Sources, :source_type, fn _ -> :postgres end)
 
-      stub(Lotus.Config, :get_data_repo!, fn "postgres" -> Lotus.Test.Repo end)
+      stub(Lotus.Config, :get_data_source!, fn "postgres" -> Lotus.Test.Repo end)
 
       stub(Lotus.Source, :explain_plan, fn _repo, _sql, _params, _opts ->
         {:ok, postgres_explain_plan()}

--- a/test/lotus/cache/key_builder_test.exs
+++ b/test/lotus/cache/key_builder_test.exs
@@ -107,7 +107,7 @@ defmodule Lotus.Cache.KeyBuilderTest do
         Default.result_key(
           "SELECT * FROM users",
           %{id: 1},
-          [data_repo: "primary", search_path: "public", lotus_version: "1.0.0"],
+          [data_source: "primary", search_path: "public", lotus_version: "1.0.0"],
           nil
         )
 
@@ -115,7 +115,7 @@ defmodule Lotus.Cache.KeyBuilderTest do
     end
 
     test "different SQL produces different keys" do
-      opts = [data_repo: "primary", search_path: "", lotus_version: "1.0.0"]
+      opts = [data_source: "primary", search_path: "", lotus_version: "1.0.0"]
       key_a = Default.result_key("SELECT 1", %{}, opts, nil)
       key_b = Default.result_key("SELECT 2", %{}, opts, nil)
 
@@ -127,7 +127,7 @@ defmodule Lotus.Cache.KeyBuilderTest do
         Default.result_key(
           "SELECT * FROM users WHERE id = $1",
           [42],
-          [data_repo: "primary", lotus_version: "1.0.0"],
+          [data_source: "primary", lotus_version: "1.0.0"],
           nil
         )
 
@@ -135,14 +135,14 @@ defmodule Lotus.Cache.KeyBuilderTest do
     end
 
     test "nil scope produces same key format as unscoped" do
-      opts = [data_repo: "primary", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "primary", search_path: "public", lotus_version: "1.0.0"]
       key = Default.result_key("SELECT 1", %{}, opts, nil)
 
       assert Regex.match?(~r/^result:primary:[a-f0-9]{64}$/, key)
     end
 
     test "non-nil scope appends scope digest to key" do
-      opts = [data_repo: "primary", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "primary", search_path: "public", lotus_version: "1.0.0"]
       scope = %{tenant_id: 42}
       key = Default.result_key("SELECT 1", %{}, opts, scope)
 
@@ -152,7 +152,7 @@ defmodule Lotus.Cache.KeyBuilderTest do
     end
 
     test "different scopes produce different keys for same query" do
-      opts = [data_repo: "primary", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "primary", search_path: "public", lotus_version: "1.0.0"]
       sql = "SELECT * FROM users"
 
       key_a = Default.result_key(sql, %{}, opts, %{tenant_id: 1})
@@ -162,7 +162,7 @@ defmodule Lotus.Cache.KeyBuilderTest do
     end
 
     test "same scope produces same key for same query" do
-      opts = [data_repo: "primary", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "primary", search_path: "public", lotus_version: "1.0.0"]
       sql = "SELECT * FROM users"
       scope = %{tenant_id: 42}
 

--- a/test/lotus/cache/key_test.exs
+++ b/test/lotus/cache/key_test.exs
@@ -7,7 +7,7 @@ defmodule Lotus.Cache.KeyTest do
     test "generates consistent cache keys for same parameters" do
       sql = "SELECT * FROM users WHERE active = $1 AND created_at > $2"
       bound_vars = %{"1" => true, "2" => ~D[2023-01-01]}
-      opts = [data_repo: "my_repo", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "my_repo", search_path: "public", lotus_version: "1.0.0"]
 
       key1 = Key.result(sql, bound_vars, opts)
       key2 = Key.result(sql, bound_vars, opts)
@@ -18,7 +18,7 @@ defmodule Lotus.Cache.KeyTest do
 
     test "generates different keys for different SQL queries" do
       bound_vars = %{"1" => 123}
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       key1 = Key.result("SELECT * FROM users WHERE id = $1", bound_vars, opts)
       key2 = Key.result("SELECT * FROM orders WHERE user_id = $1", bound_vars, opts)
@@ -28,7 +28,7 @@ defmodule Lotus.Cache.KeyTest do
 
     test "generates different keys for different bound variables" do
       sql = "SELECT * FROM users WHERE id = $1"
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       key1 = Key.result(sql, %{"1" => 123}, opts)
       key2 = Key.result(sql, %{"1" => 456}, opts)
@@ -36,12 +36,12 @@ defmodule Lotus.Cache.KeyTest do
       assert key1 != key2
     end
 
-    test "generates different keys for different data repositories" do
+    test "generates different keys for different data sources" do
       sql = "SELECT * FROM users WHERE id = $1"
       bound_vars = %{"1" => 123}
 
-      key1 = Key.result(sql, bound_vars, data_repo: "repo1")
-      key2 = Key.result(sql, bound_vars, data_repo: "repo2")
+      key1 = Key.result(sql, bound_vars, data_source: "repo1")
+      key2 = Key.result(sql, bound_vars, data_source: "repo2")
 
       assert key1 != key2
       assert String.starts_with?(key1, "result:repo1:")
@@ -51,7 +51,7 @@ defmodule Lotus.Cache.KeyTest do
     test "generates different keys for different search paths" do
       sql = "SELECT * FROM users WHERE id = $1"
       bound_vars = %{"1" => 123}
-      base_opts = [data_repo: "my_repo"]
+      base_opts = [data_source: "my_repo"]
 
       key1 = Key.result(sql, bound_vars, base_opts ++ [search_path: "public"])
       key2 = Key.result(sql, bound_vars, base_opts ++ [search_path: "tenant1"])
@@ -62,7 +62,7 @@ defmodule Lotus.Cache.KeyTest do
     test "generates different keys for different lotus versions" do
       sql = "SELECT * FROM users WHERE id = $1"
       bound_vars = %{"1" => 123}
-      base_opts = [data_repo: "my_repo"]
+      base_opts = [data_source: "my_repo"]
 
       key1 = Key.result(sql, bound_vars, base_opts ++ [lotus_version: "1.0.0"])
       key2 = Key.result(sql, bound_vars, base_opts ++ [lotus_version: "1.1.0"])
@@ -96,7 +96,7 @@ defmodule Lotus.Cache.KeyTest do
         "9" => 0
       }
 
-      opts = [data_repo: "analytics_repo", search_path: "reports"]
+      opts = [data_source: "analytics_repo", search_path: "reports"]
 
       key = Key.result(sql, bound_vars, opts)
 
@@ -114,7 +114,7 @@ defmodule Lotus.Cache.KeyTest do
         "4" => ~D[2023-06-15]
       }
 
-      opts = [data_repo: "test_repo"]
+      opts = [data_source: "test_repo"]
       key = Key.result(sql, bound_vars, opts)
 
       assert String.starts_with?(key, "result:test_repo:")
@@ -123,7 +123,7 @@ defmodule Lotus.Cache.KeyTest do
     test "handles empty bound variables" do
       sql = "SELECT COUNT(*) FROM users"
       bound_vars = %{}
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       key = Key.result(sql, bound_vars, opts)
 
@@ -133,7 +133,7 @@ defmodule Lotus.Cache.KeyTest do
     test "handles nil values in bound variables" do
       sql = "SELECT * FROM users WHERE optional_field = $1"
       bound_vars = %{"1" => nil}
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       key = Key.result(sql, bound_vars, opts)
 
@@ -143,7 +143,7 @@ defmodule Lotus.Cache.KeyTest do
     test "generates deterministic keys across processes" do
       sql = "SELECT * FROM users WHERE id = $1"
       bound_vars = %{"1" => 123}
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       task1 = Task.async(fn -> Key.result(sql, bound_vars, opts) end)
       task2 = Task.async(fn -> Key.result(sql, bound_vars, opts) end)
@@ -154,7 +154,7 @@ defmodule Lotus.Cache.KeyTest do
       assert key1 == key2
     end
 
-    test "requires data_repo option" do
+    test "requires data_source option" do
       sql = "SELECT * FROM users"
       bound_vars = %{}
 
@@ -166,7 +166,7 @@ defmodule Lotus.Cache.KeyTest do
     test "handles list params for ad-hoc SQL" do
       sql = "SELECT * FROM users WHERE id = $1 AND status = $2"
       params = [123, "active"]
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       key = Key.result(sql, params, opts)
 
@@ -175,7 +175,7 @@ defmodule Lotus.Cache.KeyTest do
 
     test "generates same key for list params wrapped in __params__ vs direct list" do
       sql = "SELECT * FROM users WHERE id = $1"
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       wrapped_params = %{__params__: [123]}
       key1 = Key.result(sql, wrapped_params, opts)
@@ -188,7 +188,7 @@ defmodule Lotus.Cache.KeyTest do
 
     test "generates different keys for map vars vs list params with same values" do
       sql = "SELECT * FROM users WHERE id = $1"
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       vars = %{"id" => 123}
       key1 = Key.result(sql, vars, opts)
@@ -202,7 +202,7 @@ defmodule Lotus.Cache.KeyTest do
     test "uses default search_path when not provided" do
       sql = "SELECT * FROM users WHERE id = $1"
       bound_vars = %{"1" => 123}
-      opts = [data_repo: "my_repo"]
+      opts = [data_source: "my_repo"]
 
       key = Key.result(sql, bound_vars, opts)
 
@@ -214,7 +214,7 @@ defmodule Lotus.Cache.KeyTest do
     test "nil scope produces same key as unscoped" do
       sql = "SELECT * FROM users"
       bound = %{"1" => 123}
-      opts = [data_repo: "my_repo", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "my_repo", search_path: "public", lotus_version: "1.0.0"]
 
       key_without = Key.result(sql, bound, opts)
       key_with_nil = Key.result(sql, bound, opts, nil)
@@ -225,7 +225,7 @@ defmodule Lotus.Cache.KeyTest do
     test "non-nil scope produces different key" do
       sql = "SELECT * FROM users"
       bound = %{"1" => 123}
-      opts = [data_repo: "my_repo", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "my_repo", search_path: "public", lotus_version: "1.0.0"]
 
       key_unscoped = Key.result(sql, bound, opts)
       key_scoped = Key.result(sql, bound, opts, %{tenant_id: 1})
@@ -236,7 +236,7 @@ defmodule Lotus.Cache.KeyTest do
     test "different scopes produce different keys" do
       sql = "SELECT * FROM users WHERE id = $1"
       bound = %{"1" => 123}
-      opts = [data_repo: "my_repo", search_path: "public", lotus_version: "1.0.0"]
+      opts = [data_source: "my_repo", search_path: "public", lotus_version: "1.0.0"]
 
       key_a = Key.result(sql, bound, opts, %{tenant_id: 1})
       key_b = Key.result(sql, bound, opts, %{tenant_id: 2})
@@ -249,7 +249,7 @@ defmodule Lotus.Cache.KeyTest do
     test "result keys follow expected format pattern" do
       sql = "SELECT * FROM test"
       bound_vars = %{"1" => "test"}
-      opts = [data_repo: "test_repo"]
+      opts = [data_source: "test_repo"]
 
       key = Key.result(sql, bound_vars, opts)
 
@@ -258,7 +258,7 @@ defmodule Lotus.Cache.KeyTest do
 
     test "keys use SHA256 hashes (64 hex characters)" do
       sql = "SELECT test"
-      opts = [data_repo: "repo"]
+      opts = [data_source: "repo"]
 
       result_key = Key.result(sql, %{}, opts)
 
@@ -270,7 +270,7 @@ defmodule Lotus.Cache.KeyTest do
 
     test "keys are case-insensitive (lowercase hex)" do
       sql = "SELECT test"
-      opts = [data_repo: "repo"]
+      opts = [data_source: "repo"]
 
       key = Key.result(sql, %{}, opts)
       hash = key |> String.split(":") |> List.last()

--- a/test/lotus/column_visibility_test.exs
+++ b/test/lotus/column_visibility_test.exs
@@ -22,7 +22,7 @@ defmodule Lotus.ColumnVisibilityTest do
       ]
 
       Lotus.Config
-      |> stub(:column_rules_for_repo_name, fn _repo -> rules end)
+      |> stub(:column_rules_for_source_name, fn _repo -> rules end)
 
       :ok
     end
@@ -63,7 +63,7 @@ defmodule Lotus.ColumnVisibilityTest do
       ]
 
       Lotus.Config
-      |> stub(:column_rules_for_repo_name, fn _repo -> rules end)
+      |> stub(:column_rules_for_source_name, fn _repo -> rules end)
 
       :ok
     end
@@ -95,7 +95,7 @@ defmodule Lotus.ColumnVisibilityTest do
       ]
 
       Lotus.Config
-      |> stub(:column_rules_for_repo_name, fn _repo -> rules end)
+      |> stub(:column_rules_for_source_name, fn _repo -> rules end)
 
       Lotus.Visibility
       |> stub(:allowed_relation?, fn _, _ -> true end)

--- a/test/lotus/config_test.exs
+++ b/test/lotus/config_test.exs
@@ -3,7 +3,18 @@ defmodule Lotus.ConfigTest do
 
   alias Lotus.Config
 
-  @preserved_keys [:cache, :table_visibility, :schema_visibility, :column_visibility]
+  import ExUnit.CaptureLog
+
+  @preserved_keys [
+    :cache,
+    :table_visibility,
+    :schema_visibility,
+    :column_visibility,
+    :data_sources,
+    :data_repos,
+    :default_source,
+    :default_repo
+  ]
 
   setup do
     originals = Map.new(@preserved_keys, &{&1, Application.get_env(:lotus, &1)})
@@ -52,56 +63,56 @@ defmodule Lotus.ConfigTest do
 
   describe "visibility rules lookups" do
     @variants [
-      {:rules_for_repo_name, :table_visibility},
-      {:schema_rules_for_repo_name, :schema_visibility},
-      {:column_rules_for_repo_name, :column_visibility}
+      {:rules_for_source_name, :table_visibility},
+      {:schema_rules_for_source_name, :schema_visibility},
+      {:column_rules_for_source_name, :column_visibility}
     ]
 
-    test "returns repo-specific rules when repo_name matches a configured key" do
+    test "returns source-specific rules when source_name matches a configured key" do
       rules = [deny: ["secret_table"]]
 
       for {fun, key} <- @variants do
         put_visibility(key, %{postgres: rules})
 
         assert apply(Config, fun, ["postgres"]) == rules,
-               "#{fun} did not return repo-specific rules"
+               "#{fun} did not return source-specific rules"
       end
     end
 
-    test "returns an empty list when the repo-specific value is an empty list" do
+    test "returns an empty list when the source-specific value is an empty list" do
       for {fun, key} <- @variants do
         put_visibility(key, %{postgres: [], default: [deny: ["should_not_see"]]})
 
         assert apply(Config, fun, ["postgres"]) == [],
-               "#{fun} did not return empty list for empty repo-specific value"
+               "#{fun} did not return empty list for empty source-specific value"
       end
     end
 
-    test "falls through to :default when the repo-specific value is nil" do
+    test "falls through to :default when the source-specific value is nil" do
       default_rules = [deny: ["default_rule"]]
 
       for {fun, key} <- @variants do
         put_visibility(key, %{postgres: nil, default: default_rules})
 
         assert apply(Config, fun, ["postgres"]) == default_rules,
-               "#{fun} did not fall through to :default for nil repo-specific value"
+               "#{fun} did not fall through to :default for nil source-specific value"
       end
     end
 
-    test "returns :default rules when repo_name has no match and :default is present" do
+    test "returns :default rules when source_name has no match and :default is present" do
       default_rules = [deny: ["default_rule"]]
 
       for {fun, key} <- @variants do
-        put_visibility(key, %{other_repo: [deny: ["other"]], default: default_rules})
+        put_visibility(key, %{other_source: [deny: ["other"]], default: default_rules})
 
         assert apply(Config, fun, ["postgres"]) == default_rules,
                "#{fun} did not fall through to :default"
       end
     end
 
-    test "returns an empty list when repo_name has no match and :default is absent" do
+    test "returns an empty list when source_name has no match and :default is absent" do
       for {fun, key} <- @variants do
-        put_visibility(key, %{other_repo: [deny: ["other"]]})
+        put_visibility(key, %{other_source: [deny: ["other"]]})
 
         assert apply(Config, fun, ["postgres"]) == [],
                "#{fun} did not return [] when no match and no :default"
@@ -118,7 +129,7 @@ defmodule Lotus.ConfigTest do
       end
     end
 
-    test "returns :default rules for an arbitrary repo_name string with no matching key" do
+    test "returns :default rules for an arbitrary source_name string with no matching key" do
       unknown = "lotus_config_test_unknown_#{System.unique_integer([:positive])}"
       default_rules = [deny: ["secret"]]
 
@@ -126,8 +137,77 @@ defmodule Lotus.ConfigTest do
         put_visibility(key, %{postgres: [deny: ["should_not_match"]], default: default_rules})
 
         assert apply(Config, fun, [unknown]) == default_rules,
-               "#{fun} did not return :default rules for unknown repo_name"
+               "#{fun} did not return :default rules for unknown source_name"
       end
+    end
+  end
+
+  describe "deprecated config key backward compatibility" do
+    test "data_repos config key still works and resolves correctly" do
+      original_sources = Application.get_env(:lotus, :data_sources)
+      Application.delete_env(:lotus, :data_sources)
+      Application.put_env(:lotus, :data_repos, %{"test" => Lotus.Test.Repo})
+
+      log =
+        capture_log(fn ->
+          Config.reload!()
+          assert Config.data_sources() == %{"test" => Lotus.Test.Repo}
+        end)
+
+      assert log =~ "deprecated"
+      assert log =~ ":data_repos"
+      assert log =~ ":data_sources"
+
+      Application.delete_env(:lotus, :data_repos)
+      Application.put_env(:lotus, :data_sources, original_sources)
+      Config.reload!()
+    end
+
+    test "default_repo config key still works with warning" do
+      original_source = Application.get_env(:lotus, :default_source)
+      Application.delete_env(:lotus, :default_source)
+      Application.put_env(:lotus, :default_repo, "postgres")
+
+      log =
+        capture_log(fn ->
+          Config.reload!()
+          {name, _mod} = Config.default_data_source()
+          assert name == "postgres"
+        end)
+
+      assert log =~ "deprecated"
+      assert log =~ ":default_repo"
+      assert log =~ ":default_source"
+
+      Application.delete_env(:lotus, :default_repo)
+
+      if original_source do
+        Application.put_env(:lotus, :default_source, original_source)
+      end
+
+      Config.reload!()
+    end
+
+    test "both data_repos and data_sources present raises error" do
+      Application.put_env(:lotus, :data_repos, %{"old" => Lotus.Test.Repo})
+
+      assert_raise ArgumentError, ~r/Cannot configure both/, fn ->
+        Config.reload!()
+      end
+
+      Application.delete_env(:lotus, :data_repos)
+      Config.reload!()
+    end
+
+    test "both default_repo and default_source present raises error" do
+      Application.put_env(:lotus, :default_repo, "old")
+
+      assert_raise ArgumentError, ~r/Cannot configure both/, fn ->
+        Config.reload!()
+      end
+
+      Application.delete_env(:lotus, :default_repo)
+      Config.reload!()
     end
   end
 

--- a/test/lotus/data_source_test.exs
+++ b/test/lotus/data_source_test.exs
@@ -1,31 +1,31 @@
-defmodule Lotus.DataRepoTest do
+defmodule Lotus.DataSourceTest do
   use Lotus.Case, async: true
 
-  describe "data repository configuration" do
-    test "lists configured data repositories" do
-      repo_names = Lotus.list_data_repo_names()
-      assert "postgres" in repo_names
-      assert "sqlite" in repo_names
-      assert "mysql" in repo_names
+  describe "data source configuration" do
+    test "lists configured data sources" do
+      source_names = Lotus.list_data_source_names()
+      assert "postgres" in source_names
+      assert "sqlite" in source_names
+      assert "mysql" in source_names
     end
 
-    test "gets data repository by name" do
-      assert Lotus.get_data_repo!("postgres") == Lotus.Test.Repo
-      assert Lotus.get_data_repo!("sqlite") == Lotus.Test.SqliteRepo
-      assert Lotus.get_data_repo!("mysql") == Lotus.Test.MysqlRepo
+    test "gets data source by name" do
+      assert Lotus.get_data_source!("postgres") == Lotus.Test.Repo
+      assert Lotus.get_data_source!("sqlite") == Lotus.Test.SqliteRepo
+      assert Lotus.get_data_source!("mysql") == Lotus.Test.MysqlRepo
     end
 
-    test "raises when getting non-existent data repo" do
-      assert_raise ArgumentError, ~r/Data repo 'nonexistent' not configured/, fn ->
-        Lotus.get_data_repo!("nonexistent")
+    test "raises when getting non-existent data source" do
+      assert_raise ArgumentError, ~r/Data source 'nonexistent' not configured/, fn ->
+        Lotus.get_data_source!("nonexistent")
       end
     end
 
-    test "returns all configured data repos" do
-      data_repos = Lotus.data_repos()
-      assert data_repos["postgres"] == Lotus.Test.Repo
-      assert data_repos["sqlite"] == Lotus.Test.SqliteRepo
-      assert data_repos["mysql"] == Lotus.Test.MysqlRepo
+    test "returns all configured data sources" do
+      data_sources = Lotus.data_sources()
+      assert data_sources["postgres"] == Lotus.Test.Repo
+      assert data_sources["sqlite"] == Lotus.Test.SqliteRepo
+      assert data_sources["mysql"] == Lotus.Test.MysqlRepo
     end
   end
 
@@ -56,7 +56,7 @@ defmodule Lotus.DataRepoTest do
       assert result.rows == [[2]]
     end
 
-    test "defaults to first configured data repo when no repo specified" do
+    test "defaults to first configured data source when no repo specified" do
       # Should use "postgres" since it's first in alphabetical order
       {:ok, result} = Lotus.run_sql("SELECT 3 as test_value")
       assert result.columns == ["test_value"]

--- a/test/lotus/preflight_mysql_test.exs
+++ b/test/lotus/preflight_mysql_test.exs
@@ -191,7 +191,7 @@ defmodule Lotus.PreflightMysqlTest do
     setup do
       Mimic.copy(Lotus.Config)
       config = [allow: [], deny: ["test_users", "test_posts"]]
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> config end)
       :ok
     end
 

--- a/test/lotus/preflight_postgres_test.exs
+++ b/test/lotus/preflight_postgres_test.exs
@@ -155,7 +155,7 @@ defmodule Lotus.PreflightPostgresTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> config end)
       :ok
     end
 
@@ -202,7 +202,7 @@ defmodule Lotus.PreflightPostgresTest do
         deny: []
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> config end)
       :ok
     end
 
@@ -234,7 +234,7 @@ defmodule Lotus.PreflightPostgresTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> config end)
       :ok
     end
 

--- a/test/lotus/preflight_sqlite_test.exs
+++ b/test/lotus/preflight_sqlite_test.exs
@@ -131,7 +131,7 @@ defmodule Lotus.PreflightSqliteTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> config end)
       :ok
     end
 

--- a/test/lotus/schema_test.exs
+++ b/test/lotus/schema_test.exs
@@ -352,25 +352,25 @@ defmodule Lotus.SchemaTest do
 
   describe "general error handling" do
     test "returns error for non-existent repo name" do
-      assert_raise ArgumentError, ~r/Data repo 'nonexistent' not configured/, fn ->
+      assert_raise ArgumentError, ~r/Data source 'nonexistent' not configured/, fn ->
         Schema.list_tables("nonexistent")
       end
     end
 
     test "list_schemas returns error for non-existent repo name" do
-      assert_raise ArgumentError, ~r/Data repo 'nonexistent' not configured/, fn ->
+      assert_raise ArgumentError, ~r/Data source 'nonexistent' not configured/, fn ->
         Schema.list_schemas("nonexistent")
       end
     end
 
     test "get_table_schema returns error for non-existent repo name" do
-      assert_raise ArgumentError, ~r/Data repo 'nonexistent' not configured/, fn ->
+      assert_raise ArgumentError, ~r/Data source 'nonexistent' not configured/, fn ->
         Schema.get_table_schema("nonexistent", "some_table")
       end
     end
 
     test "get_table_stats returns error for non-existent repo name" do
-      assert_raise ArgumentError, ~r/Data repo 'nonexistent' not configured/, fn ->
+      assert_raise ArgumentError, ~r/Data source 'nonexistent' not configured/, fn ->
         Schema.get_table_stats("nonexistent", "some_table")
       end
     end

--- a/test/lotus/search_path_test.exs
+++ b/test/lotus/search_path_test.exs
@@ -13,7 +13,7 @@ defmodule Lotus.SearchPathTest do
           name: "Unqualified Customers Query",
           statement: "SELECT COUNT(*) FROM customers",
           search_path: "reporting, public",
-          data_repo: "postgres"
+          data_source: "postgres"
         })
 
       # The query should execute successfully using the search_path to find reporting.customers
@@ -36,7 +36,7 @@ defmodule Lotus.SearchPathTest do
         Storage.create_query(%{
           name: "Override Test",
           statement: "SELECT COUNT(*) FROM customers",
-          data_repo: "postgres"
+          data_source: "postgres"
         })
 
       assert {:ok, result} = Lotus.run_query(query, search_path: "reporting, public")

--- a/test/lotus/source/resolvers/static_test.exs
+++ b/test/lotus/source/resolvers/static_test.exs
@@ -113,7 +113,7 @@ defmodule Lotus.Source.Resolvers.StaticTest do
     end
 
     test "raises for unknown name" do
-      assert_raise ArgumentError, ~r/Data repo 'unknown' not configured/, fn ->
+      assert_raise ArgumentError, ~r/Data source 'unknown' not configured/, fn ->
         Static.get_source!("unknown")
       end
     end

--- a/test/lotus/source_test.exs
+++ b/test/lotus/source_test.exs
@@ -173,7 +173,7 @@ defmodule Lotus.SourceTest do
     end
 
     test "defaults to configured default repo when repo is nil" do
-      {_name, default_mod} = Lotus.Config.default_data_repo()
+      {_name, default_mod} = Lotus.Config.default_data_source()
       result = Source.param_placeholder(nil, 1, "id", :integer)
 
       expected =

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -152,7 +152,7 @@ defmodule Lotus.SourcesTest do
     end
 
     test "raises for unknown repo name" do
-      assert_raise ArgumentError, ~r/Data repo 'unknown' not configured/, fn ->
+      assert_raise ArgumentError, ~r/Data source 'unknown' not configured/, fn ->
         Sources.source_type("unknown")
       end
     end
@@ -191,7 +191,7 @@ defmodule Lotus.SourcesTest do
     end
 
     test "raises for unknown name" do
-      assert_raise ArgumentError, ~r/Data repo 'unknown' not configured/, fn ->
+      assert_raise ArgumentError, ~r/Data source 'unknown' not configured/, fn ->
         Sources.get_source!("unknown")
       end
     end

--- a/test/lotus/storage/query_test.exs
+++ b/test/lotus/storage/query_test.exs
@@ -127,7 +127,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE id = {{id}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:ok, "SELECT * FROM users WHERE id = $1", [1]} =
@@ -138,7 +138,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE age > {{min_age}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:error, "Missing required variable: min_age"} =
@@ -149,7 +149,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE country IN ({{countries}})",
         variables: [%{name: "countries", type: :text, list: true}],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:error, "List variable 'countries' must have at least one value"} =
@@ -163,7 +163,7 @@ defmodule Lotus.Storage.QueryTest do
           %{name: "active", type: :boolean, default: true},
           %{name: "age", type: :number, default: "18"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:ok, _sql, [false, 0]} =
@@ -174,7 +174,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE status = {{status}}",
         variables: [%{name: "status", type: :text, default: "active"}],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:ok, _sql, ["active"]} =
@@ -185,7 +185,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE age > {{min_age}}",
         variables: [%{name: "min_age", type: :number}],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:error, "Invalid number format: 'not-a-number'" <> _} =
@@ -198,7 +198,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE age > {{min_age}} AND active = {{active}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"min_age" => 30, "active" => true})
@@ -212,7 +212,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE age > {{min_age}} AND active = {{active}}",
         variables: [],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"min_age" => 30, "active" => true})
@@ -221,11 +221,11 @@ defmodule Lotus.Storage.QueryTest do
       assert params == [30, true]
     end
 
-    test "to_sql_params with nil data_repo defaults to PostgreSQL style" do
+    test "to_sql_params with nil data_source defaults to PostgreSQL style" do
       q = %Query{
         statement: "SELECT * FROM users WHERE id = {{id}}",
         variables: [],
-        data_repo: nil
+        data_source: nil
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"id" => 123})
@@ -240,7 +240,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "min_age", type: :number, default: "40"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -256,7 +256,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "min_age", type: :number, default: "40"}
         ],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -295,7 +295,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "name", type: :text, default: "Jack"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -311,7 +311,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "name", type: :text, default: "Jack"}
         ],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -326,7 +326,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "status", type: :text, default: "inactive"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"status" => "active"})
@@ -339,7 +339,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE deleted_at IS {{deleted}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert_raise ArgumentError, ~r/Missing required variable: deleted/, fn ->
@@ -351,7 +351,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "INSERT INTO users (name, age, email) VALUES ({{name}}, {{age}}, {{email}})",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} =
@@ -523,7 +523,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "min_age", type: :number, default: "30"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -538,7 +538,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "since", type: :date, default: "2024-01-01"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -553,7 +553,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "status", type: :text, default: "active"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -569,7 +569,7 @@ defmodule Lotus.Storage.QueryTest do
           %{name: "min_age", type: :number},
           %{name: "since", type: :date}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"min_age" => "25", "since" => "2024-06-01"})
@@ -584,7 +584,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "min_age", type: :number, default: "30"}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"min_age" => "45"})
@@ -597,7 +597,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE name = {{name}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"name" => "John"})
@@ -656,7 +656,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: String.trim(attrs.statement),
         variables: get_field(changeset, :variables),
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       # org_id has no default, so it should raise an error when called with empty vars
@@ -755,7 +755,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE users.id = {{user_id}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       uuid_string = "550e8400-e29b-41d4-a716-446655440000"
@@ -775,7 +775,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "min_age", type: :number}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"min_age" => "25"})
@@ -790,7 +790,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM orders WHERE orders.total = {{amount}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       # Should not crash when schema cache unavailable
@@ -809,7 +809,7 @@ defmodule Lotus.Storage.QueryTest do
         WHERE u.status = {{status}}
         """,
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"status" => "active"})
@@ -826,7 +826,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "min_age", type: :number}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert_raise ArgumentError, ~r/Invalid number format/, fn ->
@@ -840,7 +840,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "since", type: :date}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert_raise ArgumentError, ~r/Invalid date format/, fn ->
@@ -852,7 +852,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE name = {{name}}",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       # No type, so value passes through as-is
@@ -868,7 +868,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "countries", type: :text, list: true}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"countries" => ["US", "UK", "DE"]})
@@ -884,7 +884,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "countries", type: :text, list: true}
         ],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"countries" => ["US", "UK", "DE"]})
@@ -900,7 +900,7 @@ defmodule Lotus.Storage.QueryTest do
           %{name: "countries", type: :text, list: true},
           %{name: "min_age", type: :number}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} =
@@ -918,7 +918,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "ids", type: :number, list: true}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"ids" => ["1", "2", "3"]})
@@ -933,7 +933,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "countries", type: :text, list: true}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert_raise ArgumentError, ~r/must have at least one value/, fn ->
@@ -947,7 +947,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "countries", type: :text, list: true}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"countries" => "US, UK, DE"})
@@ -962,7 +962,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "countries", type: :text, list: true}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"countries" => ["US"]})
@@ -980,7 +980,7 @@ defmodule Lotus.Storage.QueryTest do
           %{name: "countries", type: :text, list: true},
           %{name: "min_age", type: :number}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} =
@@ -1002,7 +1002,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE 1=1 [[AND status = {{status}}]]",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"status" => "active"})
@@ -1015,7 +1015,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE 1=1 [[AND status = {{status}}]]",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{})
@@ -1028,7 +1028,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE id = {{id}} [[AND status = {{status}}]]",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, params} = Query.to_sql_params!(q, %{"id" => 1})
@@ -1043,7 +1043,7 @@ defmodule Lotus.Storage.QueryTest do
         variables: [
           %{name: "countries", type: :text, list: true}
         ],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       # With values
@@ -1070,7 +1070,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE created = {{date}}",
         variables: [%{name: "date", type: :date}],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       {sql, _} = Query.to_sql_params!(q, %{"date" => "2024-01-01"})
@@ -1082,7 +1082,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE created = {{date}}",
         variables: [%{name: "date", type: :date}],
-        data_repo: "mysql"
+        data_source: "mysql"
       }
 
       {sql, _} = Query.to_sql_params!(q, %{"date" => "2024-01-01"})
@@ -1094,7 +1094,7 @@ defmodule Lotus.Storage.QueryTest do
       q = %Query{
         statement: "SELECT * FROM users WHERE created = {{date}}",
         variables: [%{name: "date", type: :date}],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       {sql, _} = Query.to_sql_params!(q, %{"date" => "2024-01-01"})

--- a/test/lotus/storage_test.exs
+++ b/test/lotus/storage_test.exs
@@ -167,41 +167,41 @@ defmodule Lotus.StorageTest do
       assert query.name == "Minimal Query"
       assert query.description == nil
       assert query.statement == "SELECT 1"
-      assert query.data_repo == nil
+      assert query.data_source == nil
     end
 
-    test "creates query with valid data_repo" do
+    test "creates query with valid data_source" do
       attrs = %{
         name: "Analytics Query",
         statement: "SELECT COUNT(*) FROM page_views",
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:ok, query} = Storage.create_query(attrs)
-      assert query.data_repo == "postgres"
+      assert query.data_source == "postgres"
     end
 
-    test "normalizes empty string data_repo to nil" do
+    test "normalizes empty string data_source to nil" do
       attrs = %{
         name: "Test Query",
         statement: "SELECT 1",
-        data_repo: ""
+        data_source: ""
       }
 
       assert {:ok, query} = Storage.create_query(attrs)
-      assert query.data_repo == nil
+      assert query.data_source == nil
     end
 
-    test "returns error with invalid data_repo" do
+    test "returns error with invalid data_source" do
       attrs = %{
-        name: "Invalid Repo Query",
+        name: "Invalid Source Query",
         statement: "SELECT 1",
-        data_repo: "nonexistent_repo"
+        data_source: "nonexistent_repo"
       }
 
       assert {:error, changeset} = Storage.create_query(attrs)
       refute changeset.valid?
-      assert %{data_repo: [error_msg]} = errors_on(changeset)
+      assert %{data_source: [error_msg]} = errors_on(changeset)
       assert error_msg =~ "must be one of: mysql, postgres, sqlite"
     end
 

--- a/test/lotus/visibility/resolvers/static_test.exs
+++ b/test/lotus/visibility/resolvers/static_test.exs
@@ -17,7 +17,7 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:schema_rules_for_repo_name, fn repo_name ->
+      |> stub(:schema_rules_for_source_name, fn repo_name ->
         if repo_name == "postgres", do: schema_rules, else: []
       end)
 
@@ -28,13 +28,13 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       default_rules = [allow: ["public"], deny: []]
 
       Lotus.Config
-      |> stub(:schema_rules_for_repo_name, fn _repo_name -> default_rules end)
+      |> stub(:schema_rules_for_source_name, fn _repo_name -> default_rules end)
 
       assert Static.schema_rules_for("unknown_repo", nil) == default_rules
     end
 
     test "returns empty list when no rules configured" do
-      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> [] end)
+      Lotus.Config |> stub(:schema_rules_for_source_name, fn _repo_name -> [] end)
 
       assert Static.schema_rules_for("postgres", nil) == []
       assert Static.schema_rules_for("mysql", nil) == []
@@ -47,14 +47,14 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
+      |> stub(:schema_rules_for_source_name, fn _repo_name -> schema_rules end)
 
       assert Static.schema_rules_for("postgres", nil) == schema_rules
     end
 
     test "ignores scope argument" do
       rules = [allow: ["public"]]
-      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> rules end)
+      Lotus.Config |> stub(:schema_rules_for_source_name, fn _repo_name -> rules end)
 
       assert Static.schema_rules_for("postgres", nil) == rules
       assert Static.schema_rules_for("postgres", %{role: :admin}) == rules
@@ -73,7 +73,7 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:rules_for_repo_name, fn repo_name ->
+      |> stub(:rules_for_source_name, fn repo_name ->
         if repo_name == "postgres", do: table_rules, else: []
       end)
 
@@ -84,13 +84,13 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       default_rules = [allow: [], deny: ["sensitive_data"]]
 
       Lotus.Config
-      |> stub(:rules_for_repo_name, fn _repo_name -> default_rules end)
+      |> stub(:rules_for_source_name, fn _repo_name -> default_rules end)
 
       assert Static.table_rules_for("unknown_repo", nil) == default_rules
     end
 
     test "returns empty list when no rules configured" do
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> [] end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> [] end)
 
       assert Static.table_rules_for("postgres", nil) == []
       assert Static.table_rules_for("mysql", nil) == []
@@ -108,7 +108,7 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
+      |> stub(:rules_for_source_name, fn _repo_name -> table_rules end)
 
       assert Static.table_rules_for("postgres", nil) == table_rules
     end
@@ -123,7 +123,7 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:column_rules_for_repo_name, fn repo_name ->
+      |> stub(:column_rules_for_source_name, fn repo_name ->
         if repo_name == "postgres", do: column_rules, else: []
       end)
 
@@ -136,13 +136,13 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:column_rules_for_repo_name, fn _repo_name -> default_rules end)
+      |> stub(:column_rules_for_source_name, fn _repo_name -> default_rules end)
 
       assert Static.column_rules_for("unknown_repo", nil) == default_rules
     end
 
     test "returns empty list when no rules configured" do
-      Lotus.Config |> stub(:column_rules_for_repo_name, fn _repo_name -> [] end)
+      Lotus.Config |> stub(:column_rules_for_source_name, fn _repo_name -> [] end)
 
       assert Static.column_rules_for("postgres", nil) == []
       assert Static.column_rules_for("mysql", nil) == []
@@ -161,7 +161,7 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+      |> stub(:column_rules_for_source_name, fn _repo_name -> column_rules end)
 
       assert Static.column_rules_for("postgres", nil) == column_rules
     end
@@ -217,9 +217,9 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
-      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
-      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+      |> stub(:schema_rules_for_source_name, fn _repo_name -> schema_rules end)
+      |> stub(:rules_for_source_name, fn _repo_name -> table_rules end)
+      |> stub(:column_rules_for_source_name, fn _repo_name -> column_rules end)
 
       assert Static.schema_rules_for("postgres", nil) == schema_rules
       assert Static.table_rules_for("postgres", nil) == table_rules
@@ -244,9 +244,9 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       ]
 
       Lotus.Config
-      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
-      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
-      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+      |> stub(:schema_rules_for_source_name, fn _repo_name -> schema_rules end)
+      |> stub(:rules_for_source_name, fn _repo_name -> table_rules end)
+      |> stub(:column_rules_for_source_name, fn _repo_name -> column_rules end)
 
       assert Static.schema_rules_for("postgres", nil) == schema_rules
       assert Static.table_rules_for("postgres", nil) == table_rules
@@ -270,9 +270,9 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       column_rules = []
 
       Lotus.Config
-      |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_rules end)
-      |> stub(:rules_for_repo_name, fn _repo_name -> table_rules end)
-      |> stub(:column_rules_for_repo_name, fn _repo_name -> column_rules end)
+      |> stub(:schema_rules_for_source_name, fn _repo_name -> schema_rules end)
+      |> stub(:rules_for_source_name, fn _repo_name -> table_rules end)
+      |> stub(:column_rules_for_source_name, fn _repo_name -> column_rules end)
 
       assert Static.schema_rules_for("mysql", nil) == schema_rules
       assert Static.table_rules_for("mysql", nil) == table_rules
@@ -281,11 +281,11 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
   end
 
   describe "consistency with Config functions" do
-    test "schema_rules_for delegates directly to Config.schema_rules_for_repo_name" do
+    test "schema_rules_for delegates directly to Config.schema_rules_for_source_name" do
       test_rules = [allow: ["public"], deny: []]
 
       Lotus.Config
-      |> stub(:schema_rules_for_repo_name, fn repo_name ->
+      |> stub(:schema_rules_for_source_name, fn repo_name ->
         if repo_name == "test_repo", do: test_rules, else: []
       end)
 
@@ -293,11 +293,11 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       assert result == test_rules
     end
 
-    test "table_rules_for delegates directly to Config.rules_for_repo_name" do
+    test "table_rules_for delegates directly to Config.rules_for_source_name" do
       test_rules = [allow: [{"public", "users"}], deny: []]
 
       Lotus.Config
-      |> stub(:rules_for_repo_name, fn repo_name ->
+      |> stub(:rules_for_source_name, fn repo_name ->
         if repo_name == "test_repo", do: test_rules, else: []
       end)
 
@@ -305,11 +305,11 @@ defmodule Lotus.Visibility.Resolvers.StaticTest do
       assert result == test_rules
     end
 
-    test "column_rules_for delegates directly to Config.column_rules_for_repo_name" do
+    test "column_rules_for delegates directly to Config.column_rules_for_source_name" do
       test_rules = [{nil, "passwords", :omit}]
 
       Lotus.Config
-      |> stub(:column_rules_for_repo_name, fn repo_name ->
+      |> stub(:column_rules_for_source_name, fn repo_name ->
         if repo_name == "test_repo", do: test_rules, else: []
       end)
 

--- a/test/lotus/visibility_test.exs
+++ b/test/lotus/visibility_test.exs
@@ -55,7 +55,7 @@ defmodule Lotus.VisibilityTest do
         deny: []
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> allow_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> allow_config end)
       :ok
     end
 
@@ -82,7 +82,7 @@ defmodule Lotus.VisibilityTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> deny_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> deny_config end)
       :ok
     end
 
@@ -121,7 +121,7 @@ defmodule Lotus.VisibilityTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> regex_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> regex_config end)
       :ok
     end
 
@@ -160,7 +160,7 @@ defmodule Lotus.VisibilityTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> config end)
       :ok
     end
 
@@ -193,7 +193,7 @@ defmodule Lotus.VisibilityTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> config end)
       :ok
     end
 
@@ -220,7 +220,7 @@ defmodule Lotus.VisibilityTest do
 
   describe "edge cases" do
     setup do
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> [] end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> [] end)
       :ok
     end
 
@@ -253,7 +253,7 @@ defmodule Lotus.VisibilityTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> precedence_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> precedence_config end)
 
       refute Visibility.allowed_relation?("postgres", {"public", "special_table"})
     end
@@ -266,7 +266,7 @@ defmodule Lotus.VisibilityTest do
         deny: []
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> precedence_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> precedence_config end)
 
       refute Visibility.allowed_relation?("postgres", {"public", "schema_migrations"})
     end
@@ -286,7 +286,7 @@ defmodule Lotus.VisibilityTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> warehouse_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> warehouse_config end)
 
       assert Visibility.allowed_relation?("postgres", {"public", "dim_customers"})
       assert Visibility.allowed_relation?("postgres", {"public", "fact_sales"})
@@ -311,7 +311,7 @@ defmodule Lotus.VisibilityTest do
         ]
       ]
 
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> business_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> business_config end)
 
       assert Visibility.allowed_relation?("postgres", {"public", "users"})
       assert Visibility.allowed_relation?("postgres", {"public", "orders"})
@@ -325,7 +325,7 @@ defmodule Lotus.VisibilityTest do
 
   describe "schema visibility" do
     setup do
-      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> [] end)
+      Lotus.Config |> stub(:schema_rules_for_source_name, fn _repo_name -> [] end)
       :ok
     end
 
@@ -373,7 +373,7 @@ defmodule Lotus.VisibilityTest do
         deny: ["restricted"]
       ]
 
-      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_config end)
+      Lotus.Config |> stub(:schema_rules_for_source_name, fn _repo_name -> schema_config end)
       :ok
     end
 
@@ -411,8 +411,8 @@ defmodule Lotus.VisibilityTest do
         deny: []
       ]
 
-      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> schema_config end)
-      Lotus.Config |> stub(:rules_for_repo_name, fn _repo_name -> table_config end)
+      Lotus.Config |> stub(:schema_rules_for_source_name, fn _repo_name -> schema_config end)
+      Lotus.Config |> stub(:rules_for_source_name, fn _repo_name -> table_config end)
       :ok
     end
 
@@ -428,7 +428,7 @@ defmodule Lotus.VisibilityTest do
 
   describe "MySQL schema visibility" do
     setup do
-      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> [] end)
+      Lotus.Config |> stub(:schema_rules_for_source_name, fn _repo_name -> [] end)
       :ok
     end
 
@@ -447,7 +447,7 @@ defmodule Lotus.VisibilityTest do
 
   describe "SQLite schema visibility" do
     setup do
-      Lotus.Config |> stub(:schema_rules_for_repo_name, fn _repo_name -> [] end)
+      Lotus.Config |> stub(:schema_rules_for_source_name, fn _repo_name -> [] end)
       :ok
     end
 

--- a/test/lotus_test.exs
+++ b/test/lotus_test.exs
@@ -102,18 +102,18 @@ defmodule LotusTest do
       assert query.description == "A test query"
       assert query.statement == "SELECT * FROM test_users"
       assert query.variables == []
-      assert query.data_repo == nil
+      assert query.data_source == nil
     end
 
-    test "creates query with data_repo" do
+    test "creates query with data_source" do
       attrs = %{
         name: "Analytics Query",
         statement: "SELECT COUNT(*) FROM page_views",
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       assert {:ok, query} = Lotus.create_query(attrs)
-      assert query.data_repo == "sqlite"
+      assert query.data_source == "sqlite"
     end
 
     test "returns error with invalid attributes" do
@@ -397,12 +397,12 @@ defmodule LotusTest do
       assert error =~ "relation \"nonexistent_table\" does not exist"
     end
 
-    test "uses stored data_repo when specified" do
+    test "uses stored data_source when specified" do
       query = %Query{
         name: "Test Data Query",
         statement: "SELECT 1 as result",
         variables: [],
-        data_repo: "postgres"
+        data_source: "postgres"
       }
 
       assert {:ok, result} = Lotus.run_query(query)
@@ -410,12 +410,12 @@ defmodule LotusTest do
       assert result.rows == [[1]]
     end
 
-    test "runtime repo option overrides stored data_repo" do
+    test "runtime repo option overrides stored data_source" do
       query = %Query{
         name: "Override Test Query",
         statement: "SELECT 1 as result",
         variables: [],
-        data_repo: "sqlite"
+        data_source: "sqlite"
       }
 
       assert {:ok, result} = Lotus.run_query(query, repo: "postgres")
@@ -423,7 +423,7 @@ defmodule LotusTest do
       assert result.rows == [[1]]
     end
 
-    test "falls back to default repo when no data_repo specified" do
+    test "falls back to default repo when no data_source specified" do
       query = %Query{
         name: "Default Repo Query",
         statement: "SELECT 1 as result",


### PR DESCRIPTION
Rename all data-source-related `repo`/`repo_name` terminology to `source`/`source_name` for consistency and to prepare for non-SQL data source support.

- Config keys: `data_repos` → `data_sources`, `default_repo` → `default_source` (old keys still work with Logger.warning deprecation, conflict raises)
- Public API: new functions with @deprecated aliases (removal in v1.0)
- Query struct: `data_repo` field → `data_source` (DB column unchanged via Ecto `source:` option, no migration needed)
- Internal: resolve_repo → resolve_source, repo_module? → source_module?, @type repo → @type source_module
- Tests: 1695 pass, backward-compat tests for config key deprecation
- Docs: guides, changelog, and moduledocs updated