### PR TITLE
refactor(adapter): extract pipeline logic into adapter callbacks (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Renamed public functions: `data_repos/0` → `data_sources/0`, `get_data_repo!/1` → `get_data_source!/1`, `list_data_repo_names/0` → `list_data_source_names/0`, `default_data_repo/0` → `default_data_source/0`, `rules_for_repo_name/1` → `rules_for_source_name/1` (and schema/column variants)
 - Renamed `data_repo` field in `Lotus.Storage.Query` to `data_source` (DB column unchanged)
 - Renamed `@type repo` in `Lotus.Source` to `@type source_module`
+- Removed `FilterInjector.quote_value/1` — no longer needed since values are parameterized
+- Removed duplicated private `Lotus.trim_trailing_semicolon/1` in favor of `Lotus.SQL.Sanitizer.strip_trailing_semicolon/1`, eliminating code duplication and a redundant double-trim in the window pagination path (#155)
+- Extracted shared filter → sort → window → cache → execute pipeline from `Lotus.run_sql/3` and `Lotus.execute_query/5` into a single private `execute_with_options/7` helper. `run_sql/3` now reuses `build_cache_tags/3` and `determine_cache_profile/1` instead of inlining the same logic. No public API or behavior changes (#160)
+- `Lotus.can_run?/2` now reuses the private `prepare_variables/2` helper instead of duplicating the default-merge logic inline. No behavior change (#156)
+- Extracted SQL sanitization (`assert_single_statement`, deny-list), EXPLAIN-based relation extraction, and window pagination SQL construction from `Runner`, `Preflight`, and `Lotus` into 4 new optional adapter callbacks (`sanitize_query/3`, `transform_query/4`, `extract_accessed_resources/4`, `apply_window/4`). `Runner` and `Preflight` now delegate to `Adapter` dispatch helpers with safe defaults for adapters that don't implement the optional callbacks. No public API or behavior changes (#208)
 
 ### Deprecated
 
@@ -22,12 +27,10 @@
 - `Lotus.Config.schema_rules_for_repo_name/1` — use `Lotus.Config.schema_rules_for_source_name/1` (will be removed in v1.0)
 - `Lotus.Config.column_rules_for_repo_name/1` — use `Lotus.Config.column_rules_for_source_name/1` (will be removed in v1.0)
 
-### Fixed
-
-- `get_table_schema/3` and `get_table_stats/3` now propagate adapter errors (e.g. permission denied, connection errors) instead of masking them as "Table not found" (#189)
-
 ### Breaking
 
+- `FilterInjector.apply/3` is now `apply/5` — accepts `params` (existing parameter list) and `placeholder_fn` (database-specific placeholder generator), returns `{sql, params}` tuple instead of a plain SQL string
+- `Lotus.Source.apply_filters/2` callback is now `apply_filters/3` — accepts `params` list and returns `{sql, params}` tuple. All source adapters (Postgres, MySQL, SQLite3, Default) updated accordingly
 - `Lotus.Visibility.Resolver` callbacks now accept a second `scope` argument: `schema_rules_for/2`, `table_rules_for/2`, `column_rules_for/2`. Existing implementations must update their function signatures to accept `scope` (even if ignored). The default `Static` resolver accepts and ignores scope, so static config users are unaffected.
 - Middleware payload key `:repo` renamed to `:source` across all events (`:before_query`, `:after_query`, `:after_list_schemas`, `:after_list_tables`, `:after_get_table_schema`, `:after_list_relations`, `:after_discover`). The duplicate `:repo_name` key has been removed from discovery event payloads. Middleware modules that pattern-match on `%{repo: _}` or `%{repo_name: _}` must update to `%{source: _}`.
 - `Sources.resolve!/2` returns `%Lotus.Source.Adapter{}` struct instead of `{module, name}` tuple
@@ -36,7 +39,6 @@
 - Source behaviour SQL generation callbacks (`param_placeholder`, `apply_filters`, `apply_sorts`, `quote_identifier`, `limit_offset_placeholders`) now take `state` as first argument
 - Source behaviour error handling callbacks (`format_error`, `handled_errors`) now take `state` as first argument
 - `Lotus.Storage.Query.to_sql_params/2` now returns `{:ok, sql, params} | {:error, reason}` instead of returning `{sql, params}` and raising `ArgumentError` for missing variables, empty list variables, or invalid type-cast values. A new `Lotus.Storage.Query.to_sql_params!/2` preserves the previous raising behaviour for callers that prefer exceptions (#163).
-- **Note:** The public API (`Lotus.run_query/2`, `Lotus.run_sql/3`, `Lotus.list_schemas/2`, etc.) is unchanged. These are internal API changes affecting code that calls `Runner`, `Sources`, `Preflight`, or `Source` directly.
 
 ### Added
 
@@ -54,37 +56,30 @@
 - `Lotus.Cache.KeyBuilder` behaviour for pluggable cache key generation. Defines `discovery_key/2` and `result_key/4` callbacks plus a public `scope_digest/1` utility function. Configure via `cache: %{key_builder: MyApp.KeyBuilder}`. Default implementation (`Lotus.Cache.KeyBuilder.Default`) preserves existing key generation logic (#195)
 - Scope-aware result cache keys: `result_key/4` accepts an optional `scope` parameter (default `nil`). When non-nil, the scope digest is appended to the result cache key and a `"scope:<digest>"` tag is added to the cache entry, so `invalidate_scope/1` now clears both discovery and result cache entries for the given scope (#196)
 - `Lotus.Config.cache_key_builder/0` helper to retrieve the configured key builder module (defaults to `Lotus.Cache.KeyBuilder.Default`)
+- 4 optional adapter callbacks for query pipeline participation: `sanitize_query/3`, `transform_query/4`, `extract_accessed_resources/4`, `apply_window/4`. Non-SQL adapters can implement these to sanitize, transform, authorize, and paginate queries using native mechanisms. Dispatch helpers in `Lotus.Source.Adapter` use `function_exported?/3` with safe defaults (`:ok`, passthrough, `:skip`, `nil`) so existing adapters continue to work unchanged (#208)
 - Middleware exception safety: raised exceptions inside middleware `call/2` are now caught and surfaced as `{:error, exception}` instead of propagating uncaught. The `rescue` is scoped to the individual `call/2` invocation so subsequent middleware never runs (#177)
 - `:context` metadata in query telemetry events (`[:lotus, :query, :start | :stop | :exception]`). The caller-supplied `:context` option is now included in event metadata, enabling per-endpoint attribution, distributed trace correlation, and request ID tagging without wrapping or forking `Runner` (#175)
 
 ### Security
 
-- **FIX:** Use parameterized queries in `FilterInjector` instead of string-interpolated values — filter values are now bound as query parameters (`$1`, `?`) and never appear in the SQL string, eliminating SQL injection risk via crafted filter values (#152)
-- **FIX:** Validate column names in `FilterInjector` and `SortInjector` against `[a-zA-Z_][a-zA-Z0-9_]*` using `Lotus.SQL.Identifier`, rejecting column names containing spaces, quotes, semicolons, or other special characters (#152)
-- **FIX:** Track nesting depth in `Runner`'s `skip_block_comment/1` so the single-statement parser matches PostgreSQL's nested block comment semantics. The previous implementation exited at the first `*/`, which could let a second statement slip past `assert_single_statement/1` when hidden inside a nested comment (#164)
+- Use parameterized queries in `FilterInjector` instead of string-interpolated values — filter values are now bound as query parameters (`$1`, `?`) and never appear in the SQL string, eliminating SQL injection risk via crafted filter values (#152)
+- Validate column names in `FilterInjector` and `SortInjector` against `[a-zA-Z_][a-zA-Z0-9_]*` using `Lotus.SQL.Identifier`, rejecting column names containing spaces, quotes, semicolons, or other special characters (#152)
+- Track nesting depth in `Runner`'s `skip_block_comment/1` so the single-statement parser matches PostgreSQL's nested block comment semantics. The previous implementation exited at the first `*/`, which could let a second statement slip past `assert_single_statement/1` when hidden inside a nested comment (#164)
 
 ### Fixed
 
-- **FIX:** `Lotus.Storage.Query.to_sql_params/2` now correctly uses falsy supplied values (`false`, `0`) instead of short-circuiting through `||` and falling back to the variable's default. `nil` supplied values still fall back to the default (#163).
-- **FIX:** `Lotus.Config.cache_namespace/0` now returns a consistent `"lotus:v1"` default regardless of whether a cache is configured, eliminating an inconsistency where the un-configured path returned `"lotus:v0"` (#165)
-- **FIX:** `Lotus.Normalizer` implementation for `URI` now uses `URI.to_string/1` instead of `inspect/1`, producing the actual URL string rather than the `%URI{}` struct representation (#159)
-- **FIX:** Propagate `Repo.transaction/1` errors from `Dashboards.reorder_dashboard_cards/2` instead of unconditionally returning `:ok`. Spec updated to `:ok | {:error, term()}` (#157)
-- **FIX:** Use `Task.Supervisor` instead of bare `Task.async` for dashboard card execution, ensuring proper OTP supervision and fault tolerance. Added `Lotus.TaskSupervisor` to the supervision tree.
-- **PERF:** Cache validated `Lotus.Config` in `:persistent_term` to avoid repeated `NimbleOptions.validate/2` on every accessor call. Config is eagerly validated once at boot from `Lotus.Supervisor.init/1`; a new `Lotus.Config.reload!/0` refreshes the cached value when the application environment changes (e.g. in tests) (#154)
-- **DOCS:** Clarify in the installation and caching guides that Lotus's supervisor starts automatically with the `:lotus` OTP application — consumers do not need to add `Lotus` to their own supervision tree to enable caching
-- **DOCS:** Add `@spec` annotations to all public functions in `Lotus.Cache` (`get/1`, `put/4`, `get_or_store/4`, `delete/1`, `invalidate_tags/1`, `enabled?/0`) to improve discoverability and Dialyzer coverage (#161)
-- **FIX:** `guides/middleware.md` documented the `:after_get_table_schema` payload key as `:table_schema`, but `Lotus.Schema` actually sends `:columns` (plus the previously-undocumented `:table_name` and `:schema` keys). Middleware written to the documented contract would have raised `KeyError`. Doc now matches the code (#173)
-- **FIX:** Discovery middleware (`:after_list_*`) previously ran **inside** the schema cache callback, so context-sensitive filtering was cached by the first caller's context and served to later callers with different contexts. The middleware pipeline now runs outside the cache; only the raw, visibility-filtered adapter result is cached. Side-effecting middleware (e.g. audit logging) that previously undercounted by logging only on cache misses will now run on every call — adjust if this change in volume matters for your use case (#173)
-- **BEHAVIOR:** Discovery middleware that raises an exception now propagates the exception to the caller instead of being converted to `{:error, message}`. The previous conversion was an incidental side-effect of an adapter-level `try/rescue` that wrapped the middleware pipeline; after the cache refactor above, middleware runs outside that rescue. This matches the existing behavior of `:before_query` / `:after_query` middleware in `Lotus.Runner`. Middleware should return `{:halt, reason}` for error conditions, not raise (#173)
-
-### Changed
-
-- **BREAKING:** `FilterInjector.apply/3` is now `apply/5` — accepts `params` (existing parameter list) and `placeholder_fn` (database-specific placeholder generator), returns `{sql, params}` tuple instead of a plain SQL string
-- **BREAKING:** `Lotus.Source.apply_filters/2` callback is now `apply_filters/3` — accepts `params` list and returns `{sql, params}` tuple. All source adapters (Postgres, MySQL, SQLite3, Default) updated accordingly
-- Removed `FilterInjector.quote_value/1` — no longer needed since values are parameterized
-- **REFACTOR:** Remove duplicated private `Lotus.trim_trailing_semicolon/1` in favor of `Lotus.SQL.Sanitizer.strip_trailing_semicolon/1`, eliminating code duplication and a redundant double-trim in the window pagination path (#155)
-- **REFACTOR:** Extract shared filter → sort → window → cache → execute pipeline from `Lotus.run_sql/3` and `Lotus.execute_query/5` into a single private `execute_with_options/7` helper. `run_sql/3` now reuses `build_cache_tags/3` and `determine_cache_profile/1` instead of inlining the same logic. No public API or behavior changes (#160)
-- **REFACTOR:** `Lotus.can_run?/2` now reuses the private `prepare_variables/2` helper instead of duplicating the default-merge logic inline. No behavior change (#156)
+- `get_table_schema/3` and `get_table_stats/3` now propagate adapter errors (e.g. permission denied, connection errors) instead of masking them as "Table not found" (#189)
+- `Lotus.Storage.Query.to_sql_params/2` now correctly uses falsy supplied values (`false`, `0`) instead of short-circuiting through `||` and falling back to the variable's default. `nil` supplied values still fall back to the default (#163).
+- `Lotus.Config.cache_namespace/0` now returns a consistent `"lotus:v1"` default regardless of whether a cache is configured, eliminating an inconsistency where the un-configured path returned `"lotus:v0"` (#165)
+- `Lotus.Normalizer` implementation for `URI` now uses `URI.to_string/1` instead of `inspect/1`, producing the actual URL string rather than the `%URI{}` struct representation (#159)
+- Propagate `Repo.transaction/1` errors from `Dashboards.reorder_dashboard_cards/2` instead of unconditionally returning `:ok`. Spec updated to `:ok | {:error, term()}` (#157)
+- Use `Task.Supervisor` instead of bare `Task.async` for dashboard card execution, ensuring proper OTP supervision and fault tolerance. Added `Lotus.TaskSupervisor` to the supervision tree.
+- Cache validated `Lotus.Config` in `:persistent_term` to avoid repeated `NimbleOptions.validate/2` on every accessor call. Config is eagerly validated once at boot from `Lotus.Supervisor.init/1`; a new `Lotus.Config.reload!/0` refreshes the cached value when the application environment changes (e.g. in tests) (#154)
+- Clarify in the installation and caching guides that Lotus's supervisor starts automatically with the `:lotus` OTP application — consumers do not need to add `Lotus` to their own supervision tree to enable caching
+- Add `@spec` annotations to all public functions in `Lotus.Cache` (`get/1`, `put/4`, `get_or_store/4`, `delete/1`, `invalidate_tags/1`, `enabled?/0`) to improve discoverability and Dialyzer coverage (#161)
+- `guides/middleware.md` documented the `:after_get_table_schema` payload key as `:table_schema`, but `Lotus.Schema` actually sends `:columns` (plus the previously-undocumented `:table_name` and `:schema` keys). Middleware written to the documented contract would have raised `KeyError`. Doc now matches the code (#173)
+- Discovery middleware (`:after_list_*`) previously ran **inside** the schema cache callback, so context-sensitive filtering was cached by the first caller's context and served to later callers with different contexts. The middleware pipeline now runs outside the cache; only the raw, visibility-filtered adapter result is cached. Side-effecting middleware (e.g. audit logging) that previously undercounted by logging only on cache misses will now run on every call — adjust if this change in volume matters for your use case (#173)
+- Discovery middleware that raises an exception now propagates the exception to the caller instead of being converted to `{:error, message}`. The previous conversion was an incidental side-effect of an adapter-level `try/rescue` that wrapped the middleware pipeline; after the cache refactor above, middleware runs outside that rescue. This matches the existing behavior of `:before_query` / `:after_query` middleware in `Lotus.Runner`. Middleware should return `{:halt, reason}` for error conditions, not raise (#173)
 
 ## [0.16.4] - 2026-03-10
 

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -67,6 +67,7 @@ defmodule Lotus do
 
   alias Lotus.Cache.{Key, KeyBuilder}
   alias Lotus.{Config, Dashboards, Result, Runner, Schema, Sources, Storage, Viz}
+  alias Lotus.Source.Adapter
   alias Lotus.Storage.Query
 
   def child_spec(opts), do: Lotus.Supervisor.child_spec(opts)
@@ -465,6 +466,8 @@ defmodule Lotus do
 
   defp execute_with_options(adapter, sql, params, opts, runner_opts, cache_identity, query_id) do
     search_path = Keyword.get(runner_opts, :search_path)
+
+    {sql, params} = Adapter.transform_query(adapter, sql, params, runner_opts)
 
     filters = Keyword.get(opts, :filters, [])
     {sql, params} = Lotus.Source.apply_filters(adapter, sql, params, filters)
@@ -886,45 +889,15 @@ defmodule Lotus do
 
   defp maybe_apply_window(sql, params, adapter, search_path, window_opts)
        when is_list(window_opts) do
-    alias Lotus.Source.Adapter
-    alias Lotus.SQL.Sanitizer
-
-    base_sql = Sanitizer.strip_trailing_semicolon(sql)
     limit = resolve_window_limit(window_opts)
     offset = Keyword.get(window_opts, :offset, 0)
     count_mode = Keyword.get(window_opts, :count, :none)
 
-    {limit_ph, offset_ph} =
-      Adapter.limit_offset_placeholders(
-        adapter,
-        length(params) + 1,
-        length(params) + 2
-      )
+    full_opts = [limit: limit, offset: offset, count: count_mode, search_path: search_path]
 
-    paged_sql =
-      "SELECT * FROM (" <>
-        base_sql <> ") AS lotus_sub LIMIT " <> limit_ph <> " OFFSET " <> offset_ph
+    {paged_sql, paged_params, window_meta} =
+      Adapter.apply_window(adapter, sql, params, full_opts)
 
-    paged_params = params ++ [limit, offset]
-
-    window_meta =
-      case count_mode do
-        :exact ->
-          %{
-            window: %{limit: limit, offset: offset},
-            total_count: :pending,
-            total_mode: :exact,
-            count_sql: "SELECT COUNT(*) FROM (" <> base_sql <> ") AS lotus_sub",
-            count_params: params,
-            adapter: adapter,
-            search_path: search_path
-          }
-
-        _ ->
-          %{window: %{limit: limit, offset: offset}, total_count: nil, total_mode: :none}
-      end
-
-    # Include window in cache key bound variables
     cache_bound = %{
       __params__: params,
       __window__: %{limit: limit, offset: offset, count: count_mode}

--- a/lib/lotus/preflight.ex
+++ b/lib/lotus/preflight.ex
@@ -2,8 +2,9 @@ defmodule Lotus.Preflight do
   @moduledoc """
   SQL preflight authorization for Lotus.
 
-  Uses EXPLAIN to extract which tables/relations a query will access,
-  then checks those relations against visibility rules before execution.
+  Delegates to the adapter's `extract_accessed_resources/4` callback to
+  discover which tables/relations a query will access, then checks those
+  relations against visibility rules before execution.
 
   This provides defense-in-depth by blocking queries that would access
   denied tables, even if they're accessed through views or complex subqueries.
@@ -16,8 +17,8 @@ defmodule Lotus.Preflight do
   @doc """
   Authorizes a SQL query by checking all relations it would access.
 
-  Uses EXPLAIN (without executing) to discover which tables the query
-  would touch, then validates each against the visibility rules.
+  Delegates resource extraction to the adapter, then validates each
+  relation against the visibility rules.
 
   ## Examples
 
@@ -30,265 +31,29 @@ defmodule Lotus.Preflight do
   @spec authorize(Adapter.t(), String.t(), list(), String.t() | nil) ::
           :ok | {:error, String.t()}
   def authorize(%Adapter{} = adapter, sql, params, search_path \\ nil) do
-    case adapter.source_type do
-      :postgres -> authorize_pg(adapter, sql, params, search_path)
-      :sqlite -> authorize_sqlite(adapter, sql, params, search_path)
-      :mysql -> authorize_mysql(adapter, sql, params, search_path)
-      _ -> :ok
-    end
-  end
-
-  defp authorize_pg(%Adapter{} = adapter, sql, params, search_path) do
-    explain = "EXPLAIN (VERBOSE, FORMAT JSON) " <> sql
     opts = if search_path, do: [search_path: search_path], else: []
 
-    case Adapter.execute_query(adapter, explain, params, opts) do
-      {:ok, %{rows: [[json]]}} ->
-        json
-        |> parse_pg_explain_plan()
-        |> collect_pg_relations(MapSet.new())
-        |> MapSet.to_list()
-        |> check_relations_visibility(adapter.name)
-
-      {:error, e} ->
-        {:error, normalize_preflight_error(e)}
-    end
-  end
-
-  defp parse_pg_explain_plan(json) do
-    plan_data =
-      case json do
-        binary when is_binary(binary) -> Lotus.JSON.decode!(binary)
-        data when is_list(data) or is_map(data) -> data
-      end
-
-    case plan_data do
-      [first | _] -> Map.fetch!(first, "Plan")
-      %{"Plan" => plan} -> plan
-    end
-  end
-
-  defp authorize_sqlite(%Adapter{} = adapter, sql, params, _search_path) do
-    alias_map = parse_alias_map(sql)
-
-    explain = "EXPLAIN QUERY PLAN " <> sql
-
-    case Adapter.execute_query(adapter, explain, params, []) do
-      {:ok, %{rows: rows}} ->
-        rels =
-          rows
-          |> Enum.map(fn row -> Enum.join(row, " ") end)
-          # names (base or alias)
-          |> Enum.flat_map(&extract_sqlite_relations/1)
-          # rewrite alias -> base
-          |> Enum.map(&resolve_alias(&1, alias_map))
-          |> Enum.reject(&is_nil/1)
-          |> MapSet.new()
-          |> MapSet.to_list()
-          |> Enum.map(&{nil, &1})
-
+    case Adapter.extract_accessed_resources(adapter, sql, params, opts) do
+      {:ok, relations} ->
+        rels = MapSet.to_list(relations)
         check_relations_visibility(rels, adapter.name)
 
       {:error, e} ->
         {:error, normalize_preflight_error(e)}
-    end
-  end
 
-  defp authorize_mysql(%Adapter{} = adapter, sql, params, _search_path) do
-    alias_map = parse_alias_map(sql)
-
-    explain = "EXPLAIN FORMAT=JSON " <> sql
-
-    case Adapter.execute_query(adapter, explain, params, []) do
-      {:ok, %{rows: [[json]]}} ->
-        explain_rels =
-          json
-          |> Lotus.JSON.decode!()
-          |> collect_mysql_relations(MapSet.new())
-          |> MapSet.to_list()
-          |> Enum.map(fn {schema, table_name} ->
-            {schema, resolve_alias(table_name, alias_map)}
-          end)
-          |> Enum.reject(fn {_schema, name} -> is_nil(name) end)
-
-        sql_rels = extract_mysql_tables_from_sql(sql)
-        rels = choose_mysql_relations(explain_rels, sql_rels, sql)
-
-        check_relations_visibility(rels, adapter.name)
-
-      {:error, e} ->
-        {:error, normalize_preflight_error(e)}
+      :skip ->
+        :ok
     end
   end
 
   defp check_relations_visibility(rels, source_name) do
-    if Enum.all?(rels, &Visibility.allowed_relation?(source_name, &1)) do
-      Relations.put(rels)
+    {allowed, blocked} = Enum.split_with(rels, &Visibility.allowed_relation?(source_name, &1))
+
+    if blocked == [] do
+      Relations.put(allowed)
       :ok
     else
-      blocked = Enum.reject(rels, &Visibility.allowed_relation?(source_name, &1))
       {:error, "Query touches blocked table(s): #{format_relations(blocked)}"}
-    end
-  end
-
-  defp collect_pg_relations(%{"Plans" => plans} = node, acc) do
-    Enum.reduce(plans, collect_pg_here(node, acc), &collect_pg_relations/2)
-  end
-
-  defp collect_pg_relations(node, acc), do: collect_pg_here(node, acc)
-
-  defp collect_pg_here(node, acc) do
-    case {node["Schema"], node["Relation Name"]} do
-      {schema, rel} when is_binary(schema) and is_binary(rel) ->
-        MapSet.put(acc, {schema, rel})
-
-      _ ->
-        acc
-    end
-  end
-
-  defp collect_mysql_relations(%{"query_block" => query_block}, acc) do
-    collect_mysql_query_block(query_block, acc)
-  end
-
-  defp collect_mysql_relations(data, acc) when is_list(data) do
-    Enum.reduce(data, acc, &collect_mysql_relations/2)
-  end
-
-  defp collect_mysql_relations(data, acc) when is_map(data) do
-    case Map.get(data, "query_block") do
-      nil -> acc
-      query_block -> collect_mysql_query_block(query_block, acc)
-    end
-  end
-
-  defp collect_mysql_relations(_, acc), do: acc
-
-  defp collect_mysql_query_block(%{"table" => table_info}, acc) when is_map(table_info) do
-    case Map.get(table_info, "table_name") do
-      table_name when is_binary(table_name) ->
-        schema = Map.get(table_info, "schema")
-        MapSet.put(acc, {schema, table_name})
-
-      _ ->
-        acc
-    end
-  end
-
-  defp collect_mysql_query_block(%{"nested_loop" => nested_loop}, acc)
-       when is_list(nested_loop) do
-    Enum.reduce(nested_loop, acc, fn item, acc_inner ->
-      collect_mysql_query_block(item, acc_inner)
-    end)
-  end
-
-  defp collect_mysql_query_block(data, acc) when is_map(data) do
-    data
-    |> Enum.reduce(acc, fn {_key, value}, acc_inner ->
-      collect_mysql_relations(value, acc_inner)
-    end)
-  end
-
-  defp collect_mysql_query_block(_, acc), do: acc
-
-  # Extract table names directly from SQL when EXPLAIN aliases fail
-  defp extract_mysql_tables_from_sql(sql) do
-    # Look for schema.table and table patterns in FROM/JOIN clauses
-    table_regex =
-      ~r/(?:FROM|JOIN)\s+(?:(`?)([a-zA-Z_][a-zA-Z0-9_]*)\1\.)?(`?)([a-zA-Z_][a-zA-Z0-9_]*)\3(?:\s+(?:AS\s+)?[a-zA-Z_][a-zA-Z0-9_]*)?/i
-
-    Regex.scan(table_regex, sql)
-    |> Enum.map(fn
-      [_, _, schema, _, table] when schema != "" -> {schema, table}
-      [_, "", "", _, table] -> {nil, table}
-    end)
-    |> Enum.uniq()
-  end
-
-  defp choose_mysql_relations(explain_rels, sql_rels, sql) do
-    if should_use_sql_relations?(explain_rels, sql) do
-      sql_rels
-    else
-      explain_rels
-    end
-  end
-
-  defp should_use_sql_relations?(explain_rels, sql) do
-    Enum.empty?(explain_rels) or
-      Enum.all?(explain_rels, fn {_, name} -> String.length(name) <= 4 end) or
-      String.contains?(sql, "information_schema") or
-      String.contains?(sql, "performance_schema") or
-      String.contains?(sql, "mysql.") or
-      String.contains?(sql, "sys.")
-  end
-
-  # Map of alias -> base table derived from SQL text.
-  # Handles: FROM t a | FROM t AS a | JOIN t a | JOIN t AS a (quoted or not).
-  # Ignores subquery aliases like FROM (SELECT ...) a.
-  defp parse_alias_map(sql) do
-    s = strip_sql_comments(sql)
-
-    rx_from = ~r/\bFROM\s+("?[A-Za-z0-9_]+"?)\s+(?:AS\s+)?("?[A-Za-z0-9_]+"?)/i
-    rx_join = ~r/\bJOIN\s+("?[A-Za-z0-9_]+"?)\s+(?:AS\s+)?("?[A-Za-z0-9_]+"?)/i
-
-    [rx_from, rx_join]
-    |> Enum.flat_map(&Regex.scan(&1, s))
-    |> Enum.reduce(%{}, fn
-      [_, base, alias], acc ->
-        base = normalize_ident(base)
-        alias = normalize_ident(alias)
-        if base == "(", do: acc, else: Map.put(acc, alias, base)
-
-      _, acc ->
-        acc
-    end)
-  end
-
-  defp strip_sql_comments(s) do
-    s
-    |> String.replace(~r/--.*$/m, "")
-    |> String.replace(~r/\/\*[\s\S]*?\*\//, "")
-  end
-
-  defp normalize_ident(<<"\"", rest::binary>>) do
-    rest |> String.trim_trailing(~s|"|) |> String.replace(~s|""|, ~s|"|)
-  end
-
-  defp normalize_ident(s), do: s
-
-  defp resolve_alias(name, alias_map), do: Map.get(alias_map, name, name)
-
-  # Extract relation tokens from plan lines.
-  # Covers:
-  #   SCAN/SEARCH TABLE <base> AS <alias>    -> capture <base>
-  #   SCAN/SEARCH TABLE <base>               -> capture <base>
-  #   SCAN/SEARCH <name>                     -> capture <name> (alias or base; remapped later)
-  defp extract_sqlite_relations(text) do
-    cond do
-      Regex.match?(
-        ~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)\s+AS\s+("[^"]+"|[A-Za-z0-9_]+)/,
-        text
-      ) ->
-        for [_, base, _alias] <-
-              Regex.scan(
-                ~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)\s+AS\s+("[^"]+"|[A-Za-z0-9_]+)/,
-                text
-              ) do
-          normalize_ident(base)
-        end
-
-      Regex.match?(~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)/, text) ->
-        for [_, base] <- Regex.scan(~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)/, text) do
-          normalize_ident(base)
-        end
-
-      Regex.match?(~r/\b(?:SCAN|SEARCH)\s+("[^"]+"|[A-Za-z0-9_]+)/, text) ->
-        for [_, name] <- Regex.scan(~r/\b(?:SCAN|SEARCH)\s+("[^"]+"|[A-Za-z0-9_]+)/, text) do
-          normalize_ident(name)
-        end
-
-      true ->
-        []
     end
   end
 
@@ -310,8 +75,6 @@ defmodule Lotus.Preflight do
     |> strip_explain_query_tail()
   end
 
-  # If a driver glued the SQL after the message (e.g. "\nquery: EXPLAIN ..."),
-  # hide it so tests/users don't see our internal EXPLAIN wrapper.
   defp strip_explain_query_tail(msg) do
     Regex.replace(~r/\n?query:\s*EXPLAIN[\s\S]*\z/i, msg, "")
     |> String.trim_trailing()

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -22,11 +22,6 @@ defmodule Lotus.Runner do
           search_path: String.t() | nil
         ]
 
-  # Deny list for dangerous operations (defense-in-depth).
-  # Skipped when `read_only: false` is passed in opts.
-  # The DB-level read-only transaction guard provides an additional safety layer.
-  @deny ~r/\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|GRANT|REVOKE|VACUUM|ANALYZE|CALL|LOCK)\b/i
-
   @spec run_sql(Adapter.t(), sql(), params(), opts()) ::
           {:ok, query_result()} | {:error, term()}
   def run_sql(%Adapter{} = adapter, sql, params \\ [], opts \\ [])
@@ -34,11 +29,9 @@ defmodule Lotus.Runner do
     context = Keyword.get(opts, :context)
     telemetry_meta = %{repo: adapter.name, sql: sql, params: params, context: context}
     start_time = Telemetry.query_start(telemetry_meta)
-    read_only = Keyword.get(opts, :read_only, true)
 
     result =
-      with :ok <- assert_single_statement(sql),
-           :ok <- assert_not_denied(sql, read_only),
+      with :ok <- Adapter.sanitize_query(adapter, sql, sanitize_opts(opts)),
            :ok <- preflight_visibility(adapter, sql, params, opts),
            :ok <- run_before_query(adapter, sql, params, context),
            {:ok, %Result{} = res} <- exec_read_only(adapter, sql, params, opts),
@@ -206,102 +199,8 @@ defmodule Lotus.Runner do
     left_part <> masked <> right_part
   end
 
-  # Allow a single statement with an optional trailing semicolon.
-  # Reject any additional top-level semicolons (outside strings/comments).
-  defp assert_single_statement(sql) do
-    s = String.trim(sql)
-
-    s =
-      if String.ends_with?(s, ";") do
-        s
-        |> String.trim_trailing()
-        |> String.trim_trailing(";")
-        |> String.trim_trailing()
-      else
-        s
-      end
-
-    if has_top_level_semicolon?(s) do
-      {:error, "Only a single statement is allowed"}
-    else
-      :ok
-    end
-  end
-
-  defp has_top_level_semicolon?(bin), do: scan_semicolons(bin, :code)
-
-  # State machine that skips semicolons inside:
-  # - single-quoted strings
-  # - double-quoted identifiers
-  # - PostgreSQL dollar-quoted strings ($tag$ ... $tag$ or $ ... $)
-  # - line comments (-- ...\n)
-  # - block comments (/* ... */)
-  defp scan_semicolons(<<>>, _state), do: false
-
-  defp scan_semicolons(<<?;, _::binary>>, :code), do: true
-
-  defp scan_semicolons(<<"--", rest::binary>>, :code),
-    do: scan_semicolons(skip_to_eol(rest), :code)
-
-  defp scan_semicolons(<<"/*", rest::binary>>, :code),
-    do: scan_semicolons(skip_block_comment(rest), :code)
-
-  defp scan_semicolons(<<"'", rest::binary>>, :code),
-    do: scan_semicolons(skip_single_quoted(rest), :code)
-
-  defp scan_semicolons(<<"\"", rest::binary>>, :code),
-    do: scan_semicolons(skip_double_quoted(rest), :code)
-
-  defp scan_semicolons(<<"$", rest::binary>>, :code) do
-    case take_dollar_tag(rest, "") do
-      {:tag, tag, after_tag} -> scan_semicolons(skip_dollar_quoted(after_tag, tag), :code)
-      :no_tag -> scan_semicolons(rest, :code)
-    end
-  end
-
-  defp scan_semicolons(<<_::utf8, rest::binary>>, :code),
-    do: scan_semicolons(rest, :code)
-
-  defp skip_to_eol(<<>>), do: <<>>
-  defp skip_to_eol(<<"\n", rest::binary>>), do: rest
-  defp skip_to_eol(<<_::utf8, rest::binary>>), do: skip_to_eol(rest)
-
-  # PostgreSQL supports nested block comments. Track depth so a nested `/*`
-  # does not let the parser exit early on the first `*/`, which would let a
-  # subsequent statement slip past `assert_single_statement/1`.
-  defp skip_block_comment(rest), do: skip_block_comment(rest, 1)
-
-  defp skip_block_comment(<<>>, _depth), do: <<>>
-  defp skip_block_comment(<<"*/", rest::binary>>, 1), do: rest
-  defp skip_block_comment(<<"*/", rest::binary>>, depth), do: skip_block_comment(rest, depth - 1)
-  defp skip_block_comment(<<"/*", rest::binary>>, depth), do: skip_block_comment(rest, depth + 1)
-  defp skip_block_comment(<<_::utf8, rest::binary>>, depth), do: skip_block_comment(rest, depth)
-
-  defp skip_single_quoted(<<>>), do: <<>>
-  defp skip_single_quoted(<<"''", rest::binary>>), do: skip_single_quoted(rest)
-  defp skip_single_quoted(<<"'", rest::binary>>), do: rest
-  defp skip_single_quoted(<<_::utf8, rest::binary>>), do: skip_single_quoted(rest)
-
-  defp skip_double_quoted(<<>>), do: <<>>
-  defp skip_double_quoted(<<"\"\"", rest::binary>>), do: skip_double_quoted(rest)
-  defp skip_double_quoted(<<"\"", rest::binary>>), do: rest
-  defp skip_double_quoted(<<_::utf8, rest::binary>>), do: skip_double_quoted(rest)
-
-  defp take_dollar_tag(<<"$", rest::binary>>, acc), do: {:tag, acc, rest}
-
-  defp take_dollar_tag(<<c, rest::binary>>, acc)
-       when c in ?A..?Z or c in ?a..?z or c in ?0..?9 or c == ?_,
-       do: take_dollar_tag(rest, <<acc::binary, c>>)
-
-  defp take_dollar_tag(_, _), do: :no_tag
-
-  defp skip_dollar_quoted(bin, tag) do
-    closer = "$" <> tag <> "$"
-
-    case :binary.match(bin, closer) do
-      :nomatch -> <<>>
-      {pos, len} -> :binary.part(bin, pos + len, byte_size(bin) - pos - len)
-    end
+  defp sanitize_opts(opts) do
+    Keyword.take(opts, [:read_only])
   end
 
   defp run_before_query(%Adapter{} = adapter, sql, params, context) do
@@ -320,12 +219,6 @@ defmodule Lotus.Runner do
       {:cont, %{result: res}} -> {:ok, res}
       {:halt, reason} -> {:error, reason}
     end
-  end
-
-  defp assert_not_denied(_sql, false = _read_only), do: :ok
-
-  defp assert_not_denied(sql, _read_only) do
-    if Regex.match?(@deny, sql), do: {:error, "Only read-only queries are allowed"}, else: :ok
   end
 
   defp preflight_visibility(%Adapter{} = adapter, sql, params, opts) do

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -126,6 +126,81 @@ defmodule Lotus.Source.Adapter do
               {:ok, String.t()} | {:error, term()}
 
   # ---------------------------------------------------------------------------
+  # Callbacks — Pipeline (Query Processing)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Validate that a query is safe to execute.
+
+  Called before execution to enforce single-statement and deny-list rules.
+  Return `:ok` to allow or `{:error, reason}` to block.
+
+  ## Options
+
+    * `:read_only` — when `true`, block write operations
+
+  Default (when not implemented): `:ok` (allow all queries).
+  """
+  @callback sanitize_query(state :: term(), query :: String.t(), opts :: keyword()) ::
+              :ok | {:error, String.t()}
+
+  @doc """
+  Transform a query before filters and sorts are applied.
+
+  Allows adapters to normalize or rewrite the query format. SQL adapters
+  typically pass through unchanged; non-SQL adapters may translate here.
+
+  Default (when not implemented): `{query, params}` (passthrough).
+  """
+  @callback transform_query(
+              state :: term(),
+              query :: String.t(),
+              params :: list(),
+              opts :: keyword()
+            ) ::
+              {String.t(), list()}
+
+  @doc """
+  Extract the set of tables/relations a query will access.
+
+  Used by `Lotus.Preflight` to check visibility rules before execution.
+  Return `{:ok, MapSet}` with `{schema, table}` tuples, `{:error, reason}`,
+  or `:skip` to allow the query without checking.
+
+  Default (when not implemented): `:skip`.
+  """
+  @callback extract_accessed_resources(
+              state :: term(),
+              query :: String.t(),
+              params :: list(),
+              opts :: keyword()
+            ) ::
+              {:ok, MapSet.t({String.t() | nil, String.t()})} | {:error, term()} | :skip
+
+  @doc """
+  Wrap a query with pagination (LIMIT/OFFSET) and optionally compute a count.
+
+  Returns `{paged_query, paged_params, window_meta}` where `window_meta`
+  is a map consumed by `Lotus.merge_window_meta/2`, or `nil` to skip windowing.
+
+  Default (when not implemented): `{query, params, nil}` (no windowing).
+  """
+  @callback apply_window(
+              state :: term(),
+              query :: String.t(),
+              params :: list(),
+              window_opts :: keyword()
+            ) ::
+              {String.t(), list(), map() | nil}
+
+  @optional_callbacks [
+    sanitize_query: 3,
+    transform_query: 4,
+    extract_accessed_resources: 4,
+    apply_window: 4
+  ]
+
+  # ---------------------------------------------------------------------------
   # Callbacks — Safety & Visibility
   # ---------------------------------------------------------------------------
 
@@ -248,6 +323,43 @@ defmodule Lotus.Source.Adapter do
   @spec disconnect(t()) :: :ok
   def disconnect(%__MODULE__{module: mod, state: state}) do
     mod.disconnect(state)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Dispatch helpers — Pipeline (optional callbacks with defaults)
+  # ---------------------------------------------------------------------------
+
+  @doc "Validate query safety via the adapter. Returns `:ok` if not implemented."
+  @spec sanitize_query(t(), String.t(), keyword()) :: :ok | {:error, String.t()}
+  def sanitize_query(%__MODULE__{module: mod, state: state}, query, opts) do
+    if function_exported?(mod, :sanitize_query, 3),
+      do: mod.sanitize_query(state, query, opts),
+      else: :ok
+  end
+
+  @doc "Transform query before filters/sorts. Returns `{query, params}` if not implemented."
+  @spec transform_query(t(), String.t(), list(), keyword()) :: {String.t(), list()}
+  def transform_query(%__MODULE__{module: mod, state: state}, query, params, opts) do
+    if function_exported?(mod, :transform_query, 4),
+      do: mod.transform_query(state, query, params, opts),
+      else: {query, params}
+  end
+
+  @doc "Extract accessed resources for preflight checks. Returns `:skip` if not implemented."
+  @spec extract_accessed_resources(t(), String.t(), list(), keyword()) ::
+          {:ok, MapSet.t({String.t() | nil, String.t()})} | {:error, term()} | :skip
+  def extract_accessed_resources(%__MODULE__{module: mod, state: state}, query, params, opts) do
+    if function_exported?(mod, :extract_accessed_resources, 4),
+      do: mod.extract_accessed_resources(state, query, params, opts),
+      else: :skip
+  end
+
+  @doc "Apply windowed pagination. Returns `{query, params, nil}` if not implemented."
+  @spec apply_window(t(), String.t(), list(), keyword()) :: {String.t(), list(), map() | nil}
+  def apply_window(%__MODULE__{module: mod, state: state}, query, params, window_opts) do
+    if function_exported?(mod, :apply_window, 4),
+      do: mod.apply_window(state, query, params, window_opts),
+      else: {query, params, nil}
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -21,6 +21,7 @@ defmodule Lotus.Source.Adapters.Ecto do
   @behaviour Lotus.Source.Adapter
 
   alias Lotus.Source.Adapter
+  alias Lotus.SQL.Sanitizer
 
   @impls %{
     Ecto.Adapters.Postgres => Lotus.Sources.Postgres,
@@ -256,9 +257,8 @@ defmodule Lotus.Source.Adapters.Ecto do
   def sanitize_query(_repo, query, opts) do
     read_only = Keyword.get(opts, :read_only, true)
 
-    with :ok <- assert_single_statement(query),
-         :ok <- assert_not_denied(query, read_only) do
-      :ok
+    with :ok <- assert_single_statement(query) do
+      assert_not_denied(query, read_only)
     end
   end
 
@@ -280,7 +280,7 @@ defmodule Lotus.Source.Adapters.Ecto do
 
   @impl true
   def apply_window(repo, query, params, window_opts) do
-    base_sql = Lotus.SQL.Sanitizer.strip_trailing_semicolon(query)
+    base_sql = Sanitizer.strip_trailing_semicolon(query)
     limit = Keyword.fetch!(window_opts, :limit)
     offset = Keyword.get(window_opts, :offset, 0)
     count_mode = Keyword.get(window_opts, :count, :none)

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -245,6 +245,81 @@ defmodule Lotus.Source.Adapters.Ecto do
   end
 
   # ---------------------------------------------------------------------------
+  # Callbacks — Pipeline (Query Processing)
+  # ---------------------------------------------------------------------------
+
+  # Deny list for dangerous operations (defense-in-depth).
+  # Skipped when `read_only: false` is passed in opts.
+  @deny ~r/\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|GRANT|REVOKE|VACUUM|ANALYZE|CALL|LOCK)\b/i
+
+  @impl true
+  def sanitize_query(_repo, query, opts) do
+    read_only = Keyword.get(opts, :read_only, true)
+
+    with :ok <- assert_single_statement(query),
+         :ok <- assert_not_denied(query, read_only) do
+      :ok
+    end
+  end
+
+  @impl true
+  def transform_query(_repo, query, params, _opts), do: {query, params}
+
+  @impl true
+  def extract_accessed_resources(repo, query, params, opts) do
+    source_type = detect_source_type(repo)
+    search_path = Keyword.get(opts, :search_path)
+
+    case source_type do
+      :postgres -> extract_pg_resources(repo, query, params, search_path)
+      :sqlite -> extract_sqlite_resources(repo, query, params)
+      :mysql -> extract_mysql_resources(repo, query, params)
+      _ -> :skip
+    end
+  end
+
+  @impl true
+  def apply_window(repo, query, params, window_opts) do
+    base_sql = Lotus.SQL.Sanitizer.strip_trailing_semicolon(query)
+    limit = Keyword.fetch!(window_opts, :limit)
+    offset = Keyword.get(window_opts, :offset, 0)
+    count_mode = Keyword.get(window_opts, :count, :none)
+    search_path = Keyword.get(window_opts, :search_path)
+
+    param_count = length(params)
+
+    {limit_ph, offset_ph} =
+      impl_for(repo).limit_offset_placeholders(param_count + 1, param_count + 2)
+
+    paged_sql =
+      "SELECT * FROM (" <>
+        base_sql <> ") AS lotus_sub LIMIT " <> limit_ph <> " OFFSET " <> offset_ph
+
+    paged_params = params ++ [limit, offset]
+
+    window_meta =
+      case count_mode do
+        :exact ->
+          adapter_struct = wrap("__window__", repo)
+
+          %{
+            window: %{limit: limit, offset: offset},
+            total_count: :pending,
+            total_mode: :exact,
+            count_sql: "SELECT COUNT(*) FROM (" <> base_sql <> ") AS lotus_sub",
+            count_params: params,
+            adapter: adapter_struct,
+            search_path: search_path
+          }
+
+        _ ->
+          %{window: %{limit: limit, offset: offset}, total_count: nil, total_mode: :none}
+      end
+
+    {paged_sql, paged_params, window_meta}
+  end
+
+  # ---------------------------------------------------------------------------
   # Callbacks — Source Identity
   # ---------------------------------------------------------------------------
 
@@ -280,4 +355,345 @@ defmodule Lotus.Source.Adapters.Ecto do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  # ---------------------------------------------------------------------------
+  # Sanitization helpers
+  # ---------------------------------------------------------------------------
+
+  # Allow a single statement with an optional trailing semicolon.
+  # Reject any additional top-level semicolons (outside strings/comments).
+  defp assert_single_statement(sql) do
+    s = String.trim(sql)
+
+    s =
+      if String.ends_with?(s, ";") do
+        s
+        |> String.trim_trailing()
+        |> String.trim_trailing(";")
+        |> String.trim_trailing()
+      else
+        s
+      end
+
+    if has_top_level_semicolon?(s) do
+      {:error, "Only a single statement is allowed"}
+    else
+      :ok
+    end
+  end
+
+  defp has_top_level_semicolon?(bin), do: scan_semicolons(bin, :code)
+
+  # State machine that skips semicolons inside:
+  # - single-quoted strings
+  # - double-quoted identifiers
+  # - PostgreSQL dollar-quoted strings ($tag$ ... $tag$ or $ ... $)
+  # - line comments (-- ...\n)
+  # - block comments (/* ... */)
+  defp scan_semicolons(<<>>, _state), do: false
+
+  defp scan_semicolons(<<?;, _::binary>>, :code), do: true
+
+  defp scan_semicolons(<<"--", rest::binary>>, :code),
+    do: scan_semicolons(skip_to_eol(rest), :code)
+
+  defp scan_semicolons(<<"/*", rest::binary>>, :code),
+    do: scan_semicolons(skip_block_comment(rest), :code)
+
+  defp scan_semicolons(<<"'", rest::binary>>, :code),
+    do: scan_semicolons(skip_single_quoted(rest), :code)
+
+  defp scan_semicolons(<<"\"", rest::binary>>, :code),
+    do: scan_semicolons(skip_double_quoted(rest), :code)
+
+  defp scan_semicolons(<<"$", rest::binary>>, :code) do
+    case take_dollar_tag(rest, "") do
+      {:tag, tag, after_tag} -> scan_semicolons(skip_dollar_quoted(after_tag, tag), :code)
+      :no_tag -> scan_semicolons(rest, :code)
+    end
+  end
+
+  defp scan_semicolons(<<_::utf8, rest::binary>>, :code),
+    do: scan_semicolons(rest, :code)
+
+  defp skip_to_eol(<<>>), do: <<>>
+  defp skip_to_eol(<<"\n", rest::binary>>), do: rest
+  defp skip_to_eol(<<_::utf8, rest::binary>>), do: skip_to_eol(rest)
+
+  defp skip_block_comment(rest), do: skip_block_comment(rest, 1)
+
+  defp skip_block_comment(<<>>, _depth), do: <<>>
+  defp skip_block_comment(<<"*/", rest::binary>>, 1), do: rest
+  defp skip_block_comment(<<"*/", rest::binary>>, depth), do: skip_block_comment(rest, depth - 1)
+  defp skip_block_comment(<<"/*", rest::binary>>, depth), do: skip_block_comment(rest, depth + 1)
+  defp skip_block_comment(<<_::utf8, rest::binary>>, depth), do: skip_block_comment(rest, depth)
+
+  defp skip_single_quoted(<<>>), do: <<>>
+  defp skip_single_quoted(<<"''", rest::binary>>), do: skip_single_quoted(rest)
+  defp skip_single_quoted(<<"'", rest::binary>>), do: rest
+  defp skip_single_quoted(<<_::utf8, rest::binary>>), do: skip_single_quoted(rest)
+
+  defp skip_double_quoted(<<>>), do: <<>>
+  defp skip_double_quoted(<<"\"\"", rest::binary>>), do: skip_double_quoted(rest)
+  defp skip_double_quoted(<<"\"", rest::binary>>), do: rest
+  defp skip_double_quoted(<<_::utf8, rest::binary>>), do: skip_double_quoted(rest)
+
+  defp take_dollar_tag(<<"$", rest::binary>>, acc), do: {:tag, acc, rest}
+
+  defp take_dollar_tag(<<c, rest::binary>>, acc)
+       when c in ?A..?Z or c in ?a..?z or c in ?0..?9 or c == ?_,
+       do: take_dollar_tag(rest, <<acc::binary, c>>)
+
+  defp take_dollar_tag(_, _), do: :no_tag
+
+  defp skip_dollar_quoted(bin, tag) do
+    closer = "$" <> tag <> "$"
+
+    case :binary.match(bin, closer) do
+      :nomatch -> <<>>
+      {pos, len} -> :binary.part(bin, pos + len, byte_size(bin) - pos - len)
+    end
+  end
+
+  defp assert_not_denied(_sql, false = _read_only), do: :ok
+
+  defp assert_not_denied(sql, _read_only) do
+    if Regex.match?(@deny, sql), do: {:error, "Only read-only queries are allowed"}, else: :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Resource extraction helpers
+  # ---------------------------------------------------------------------------
+
+  defp extract_pg_resources(repo, sql, params, search_path) do
+    explain = "EXPLAIN (VERBOSE, FORMAT JSON) " <> sql
+    opts = if search_path, do: [search_path: search_path], else: []
+
+    case execute_query(repo, explain, params, opts) do
+      {:ok, %{rows: [[json]]}} ->
+        relations =
+          json
+          |> parse_pg_explain_plan()
+          |> collect_pg_relations(MapSet.new())
+
+        {:ok, relations}
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  defp parse_pg_explain_plan(json) do
+    plan_data =
+      case json do
+        binary when is_binary(binary) -> Lotus.JSON.decode!(binary)
+        data when is_list(data) or is_map(data) -> data
+      end
+
+    case plan_data do
+      [first | _] -> Map.fetch!(first, "Plan")
+      %{"Plan" => plan} -> plan
+    end
+  end
+
+  defp collect_pg_relations(%{"Plans" => plans} = node, acc) do
+    Enum.reduce(plans, collect_pg_here(node, acc), &collect_pg_relations/2)
+  end
+
+  defp collect_pg_relations(node, acc), do: collect_pg_here(node, acc)
+
+  defp collect_pg_here(node, acc) do
+    case {node["Schema"], node["Relation Name"]} do
+      {schema, rel} when is_binary(schema) and is_binary(rel) ->
+        MapSet.put(acc, {schema, rel})
+
+      _ ->
+        acc
+    end
+  end
+
+  defp extract_sqlite_resources(repo, sql, params) do
+    alias_map = parse_alias_map(sql)
+
+    explain = "EXPLAIN QUERY PLAN " <> sql
+
+    case execute_query(repo, explain, params, []) do
+      {:ok, %{rows: rows}} ->
+        relations =
+          rows
+          |> Enum.map(fn row -> Enum.join(row, " ") end)
+          |> Enum.flat_map(&extract_sqlite_relations/1)
+          |> Enum.map(&resolve_alias(&1, alias_map))
+          |> Enum.reject(&is_nil/1)
+          |> Enum.map(&{nil, &1})
+          |> MapSet.new()
+
+        {:ok, relations}
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  defp extract_mysql_resources(repo, sql, params) do
+    alias_map = parse_alias_map(sql)
+
+    explain = "EXPLAIN FORMAT=JSON " <> sql
+
+    case execute_query(repo, explain, params, []) do
+      {:ok, %{rows: [[json]]}} ->
+        explain_rels =
+          json
+          |> Lotus.JSON.decode!()
+          |> collect_mysql_relations(MapSet.new())
+          |> MapSet.to_list()
+          |> Enum.map(fn {schema, table_name} ->
+            {schema, resolve_alias(table_name, alias_map)}
+          end)
+          |> Enum.reject(fn {_schema, name} -> is_nil(name) end)
+
+        sql_rels = extract_mysql_tables_from_sql(sql)
+        relations = choose_mysql_relations(explain_rels, sql_rels, sql) |> MapSet.new()
+
+        {:ok, relations}
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  defp collect_mysql_relations(%{"query_block" => query_block}, acc) do
+    collect_mysql_query_block(query_block, acc)
+  end
+
+  defp collect_mysql_relations(data, acc) when is_list(data) do
+    Enum.reduce(data, acc, &collect_mysql_relations/2)
+  end
+
+  defp collect_mysql_relations(data, acc) when is_map(data) do
+    case Map.get(data, "query_block") do
+      nil -> acc
+      query_block -> collect_mysql_query_block(query_block, acc)
+    end
+  end
+
+  defp collect_mysql_relations(_, acc), do: acc
+
+  defp collect_mysql_query_block(%{"table" => table_info}, acc) when is_map(table_info) do
+    case Map.get(table_info, "table_name") do
+      table_name when is_binary(table_name) ->
+        schema = Map.get(table_info, "schema")
+        MapSet.put(acc, {schema, table_name})
+
+      _ ->
+        acc
+    end
+  end
+
+  defp collect_mysql_query_block(%{"nested_loop" => nested_loop}, acc)
+       when is_list(nested_loop) do
+    Enum.reduce(nested_loop, acc, fn item, acc_inner ->
+      collect_mysql_query_block(item, acc_inner)
+    end)
+  end
+
+  defp collect_mysql_query_block(data, acc) when is_map(data) do
+    data
+    |> Enum.reduce(acc, fn {_key, value}, acc_inner ->
+      collect_mysql_relations(value, acc_inner)
+    end)
+  end
+
+  defp collect_mysql_query_block(_, acc), do: acc
+
+  defp extract_mysql_tables_from_sql(sql) do
+    table_regex =
+      ~r/(?:FROM|JOIN)\s+(?:(`?)([a-zA-Z_][a-zA-Z0-9_]*)\1\.)?(`?)([a-zA-Z_][a-zA-Z0-9_]*)\3(?:\s+(?:AS\s+)?[a-zA-Z_][a-zA-Z0-9_]*)?/i
+
+    Regex.scan(table_regex, sql)
+    |> Enum.map(fn
+      [_, _, schema, _, table] when schema != "" -> {schema, table}
+      [_, "", "", _, table] -> {nil, table}
+    end)
+    |> Enum.uniq()
+  end
+
+  defp choose_mysql_relations(explain_rels, sql_rels, sql) do
+    if should_use_sql_relations?(explain_rels, sql) do
+      sql_rels
+    else
+      explain_rels
+    end
+  end
+
+  defp should_use_sql_relations?(explain_rels, sql) do
+    Enum.empty?(explain_rels) or
+      Enum.all?(explain_rels, fn {_, name} -> String.length(name) <= 4 end) or
+      String.contains?(sql, "information_schema") or
+      String.contains?(sql, "performance_schema") or
+      String.contains?(sql, "mysql.") or
+      String.contains?(sql, "sys.")
+  end
+
+  defp parse_alias_map(sql) do
+    s = strip_sql_comments(sql)
+
+    rx_from = ~r/\bFROM\s+("?[A-Za-z0-9_]+"?)\s+(?:AS\s+)?("?[A-Za-z0-9_]+"?)/i
+    rx_join = ~r/\bJOIN\s+("?[A-Za-z0-9_]+"?)\s+(?:AS\s+)?("?[A-Za-z0-9_]+"?)/i
+
+    [rx_from, rx_join]
+    |> Enum.flat_map(&Regex.scan(&1, s))
+    |> Enum.reduce(%{}, fn
+      [_, base, alias_name], acc ->
+        base = normalize_ident(base)
+        alias_name = normalize_ident(alias_name)
+        if base == "(", do: acc, else: Map.put(acc, alias_name, base)
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp strip_sql_comments(s) do
+    s
+    |> String.replace(~r/--.*$/m, "")
+    |> String.replace(~r/\/\*[\s\S]*?\*\//, "")
+  end
+
+  defp normalize_ident(<<"\"", rest::binary>>) do
+    rest |> String.trim_trailing(~s|"|) |> String.replace(~s|""|, ~s|"|)
+  end
+
+  defp normalize_ident(s), do: s
+
+  defp resolve_alias(name, alias_map), do: Map.get(alias_map, name, name)
+
+  defp extract_sqlite_relations(text) do
+    cond do
+      Regex.match?(
+        ~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)\s+AS\s+("[^"]+"|[A-Za-z0-9_]+)/,
+        text
+      ) ->
+        for [_, base, _alias] <-
+              Regex.scan(
+                ~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)\s+AS\s+("[^"]+"|[A-Za-z0-9_]+)/,
+                text
+              ) do
+          normalize_ident(base)
+        end
+
+      Regex.match?(~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)/, text) ->
+        for [_, base] <- Regex.scan(~r/\b(?:SCAN|SEARCH)\s+TABLE\s+("[^"]+"|[A-Za-z0-9_]+)/, text) do
+          normalize_ident(base)
+        end
+
+      Regex.match?(~r/\b(?:SCAN|SEARCH)\s+("[^"]+"|[A-Za-z0-9_]+)/, text) ->
+        for [_, name] <- Regex.scan(~r/\b(?:SCAN|SEARCH)\s+("[^"]+"|[A-Za-z0-9_]+)/, text) do
+          normalize_ident(name)
+        end
+
+      true ->
+        []
+    end
+  end
 end

--- a/test/lotus/preflight_test.exs
+++ b/test/lotus/preflight_test.exs
@@ -25,15 +25,26 @@ defmodule Lotus.PreflightTest do
   end
 
   describe "fallback behavior" do
-    test "allows queries for unknown adapters" do
+    test "allows queries when adapter returns :skip" do
       unknown_adapter = %Lotus.Source.Adapter{
         name: "unknown",
-        module: Lotus.Source.Adapters.Ecto,
-        state: Lotus.Test.Repo,
+        module: Lotus.Test.NoOpAdapter,
+        state: nil,
         source_type: :other
       }
 
       assert :ok = Preflight.authorize(unknown_adapter, "SELECT * FROM anything", [])
+    end
+
+    test "allows queries when adapter does not implement extract_accessed_resources" do
+      stub_adapter = %Lotus.Source.Adapter{
+        name: "stub",
+        module: Lotus.Test.StubAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      assert :ok = Preflight.authorize(stub_adapter, "SELECT * FROM anything", [])
     end
   end
 end

--- a/test/lotus/source/adapters/ecto_test.exs
+++ b/test/lotus/source/adapters/ecto_test.exs
@@ -180,6 +180,158 @@ defmodule Lotus.Source.Adapters.EctoTest do
     end
   end
 
+  describe "sanitize_query/3" do
+    test "allows a single SELECT statement" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert :ok = Adapter.sanitize_query(adapter, "SELECT 1", [])
+    end
+
+    test "rejects multiple statements" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:error, "Only a single statement is allowed"} =
+               Adapter.sanitize_query(adapter, "SELECT 1; DROP TABLE users", [])
+    end
+
+    test "blocks DML when read_only is true" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:error, "Only read-only queries are allowed"} =
+               Adapter.sanitize_query(adapter, "INSERT INTO users VALUES (1)", read_only: true)
+    end
+
+    test "allows DML when read_only is false" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert :ok =
+               Adapter.sanitize_query(adapter, "INSERT INTO users VALUES (1)", read_only: false)
+    end
+
+    test "defaults to read_only: true" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:error, "Only read-only queries are allowed"} =
+               Adapter.sanitize_query(adapter, "DELETE FROM users", [])
+    end
+  end
+
+  describe "transform_query/4" do
+    test "passes through query and params unchanged" do
+      adapter = EctoAdapter.wrap("main", Repo)
+      assert {"SELECT 1", [42]} = Adapter.transform_query(adapter, "SELECT 1", [42], [])
+    end
+  end
+
+  describe "extract_accessed_resources/4" do
+    test "extracts postgres relations via EXPLAIN" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:ok, relations} =
+               Adapter.extract_accessed_resources(adapter, "SELECT * FROM lotus_queries", [], [])
+
+      assert MapSet.member?(relations, {"public", "lotus_queries"})
+    end
+
+    test "returns error for invalid SQL" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      assert {:error, _reason} =
+               Adapter.extract_accessed_resources(
+                 adapter,
+                 "SELECT * FROM nonexistent_xyz",
+                 [],
+                 []
+               )
+    end
+  end
+
+  describe "apply_window/4" do
+    test "wraps query with LIMIT/OFFSET for postgres" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      {paged_sql, paged_params, window_meta} =
+        Adapter.apply_window(adapter, "SELECT * FROM users", [], limit: 10, offset: 0)
+
+      assert paged_sql =~ "LIMIT"
+      assert paged_sql =~ "OFFSET"
+      assert paged_params == [10, 0]
+      assert %{window: %{limit: 10, offset: 0}} = window_meta
+    end
+
+    test "includes count metadata when count: :exact" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      {_paged_sql, _paged_params, window_meta} =
+        Adapter.apply_window(adapter, "SELECT * FROM users", [],
+          limit: 10,
+          offset: 0,
+          count: :exact
+        )
+
+      assert %{total_mode: :exact, count_sql: count_sql} = window_meta
+      assert count_sql =~ "COUNT(*)"
+    end
+
+    test "returns nil total_count when count: :none" do
+      adapter = EctoAdapter.wrap("main", Repo)
+
+      {_paged_sql, _paged_params, window_meta} =
+        Adapter.apply_window(adapter, "SELECT * FROM users", [],
+          limit: 10,
+          offset: 0,
+          count: :none
+        )
+
+      assert %{total_mode: :none, total_count: nil} = window_meta
+    end
+  end
+
+  describe "dispatch helpers for optional callbacks" do
+    test "sanitize_query returns :ok for adapter without the callback" do
+      adapter = %Adapter{
+        name: "stub",
+        module: Lotus.Test.StubAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      assert :ok = Adapter.sanitize_query(adapter, "anything", [])
+    end
+
+    test "transform_query passes through for adapter without the callback" do
+      adapter = %Adapter{
+        name: "stub",
+        module: Lotus.Test.StubAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      assert {"SELECT 1", []} = Adapter.transform_query(adapter, "SELECT 1", [], [])
+    end
+
+    test "extract_accessed_resources returns :skip for adapter without the callback" do
+      adapter = %Adapter{
+        name: "stub",
+        module: Lotus.Test.StubAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      assert :skip = Adapter.extract_accessed_resources(adapter, "SELECT 1", [], [])
+    end
+
+    test "apply_window passes through for adapter without the callback" do
+      adapter = %Adapter{
+        name: "stub",
+        module: Lotus.Test.StubAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      assert {"SELECT 1", [], nil} = Adapter.apply_window(adapter, "SELECT 1", [], [])
+    end
+  end
+
   describe "error handling" do
     test "format_error/1 formats exceptions" do
       adapter = EctoAdapter.wrap("main", Repo)

--- a/test/support/test_adapters.ex
+++ b/test/support/test_adapters.ex
@@ -1,0 +1,98 @@
+defmodule Lotus.Test.NoOpAdapter do
+  @moduledoc false
+  @behaviour Lotus.Source.Adapter
+
+  @impl true
+  def extract_accessed_resources(_state, _query, _params, _opts), do: :skip
+
+  @impl true
+  def execute_query(_state, _sql, _params, _opts), do: {:error, "not implemented"}
+  @impl true
+  def transaction(_state, _fun, _opts), do: {:error, "not implemented"}
+  @impl true
+  def list_schemas(_state), do: {:ok, []}
+  @impl true
+  def list_tables(_state, _schemas, _opts), do: {:ok, []}
+  @impl true
+  def get_table_schema(_state, _schema, _table), do: {:ok, []}
+  @impl true
+  def resolve_table_schema(_state, _table, _schemas), do: {:ok, nil}
+  @impl true
+  def quote_identifier(_state, id), do: ~s("#{id}")
+  @impl true
+  def param_placeholder(_state, index, _var, _type), do: "$#{index}"
+  @impl true
+  def limit_offset_placeholders(_state, li, oi), do: {"$#{li}", "$#{oi}"}
+  @impl true
+  def apply_filters(_state, sql, params, _filters), do: {sql, params}
+  @impl true
+  def apply_sorts(_state, sql, _sorts), do: sql
+  @impl true
+  def explain_plan(_state, _sql, _params, _opts), do: {:ok, ""}
+  @impl true
+  def builtin_denies(_state), do: []
+  @impl true
+  def builtin_schema_denies(_state), do: []
+  @impl true
+  def default_schemas(_state), do: []
+  @impl true
+  def health_check(_state), do: :ok
+  @impl true
+  def disconnect(_state), do: :ok
+  @impl true
+  def format_error(_state, error), do: inspect(error)
+  @impl true
+  def handled_errors(_state), do: []
+  @impl true
+  def source_type(_state), do: :other
+  @impl true
+  def supports_feature?(_state, _feature), do: false
+end
+
+defmodule Lotus.Test.StubAdapter do
+  @moduledoc false
+  @behaviour Lotus.Source.Adapter
+
+  @impl true
+  def execute_query(_state, _sql, _params, _opts), do: {:error, "not implemented"}
+  @impl true
+  def transaction(_state, _fun, _opts), do: {:error, "not implemented"}
+  @impl true
+  def list_schemas(_state), do: {:ok, []}
+  @impl true
+  def list_tables(_state, _schemas, _opts), do: {:ok, []}
+  @impl true
+  def get_table_schema(_state, _schema, _table), do: {:ok, []}
+  @impl true
+  def resolve_table_schema(_state, _table, _schemas), do: {:ok, nil}
+  @impl true
+  def quote_identifier(_state, id), do: ~s("#{id}")
+  @impl true
+  def param_placeholder(_state, index, _var, _type), do: "$#{index}"
+  @impl true
+  def limit_offset_placeholders(_state, li, oi), do: {"$#{li}", "$#{oi}"}
+  @impl true
+  def apply_filters(_state, sql, params, _filters), do: {sql, params}
+  @impl true
+  def apply_sorts(_state, sql, _sorts), do: sql
+  @impl true
+  def explain_plan(_state, _sql, _params, _opts), do: {:ok, ""}
+  @impl true
+  def builtin_denies(_state), do: []
+  @impl true
+  def builtin_schema_denies(_state), do: []
+  @impl true
+  def default_schemas(_state), do: []
+  @impl true
+  def health_check(_state), do: :ok
+  @impl true
+  def disconnect(_state), do: :ok
+  @impl true
+  def format_error(_state, error), do: inspect(error)
+  @impl true
+  def handled_errors(_state), do: []
+  @impl true
+  def source_type(_state), do: :other
+  @impl true
+  def supports_feature?(_state, _feature), do: false
+end


### PR DESCRIPTION
Add 4 optional adapter callbacks (sanitize_query, transform_query, extract_accessed_resources, apply_window) so non-SQL data sources can participate in the query pipeline. Move SQL-specific logic from Runner and Preflight into the Ecto adapter. Runner and Preflight now delegate to Adapter dispatch helpers with safe defaults for adapters that don't implement the optional callbacks.

Closes https://github.com/elixir-lotus/lotus/issues/208