### PR TITLE
refactor: rename run_sql to run_statement with deprecated delegates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removed `FilterInjector.quote_value/1` — no longer needed since values are parameterized
 - Removed duplicated private `Lotus.trim_trailing_semicolon/1` in favor of `Lotus.SQL.Sanitizer.strip_trailing_semicolon/1`, eliminating code duplication and a redundant double-trim in the window pagination path (#155)
 - Extracted shared filter → sort → window → cache → execute pipeline from `Lotus.run_sql/3` and `Lotus.execute_query/5` into a single private `execute_with_options/7` helper. `run_sql/3` now reuses `build_cache_tags/3` and `determine_cache_profile/1` instead of inlining the same logic. No public API or behavior changes (#160)
+- Renamed `Lotus.run_sql/3` → `Lotus.run_statement/3` and `Lotus.Runner.run_sql/4` → `Lotus.Runner.run_statement/4`; `sql` parameter renamed to `statement` throughout (#211)
 - `Lotus.can_run?/2` now reuses the private `prepare_variables/2` helper instead of duplicating the default-merge logic inline. No behavior change (#156)
 - Extracted SQL sanitization (`assert_single_statement`, deny-list), EXPLAIN-based relation extraction, and window pagination SQL construction from `Runner`, `Preflight`, and `Lotus` into 4 new optional adapter callbacks (`sanitize_query/3`, `transform_query/4`, `extract_accessed_resources/4`, `apply_window/4`). `Runner` and `Preflight` now delegate to `Adapter` dispatch helpers with safe defaults for adapters that don't implement the optional callbacks. No public API or behavior changes (#208)
 
@@ -26,6 +27,8 @@
 - `Lotus.Config.rules_for_repo_name/1` — use `Lotus.Config.rules_for_source_name/1` (will be removed in v1.0)
 - `Lotus.Config.schema_rules_for_repo_name/1` — use `Lotus.Config.schema_rules_for_source_name/1` (will be removed in v1.0)
 - `Lotus.Config.column_rules_for_repo_name/1` — use `Lotus.Config.column_rules_for_source_name/1` (will be removed in v1.0)
+- `Lotus.run_sql/3` — use `Lotus.run_statement/3` (will be removed in v1.0) (#211)
+- `Lotus.Runner.run_sql/4` — use `Lotus.Runner.run_statement/4` (will be removed in v1.0) (#211)
 
 ### Breaking
 

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -32,7 +32,7 @@ defmodule Lotus do
       {:ok, results} = Lotus.run_query(query)
 
       # Execute SQL directly (read-only)
-      {:ok, results} = Lotus.run_sql("SELECT * FROM products WHERE price > $1", [100])
+      {:ok, results} = Lotus.run_statement("SELECT * FROM products WHERE price > $1", [100])
   """
 
   @default_page_size 1000
@@ -490,7 +490,7 @@ defmodule Lotus do
     profile = determine_cache_profile(opts)
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      with {:ok, %Result{} = res} <- Runner.run_sql(adapter, sql, params, runner_opts) do
+      with {:ok, %Result{} = res} <- Runner.run_statement(adapter, sql, params, runner_opts) do
         {:ok, merge_window_meta(res, window_meta)}
       end
     end)
@@ -579,19 +579,19 @@ defmodule Lotus do
   ## Examples
 
       # Run against default configured repo
-      {:ok, result} = Lotus.run_sql("SELECT * FROM users")
+      {:ok, result} = Lotus.run_statement("SELECT * FROM users")
 
       # Run against specific repo
-      {:ok, result} = Lotus.run_sql("SELECT * FROM products", [], repo: MyApp.DataRepo)
+      {:ok, result} = Lotus.run_statement("SELECT * FROM products", [], repo: MyApp.DataRepo)
 
       # With parameters
-      {:ok, result} = Lotus.run_sql("SELECT * FROM users WHERE id = $1", [123])
+      {:ok, result} = Lotus.run_statement("SELECT * FROM users WHERE id = $1", [123])
 
       # With search_path for schema resolution
-      {:ok, result} = Lotus.run_sql("SELECT * FROM users", [], search_path: "reporting, public")
+      {:ok, result} = Lotus.run_statement("SELECT * FROM users", [], search_path: "reporting, public")
 
       # Allow write queries (development use)
-      {:ok, result} = Lotus.run_sql(
+      {:ok, result} = Lotus.run_statement(
         "INSERT INTO notes (body) VALUES ($1)",
         ["hello"],
         read_only: false
@@ -602,7 +602,7 @@ defmodule Lotus do
   page results from the SQL. See `run_query/2` for details. The cache key automatically
   incorporates the window so different pages are cached independently.
   """
-  @spec run_sql(binary(), list(any()), [
+  @spec run_statement(binary(), list(any()), [
           {:read_only, boolean()}
           | {:statement_timeout_ms, non_neg_integer()}
           | {:timeout, non_neg_integer()}
@@ -611,7 +611,7 @@ defmodule Lotus do
           | {:window, window_opts}
         ]) ::
           {:ok, Result.t()} | {:error, term()}
-  def run_sql(sql, params \\ [], opts \\ []) do
+  def run_statement(statement, params \\ [], opts \\ []) do
     adapter = Sources.resolve!(Keyword.get(opts, :repo), nil)
 
     runner_opts =
@@ -619,8 +619,14 @@ defmodule Lotus do
       |> Keyword.delete(:repo)
       |> Keyword.put_new_lazy(:read_only, &Config.read_only?/0)
 
-    execute_with_options(adapter, sql, params, opts, runner_opts, params, nil)
+    execute_with_options(adapter, statement, params, opts, runner_opts, params, nil)
   end
+
+  @doc false
+  @deprecated "Use Lotus.run_statement/3 instead"
+  @spec run_sql(binary(), list(any()), keyword()) :: {:ok, Result.t()} | {:error, term()}
+  def run_sql(statement, params \\ [], opts \\ []),
+    do: run_statement(statement, params, opts)
 
   @doc """
   Returns whether unique query names are enforced.
@@ -937,7 +943,7 @@ defmodule Lotus do
     runner_opts = build_runner_opts(meta)
 
     adapter
-    |> Runner.run_sql(count_sql, count_params, runner_opts)
+    |> Runner.run_statement(count_sql, count_params, runner_opts)
     |> parse_count_result()
   end
 

--- a/lib/lotus/ai/actions/execute_sql.ex
+++ b/lib/lotus/ai/actions/execute_sql.ex
@@ -41,7 +41,7 @@ defmodule Lotus.AI.Actions.ExecuteSQL do
   def run(params, _context) do
     started_at = DateTime.utc_now()
 
-    case Lotus.run_sql(params.sql, [], repo: params.data_source, read_only: true) do
+    case Lotus.run_statement(params.sql, [], repo: params.data_source, read_only: true) do
       {:ok, result} ->
         preview_rows =
           result.rows

--- a/lib/lotus/ai/actions/get_column_values.ex
+++ b/lib/lotus/ai/actions/get_column_values.ex
@@ -66,7 +66,7 @@ defmodule Lotus.AI.Actions.GetColumnValues do
   end
 
   defp run_and_format(query, params) do
-    case Lotus.run_sql(query, [], repo: params.data_source) do
+    case Lotus.run_statement(query, [], repo: params.data_source) do
       {:ok, result} ->
         values = Enum.map(result.rows, fn [value] -> Lotus.Normalizer.normalize(value) end)
 

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -12,7 +12,7 @@ defmodule Lotus.Runner do
   alias Lotus.Source.Adapter
   alias Lotus.Visibility.Policy
 
-  @type sql :: String.t()
+  @type statement :: String.t()
   @type params :: list()
   @type query_result :: Result.t()
   @type opts :: [
@@ -22,20 +22,20 @@ defmodule Lotus.Runner do
           search_path: String.t() | nil
         ]
 
-  @spec run_sql(Adapter.t(), sql(), params(), opts()) ::
+  @spec run_statement(Adapter.t(), statement(), params(), opts()) ::
           {:ok, query_result()} | {:error, term()}
-  def run_sql(%Adapter{} = adapter, sql, params \\ [], opts \\ [])
-      when is_binary(sql) and is_list(params) do
+  def run_statement(%Adapter{} = adapter, statement, params \\ [], opts \\ [])
+      when is_binary(statement) and is_list(params) do
     context = Keyword.get(opts, :context)
-    telemetry_meta = %{repo: adapter.name, sql: sql, params: params, context: context}
+    telemetry_meta = %{repo: adapter.name, sql: statement, params: params, context: context}
     start_time = Telemetry.query_start(telemetry_meta)
 
     result =
-      with :ok <- Adapter.sanitize_query(adapter, sql, sanitize_opts(opts)),
-           :ok <- preflight_visibility(adapter, sql, params, opts),
-           :ok <- run_before_query(adapter, sql, params, context),
-           {:ok, %Result{} = res} <- exec_read_only(adapter, sql, params, opts),
-           {:ok, %Result{} = res} <- run_after_query(adapter, sql, params, res, context) do
+      with :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
+           :ok <- preflight_visibility(adapter, statement, params, opts),
+           :ok <- run_before_query(adapter, statement, params, context),
+           {:ok, %Result{} = res} <- exec_read_only(adapter, statement, params, opts),
+           {:ok, %Result{} = res} <- run_after_query(adapter, statement, params, res, context) do
         {:ok, res}
       end
 
@@ -53,6 +53,13 @@ defmodule Lotus.Runner do
         error
     end
   end
+
+  @doc false
+  @deprecated "Use Lotus.Runner.run_statement/4 instead"
+  @spec run_sql(Adapter.t(), statement(), params(), opts()) ::
+          {:ok, query_result()} | {:error, term()}
+  def run_sql(adapter, statement, params \\ [], opts \\ []),
+    do: run_statement(adapter, statement, params, opts)
 
   defp exec_read_only(%Adapter{} = adapter, sql, params, opts) do
     Adapter.transaction(

--- a/test/integration/caching_test.exs
+++ b/test/integration/caching_test.exs
@@ -62,7 +62,7 @@ defmodule Lotus.Integration.CachingTest do
     end
   end
 
-  describe "run_sql/3 caching scenarios" do
+  describe "run_statement/3 caching scenarios" do
     setup do
       user = Fixtures.insert_user(%{name: "Cache Test User", email: "cache@test.com"})
       %{user: user}
@@ -71,12 +71,12 @@ defmodule Lotus.Integration.CachingTest do
     test "caching works by default when adapter configured", %{user: user} do
       sql = "SELECT name, email FROM test_users WHERE id = $1"
 
-      assert {:ok, result1} = Lotus.run_sql(sql, [user.id])
+      assert {:ok, result1} = Lotus.run_statement(sql, [user.id])
       assert [["Cache Test User", "cache@test.com"]] = result1.rows
 
       Repo.delete!(user)
 
-      assert {:ok, result2} = Lotus.run_sql(sql, [user.id])
+      assert {:ok, result2} = Lotus.run_statement(sql, [user.id])
 
       assert result1.rows == result2.rows
       assert result1.columns == result2.columns
@@ -91,12 +91,12 @@ defmodule Lotus.Integration.CachingTest do
 
       sql = "SELECT name FROM test_users WHERE id = $1"
 
-      assert {:ok, result1} = Lotus.run_sql(sql, [user.id], cache: [profile: :options])
+      assert {:ok, result1} = Lotus.run_statement(sql, [user.id], cache: [profile: :options])
       assert [["Cache Test User"]] = result1.rows
 
       Repo.delete!(user)
 
-      assert {:ok, result2} = Lotus.run_sql(sql, [user.id], cache: [profile: :options])
+      assert {:ok, result2} = Lotus.run_statement(sql, [user.id], cache: [profile: :options])
 
       assert result1.rows == result2.rows
       assert result1.columns == result2.columns
@@ -111,12 +111,12 @@ defmodule Lotus.Integration.CachingTest do
 
       sql = "SELECT email FROM test_users WHERE id = $1"
 
-      assert {:ok, result1} = Lotus.run_sql(sql, [user.id], cache: [ttl_ms: 5_000])
+      assert {:ok, result1} = Lotus.run_statement(sql, [user.id], cache: [ttl_ms: 5_000])
       assert [["cache@test.com"]] = result1.rows
 
       Repo.delete!(user)
 
-      assert {:ok, result2} = Lotus.run_sql(sql, [user.id], cache: [ttl_ms: 5_000])
+      assert {:ok, result2} = Lotus.run_statement(sql, [user.id], cache: [ttl_ms: 5_000])
 
       assert result1.rows == result2.rows
       assert result1.columns == result2.columns
@@ -126,15 +126,15 @@ defmodule Lotus.Integration.CachingTest do
     test "refresh mode updates cache with fresh data", %{user: user} do
       sql = "SELECT name FROM test_users WHERE id = $1"
 
-      assert {:ok, result1} = Lotus.run_sql(sql, [user.id])
+      assert {:ok, result1} = Lotus.run_statement(sql, [user.id])
       assert [["Cache Test User"]] = result1.rows
 
       Repo.delete!(user)
 
-      assert {:ok, result2} = Lotus.run_sql(sql, [user.id], cache: :refresh)
+      assert {:ok, result2} = Lotus.run_statement(sql, [user.id], cache: :refresh)
       assert [] = result2.rows
 
-      assert {:ok, result3} = Lotus.run_sql(sql, [user.id])
+      assert {:ok, result3} = Lotus.run_statement(sql, [user.id])
       assert [] = result3.rows
     end
 
@@ -146,39 +146,45 @@ defmodule Lotus.Integration.CachingTest do
 
       sql = "SELECT 'profile_refresh' as data"
 
-      assert {:ok, result} = Lotus.run_sql(sql, [], cache: [:refresh, profile: :options])
+      assert {:ok, result} = Lotus.run_statement(sql, [], cache: [:refresh, profile: :options])
       assert [["profile_refresh"]] = result.rows
     end
 
     test "tagged entries can be invalidated", %{user: user} do
       sql = "SELECT name FROM test_users WHERE id = $1"
 
-      assert {:ok, result1} = Lotus.run_sql(sql, [user.id], cache: [tags: ["user:#{user.id}"]])
+      assert {:ok, result1} =
+               Lotus.run_statement(sql, [user.id], cache: [tags: ["user:#{user.id}"]])
+
       assert [["Cache Test User"]] = result1.rows
 
       Repo.delete!(user)
 
-      assert {:ok, result2} = Lotus.run_sql(sql, [user.id], cache: [tags: ["user:#{user.id}"]])
+      assert {:ok, result2} =
+               Lotus.run_statement(sql, [user.id], cache: [tags: ["user:#{user.id}"]])
+
       assert result1.rows == result2.rows
 
       Cache.invalidate_tags(["user:#{user.id}"])
 
-      assert {:ok, result3} = Lotus.run_sql(sql, [user.id], cache: [tags: ["user:#{user.id}"]])
+      assert {:ok, result3} =
+               Lotus.run_statement(sql, [user.id], cache: [tags: ["user:#{user.id}"]])
+
       assert [] = result3.rows
     end
 
     test "bypass cache leaves existing cache intact", %{user: user} do
       sql = "SELECT name FROM test_users WHERE id = $1"
 
-      assert {:ok, result1} = Lotus.run_sql(sql, [user.id])
+      assert {:ok, result1} = Lotus.run_statement(sql, [user.id])
       assert [["Cache Test User"]] = result1.rows
 
       Repo.delete!(user)
 
-      assert {:ok, result2} = Lotus.run_sql(sql, [user.id], cache: :bypass)
+      assert {:ok, result2} = Lotus.run_statement(sql, [user.id], cache: :bypass)
       assert [] = result2.rows
 
-      assert {:ok, result3} = Lotus.run_sql(sql, [user.id])
+      assert {:ok, result3} = Lotus.run_statement(sql, [user.id])
       assert [["Cache Test User"]] = result3.rows
     end
 
@@ -189,7 +195,7 @@ defmodule Lotus.Integration.CachingTest do
       end)
 
       sql = "SELECT name FROM test_users WHERE id = $1"
-      assert {:ok, _result} = Lotus.run_sql(sql, [user.id], cache: [max_bytes: 100])
+      assert {:ok, _result} = Lotus.run_statement(sql, [user.id], cache: [max_bytes: 100])
     end
 
     test "compress option is passed to cache layer", %{user: user} do
@@ -199,7 +205,7 @@ defmodule Lotus.Integration.CachingTest do
       end)
 
       sql = "SELECT name FROM test_users WHERE id = $1"
-      assert {:ok, _result} = Lotus.run_sql(sql, [user.id], cache: [compress: false])
+      assert {:ok, _result} = Lotus.run_statement(sql, [user.id], cache: [compress: false])
     end
   end
 

--- a/test/integration/mysql/window_pagination_test.exs
+++ b/test/integration/mysql/window_pagination_test.exs
@@ -21,7 +21,7 @@ defmodule Lotus.Integration.Mysql.WindowPaginationTest do
     :ok
   end
 
-  describe "run_sql/3 with window pagination (mysql)" do
+  describe "run_statement/3 with window pagination (mysql)" do
     test "pages results without total count" do
       sql = """
       SELECT name FROM test_users
@@ -30,7 +30,10 @@ defmodule Lotus.Integration.Mysql.WindowPaginationTest do
       """
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [], repo: "mysql", window: [limit: 1, offset: 0, count: :none])
+               Lotus.run_statement(sql, [],
+                 repo: "mysql",
+                 window: [limit: 1, offset: 0, count: :none]
+               )
 
       assert result.num_rows == 1
       assert result.rows == [["Window A"]]
@@ -47,7 +50,7 @@ defmodule Lotus.Integration.Mysql.WindowPaginationTest do
       """
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [],
+               Lotus.run_statement(sql, [],
                  repo: "mysql",
                  window: [limit: 2, offset: 1, count: :exact]
                )

--- a/test/integration/postgres/window_pagination_test.exs
+++ b/test/integration/postgres/window_pagination_test.exs
@@ -21,7 +21,7 @@ defmodule Lotus.Integration.Postgres.WindowPaginationTest do
     :ok
   end
 
-  describe "run_sql/3 with window pagination (postgres)" do
+  describe "run_statement/3 with window pagination (postgres)" do
     test "pages results without total count" do
       sql = """
       SELECT name FROM test_users
@@ -30,7 +30,7 @@ defmodule Lotus.Integration.Postgres.WindowPaginationTest do
       """
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [],
+               Lotus.run_statement(sql, [],
                  repo: "postgres",
                  window: [limit: 1, offset: 0, count: :none]
                )
@@ -50,7 +50,7 @@ defmodule Lotus.Integration.Postgres.WindowPaginationTest do
       """
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [],
+               Lotus.run_statement(sql, [],
                  repo: "postgres",
                  window: [limit: 2, offset: 1, count: :exact]
                )

--- a/test/integration/sqlite/window_pagination_test.exs
+++ b/test/integration/sqlite/window_pagination_test.exs
@@ -21,7 +21,7 @@ defmodule Lotus.Integration.Sqlite.WindowPaginationTest do
     :ok
   end
 
-  describe "run_sql/3 with window pagination (sqlite)" do
+  describe "run_statement/3 with window pagination (sqlite)" do
     test "pages results without total count" do
       sql = """
       SELECT name FROM test_users
@@ -30,7 +30,10 @@ defmodule Lotus.Integration.Sqlite.WindowPaginationTest do
       """
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [], repo: "sqlite", window: [limit: 1, offset: 0, count: :none])
+               Lotus.run_statement(sql, [],
+                 repo: "sqlite",
+                 window: [limit: 1, offset: 0, count: :none]
+               )
 
       assert result.num_rows == 1
       assert result.rows == [["Window A"]]
@@ -47,7 +50,7 @@ defmodule Lotus.Integration.Sqlite.WindowPaginationTest do
       """
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [],
+               Lotus.run_statement(sql, [],
                  repo: "sqlite",
                  window: [limit: 2, offset: 1, count: :exact]
                )

--- a/test/lotus/ai/actions/execute_sql_test.exs
+++ b/test/lotus/ai/actions/execute_sql_test.exs
@@ -11,7 +11,7 @@ defmodule Lotus.AI.Actions.ExecuteSQLTest do
 
   describe "run/2" do
     test "executes SQL and returns result with metadata" do
-      stub(Lotus, :run_sql, fn _sql, _params, _opts ->
+      stub(Lotus, :run_statement, fn _sql, _params, _opts ->
         {:ok,
          Result.new(["region", "revenue"], [["US", 50_000], ["EU", 30_000]],
            num_rows: 2,
@@ -41,7 +41,7 @@ defmodule Lotus.AI.Actions.ExecuteSQLTest do
     test "truncates large result sets for LLM context" do
       rows = for i <- 1..100, do: [i, "row_#{i}"]
 
-      stub(Lotus, :run_sql, fn _sql, _params, _opts ->
+      stub(Lotus, :run_statement, fn _sql, _params, _opts ->
         {:ok, Result.new(["id", "name"], rows, num_rows: 100)}
       end)
 
@@ -57,7 +57,7 @@ defmodule Lotus.AI.Actions.ExecuteSQLTest do
     end
 
     test "captures query errors without failing the action" do
-      stub(Lotus, :run_sql, fn _sql, _params, _opts ->
+      stub(Lotus, :run_statement, fn _sql, _params, _opts ->
         {:error, "relation \"missing_table\" does not exist"}
       end)
 
@@ -77,7 +77,7 @@ defmodule Lotus.AI.Actions.ExecuteSQLTest do
     end
 
     test "enforces read-only execution" do
-      expect(Lotus, :run_sql, fn _sql, _params, opts ->
+      expect(Lotus, :run_statement, fn _sql, _params, opts ->
         assert opts[:read_only] == true
         {:ok, Result.new(["count"], [[42]], num_rows: 1)}
       end)
@@ -90,7 +90,7 @@ defmodule Lotus.AI.Actions.ExecuteSQLTest do
     end
 
     test "includes timing information" do
-      stub(Lotus, :run_sql, fn _sql, _params, _opts ->
+      stub(Lotus, :run_statement, fn _sql, _params, _opts ->
         {:ok, Result.new(["x"], [[1]], num_rows: 1)}
       end)
 

--- a/test/lotus/ai/actions/get_column_values_test.exs
+++ b/test/lotus/ai/actions/get_column_values_test.exs
@@ -10,7 +10,7 @@ defmodule Lotus.AI.Actions.GetColumnValuesTest do
 
   describe "run/2" do
     test "returns distinct values for a column" do
-      stub(Lotus, :run_sql, fn _query, _params, _opts ->
+      stub(Lotus, :run_statement, fn _query, _params, _opts ->
         {:ok, %{rows: [["active"], ["inactive"], ["pending"]]}}
       end)
 
@@ -27,7 +27,7 @@ defmodule Lotus.AI.Actions.GetColumnValuesTest do
     end
 
     test "returns empty values when column has no non-null values" do
-      stub(Lotus, :run_sql, fn _query, _params, _opts ->
+      stub(Lotus, :run_statement, fn _query, _params, _opts ->
         {:ok, %{rows: []}}
       end)
 
@@ -42,7 +42,7 @@ defmodule Lotus.AI.Actions.GetColumnValuesTest do
     end
 
     test "handles schema-qualified table names in SQL" do
-      expect(Lotus, :run_sql, fn query, _params, _opts ->
+      expect(Lotus, :run_statement, fn query, _params, _opts ->
         assert query =~ ~s("reporting"."invoices")
         {:ok, %{rows: [["open"], ["paid"]]}}
       end)
@@ -89,7 +89,7 @@ defmodule Lotus.AI.Actions.GetColumnValuesTest do
     end
 
     test "returns error when query fails" do
-      stub(Lotus, :run_sql, fn _query, _params, _opts ->
+      stub(Lotus, :run_statement, fn _query, _params, _opts ->
         {:error, "Permission denied"}
       end)
 

--- a/test/lotus/data_source_test.exs
+++ b/test/lotus/data_source_test.exs
@@ -31,34 +31,34 @@ defmodule Lotus.DataSourceTest do
 
   describe "query execution against different repos" do
     test "executes SQL against postgres repo by name" do
-      {:ok, result} = Lotus.run_sql("SELECT 1 as test_value", [], repo: "postgres")
+      {:ok, result} = Lotus.run_statement("SELECT 1 as test_value", [], repo: "postgres")
       assert result.columns == ["test_value"]
       assert result.rows == [[1]]
     end
 
     @tag :sqlite
     test "executes SQL against sqlite repo by name" do
-      {:ok, result} = Lotus.run_sql("SELECT 1 as test_value", [], repo: "sqlite")
+      {:ok, result} = Lotus.run_statement("SELECT 1 as test_value", [], repo: "sqlite")
       assert result.columns == ["test_value"]
       assert result.rows == [[1]]
     end
 
     @tag :mysql
     test "executes SQL against mysql repo by name" do
-      {:ok, result} = Lotus.run_sql("SELECT 1 as test_value", [], repo: "mysql")
+      {:ok, result} = Lotus.run_statement("SELECT 1 as test_value", [], repo: "mysql")
       assert result.columns == ["test_value"]
       assert result.rows == [[1]]
     end
 
     test "executes SQL against repo module directly" do
-      {:ok, result} = Lotus.run_sql("SELECT 2 as test_value", [], repo: Lotus.Test.Repo)
+      {:ok, result} = Lotus.run_statement("SELECT 2 as test_value", [], repo: Lotus.Test.Repo)
       assert result.columns == ["test_value"]
       assert result.rows == [[2]]
     end
 
     test "defaults to first configured data source when no repo specified" do
       # Should use "postgres" since it's first in alphabetical order
-      {:ok, result} = Lotus.run_sql("SELECT 3 as test_value")
+      {:ok, result} = Lotus.run_statement("SELECT 3 as test_value")
       assert result.columns == ["test_value"]
       assert result.rows == [[3]]
     end

--- a/test/lotus/middleware_test.exs
+++ b/test/lotus/middleware_test.exs
@@ -220,7 +220,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{PassthroughPlug, []}]
       })
 
-      assert {:ok, %Result{}} = Runner.run_sql(@pg_adapter, "SELECT 1")
+      assert {:ok, %Result{}} = Runner.run_statement(@pg_adapter, "SELECT 1")
     end
 
     test "halting middleware prevents query execution" do
@@ -228,7 +228,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{HaltPlug, [reason: "not allowed"]}]
       })
 
-      assert {:error, "not allowed"} = Runner.run_sql(@pg_adapter, "SELECT 1")
+      assert {:error, "not allowed"} = Runner.run_statement(@pg_adapter, "SELECT 1")
     end
 
     test "context is passed to before_query middleware" do
@@ -236,7 +236,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{ContextCapturePlug, []}]
       })
 
-      Runner.run_sql(@pg_adapter, "SELECT 1", [], context: %{user: "alice@example.com"})
+      Runner.run_statement(@pg_adapter, "SELECT 1", [], context: %{user: "alice@example.com"})
 
       assert_received {:middleware_context, %{user: "alice@example.com"}}
     end
@@ -246,7 +246,7 @@ defmodule Lotus.MiddlewareTest do
         before_query: [{ContextCapturePlug, []}]
       })
 
-      Runner.run_sql(@pg_adapter, "SELECT 1")
+      Runner.run_statement(@pg_adapter, "SELECT 1")
 
       assert_received {:middleware_context, nil}
     end
@@ -257,7 +257,7 @@ defmodule Lotus.MiddlewareTest do
         after_query: [{CountingPlug, []}]
       })
 
-      assert {:error, "denied"} = Runner.run_sql(@pg_adapter, "SELECT 1")
+      assert {:error, "denied"} = Runner.run_statement(@pg_adapter, "SELECT 1")
 
       refute_received :middleware_ran
     end
@@ -269,7 +269,7 @@ defmodule Lotus.MiddlewareTest do
         after_query: [{PassthroughPlug, []}]
       })
 
-      assert {:ok, %Result{rows: [[1]]}} = Runner.run_sql(@pg_adapter, "SELECT 1")
+      assert {:ok, %Result{rows: [[1]]}} = Runner.run_statement(@pg_adapter, "SELECT 1")
     end
 
     test "halting middleware in after_query returns error" do
@@ -277,7 +277,7 @@ defmodule Lotus.MiddlewareTest do
         after_query: [{HaltPlug, [reason: "post-query denied"]}]
       })
 
-      assert {:error, "post-query denied"} = Runner.run_sql(@pg_adapter, "SELECT 1")
+      assert {:error, "post-query denied"} = Runner.run_statement(@pg_adapter, "SELECT 1")
     end
 
     test "context flows to after_query middleware" do
@@ -285,7 +285,7 @@ defmodule Lotus.MiddlewareTest do
         after_query: [{ContextCapturePlug, []}]
       })
 
-      Runner.run_sql(@pg_adapter, "SELECT 1", [], context: %{role: :admin})
+      Runner.run_statement(@pg_adapter, "SELECT 1", [], context: %{role: :admin})
 
       assert_received {:middleware_context, %{role: :admin}}
     end
@@ -363,12 +363,12 @@ defmodule Lotus.MiddlewareTest do
       assert_received {:middleware_context, %{user: "bob@example.com"}}
     end
 
-    test "run_sql passes context through" do
+    test "run_statement passes context through" do
       Middleware.compile(%{
         before_query: [{ContextCapturePlug, []}]
       })
 
-      Lotus.run_sql("SELECT 1", [], context: %{user: "carol@example.com"})
+      Lotus.run_statement("SELECT 1", [], context: %{user: "carol@example.com"})
 
       assert_received {:middleware_context, %{user: "carol@example.com"}}
     end
@@ -542,7 +542,7 @@ defmodule Lotus.MiddlewareTest do
       })
 
       assert {:error, %RuntimeError{message: "boom"}} =
-               Runner.run_sql(@pg_adapter, "SELECT 1")
+               Runner.run_statement(@pg_adapter, "SELECT 1")
     end
 
     test "exception stops subsequent middleware from running" do
@@ -554,7 +554,7 @@ defmodule Lotus.MiddlewareTest do
       })
 
       assert {:error, %RuntimeError{message: "crash"}} =
-               Runner.run_sql(@pg_adapter, "SELECT 1")
+               Runner.run_statement(@pg_adapter, "SELECT 1")
 
       refute_received {:middleware_context, _}
     end
@@ -565,7 +565,7 @@ defmodule Lotus.MiddlewareTest do
       })
 
       assert {:error, %RuntimeError{message: "post-query crash"}} =
-               Runner.run_sql(@pg_adapter, "SELECT 1")
+               Runner.run_statement(@pg_adapter, "SELECT 1")
     end
   end
 
@@ -621,12 +621,12 @@ defmodule Lotus.MiddlewareTest do
   describe "backward compatibility" do
     test "no middleware configured has zero overhead" do
       # No compile call - persistent_term is empty
-      assert {:ok, %Result{}} = Runner.run_sql(@pg_adapter, "SELECT 1")
+      assert {:ok, %Result{}} = Runner.run_statement(@pg_adapter, "SELECT 1")
     end
 
     test "empty middleware map works" do
       Middleware.compile(%{})
-      assert {:ok, %Result{}} = Runner.run_sql(@pg_adapter, "SELECT 1")
+      assert {:ok, %Result{}} = Runner.run_statement(@pg_adapter, "SELECT 1")
     end
 
     test "existing callers without context work unchanged" do
@@ -635,7 +635,7 @@ defmodule Lotus.MiddlewareTest do
       })
 
       # No context option passed
-      assert {:ok, %Result{}} = Lotus.run_sql("SELECT 1")
+      assert {:ok, %Result{}} = Lotus.run_statement("SELECT 1")
       assert {:ok, tables} = Lotus.list_tables("postgres")
       refute tables == []
     end

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -15,10 +15,10 @@ defmodule Lotus.RunnerTest do
     {:ok, fixtures}
   end
 
-  describe "run_sql/4 with real tables" do
+  describe "run_statement/4 with real tables" do
     test "executes simple SELECT queries", %{users: %{kerouac: kerouac}} do
       result =
-        Runner.run_sql(@pg_adapter, "SELECT name, email FROM test_users WHERE id = $1", [
+        Runner.run_statement(@pg_adapter, "SELECT name, email FROM test_users WHERE id = $1", [
           kerouac.id
         ])
 
@@ -30,7 +30,7 @@ defmodule Lotus.RunnerTest do
       users: %{kerouac: kerouac, thompson: thompson}
     } do
       sql = "SELECT name, age FROM test_users WHERE id IN ($1, $2) ORDER BY name"
-      result = Runner.run_sql(@pg_adapter, sql, [kerouac.id, thompson.id])
+      result = Runner.run_statement(@pg_adapter, sql, [kerouac.id, thompson.id])
 
       assert {:ok,
               %{
@@ -49,7 +49,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY p.view_count DESC
       """
 
-      result = Runner.run_sql(@pg_adapter, sql, [kerouac.id])
+      result = Runner.run_statement(@pg_adapter, sql, [kerouac.id])
 
       assert {:ok,
               %{
@@ -71,7 +71,7 @@ defmodule Lotus.RunnerTest do
       WHERE published = true
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -92,7 +92,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY u.name
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -107,7 +107,7 @@ defmodule Lotus.RunnerTest do
 
     test "handles JSON operations", %{users: %{kerouac: kerouac}} do
       sql = "SELECT name, metadata->>'role' as role FROM test_users WHERE id = $1"
-      result = Runner.run_sql(@pg_adapter, sql, [kerouac.id])
+      result = Runner.run_statement(@pg_adapter, sql, [kerouac.id])
       assert {:ok, %{columns: ["name", "role"], rows: [["Jack Kerouac", "admin"]]}} = result
     end
 
@@ -115,7 +115,7 @@ defmodule Lotus.RunnerTest do
       sql =
         "SELECT title, array_length(tags, 1) as tag_count FROM test_posts WHERE 'beat' = ANY(tags)"
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:ok, %{columns: ["title", "tag_count"], rows: rows}} = result
       assert length(rows) == 2
     end
@@ -134,7 +134,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM user_posts ORDER BY name
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -152,7 +152,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "email"], rows: rows}} = result
       assert length(rows) == 2
@@ -173,7 +173,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "age_group"], rows: rows}} = result
       assert ["Charles Bukowski", "Senior"] in rows
@@ -184,7 +184,7 @@ defmodule Lotus.RunnerTest do
 
   describe "whitelist validation" do
     test "allows SELECT queries" do
-      result = Runner.run_sql(@pg_adapter, "SELECT * FROM test_users LIMIT 1")
+      result = Runner.run_statement(@pg_adapter, "SELECT * FROM test_users LIMIT 1")
       assert {:ok, %{columns: columns, rows: _}} = result
       assert "id" in columns
     end
@@ -195,24 +195,24 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM test
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:ok, %{columns: ["num"], rows: [[1]]}} = result
     end
 
     test "allows VALUES queries" do
-      result = Runner.run_sql(@pg_adapter, "VALUES (1, 'a'), (2, 'b')")
+      result = Runner.run_statement(@pg_adapter, "VALUES (1, 'a'), (2, 'b')")
       assert {:ok, %{columns: ["column1", "column2"], rows: [[1, "a"], [2, "b"]]}} = result
     end
 
     test "allows EXPLAIN queries" do
-      result = Runner.run_sql(@pg_adapter, "EXPLAIN SELECT * FROM test_users")
+      result = Runner.run_statement(@pg_adapter, "EXPLAIN SELECT * FROM test_users")
       assert {:ok, %{columns: ["QUERY PLAN"], rows: rows}} = result
       refute Enum.empty?(rows)
     end
 
     test "rejects INSERT statements" do
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "INSERT INTO test_users (name, email) VALUES ('test', 'test@example.com')"
         )
@@ -221,89 +221,91 @@ defmodule Lotus.RunnerTest do
     end
 
     test "rejects UPDATE statements" do
-      result = Runner.run_sql(@pg_adapter, "UPDATE test_users SET name = 'Updated'")
+      result = Runner.run_statement(@pg_adapter, "UPDATE test_users SET name = 'Updated'")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects DELETE statements" do
-      result = Runner.run_sql(@pg_adapter, "DELETE FROM test_users WHERE id = 1")
+      result = Runner.run_statement(@pg_adapter, "DELETE FROM test_users WHERE id = 1")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects DROP statements" do
-      result = Runner.run_sql(@pg_adapter, "DROP TABLE test_users")
+      result = Runner.run_statement(@pg_adapter, "DROP TABLE test_users")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects CREATE statements" do
-      result = Runner.run_sql(@pg_adapter, "CREATE TABLE new_table (id int)")
+      result = Runner.run_statement(@pg_adapter, "CREATE TABLE new_table (id int)")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects ALTER statements" do
-      result = Runner.run_sql(@pg_adapter, "ALTER TABLE test_users ADD COLUMN new_field text")
+      result =
+        Runner.run_statement(@pg_adapter, "ALTER TABLE test_users ADD COLUMN new_field text")
+
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "rejects TRUNCATE statements" do
-      result = Runner.run_sql(@pg_adapter, "TRUNCATE test_users")
+      result = Runner.run_statement(@pg_adapter, "TRUNCATE test_users")
       assert {:error, "Only read-only queries are allowed"} = result
     end
   end
 
   describe "deny list validation" do
     test "detects dangerous keywords in string literals" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 'DROP TABLE users' as msg")
+      result = Runner.run_statement(@pg_adapter, "SELECT 'DROP TABLE users' as msg")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "detects dangerous keywords case-insensitively" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 'InSeRt INTO users' as msg")
+      result = Runner.run_statement(@pg_adapter, "SELECT 'InSeRt INTO users' as msg")
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
     test "allows safe strings without dangerous keywords" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 'This is a safe message' as msg")
+      result = Runner.run_statement(@pg_adapter, "SELECT 'This is a safe message' as msg")
       assert {:ok, %{columns: ["msg"], rows: [["This is a safe message"]]}} = result
     end
   end
 
   describe "single statement validation" do
     test "rejects multiple statements with semicolon" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 1; SELECT 2")
+      result = Runner.run_statement(@pg_adapter, "SELECT 1; SELECT 2")
       assert {:error, "Only a single statement is allowed"} = result
     end
 
     test "allows statement with trailing semicolon" do
-      result = Runner.run_sql(@pg_adapter, "SELECT * FROM test_users;")
+      result = Runner.run_statement(@pg_adapter, "SELECT * FROM test_users;")
       assert {:ok, %{columns: columns, rows: rows}} = result
       refute Enum.empty?(columns)
       refute Enum.empty?(rows)
     end
 
     test "allows semicolon in string literals" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 'test;value' as text")
+      result = Runner.run_statement(@pg_adapter, "SELECT 'test;value' as text")
       assert {:ok, %{columns: ["text"], rows: [["test;value"]]}} = result
     end
 
     test "allows semicolon in double-quoted identifiers" do
-      result = Runner.run_sql(@pg_adapter, ~s[SELECT 'test' as "col;name"])
+      result = Runner.run_statement(@pg_adapter, ~s[SELECT 'test' as "col;name"])
       assert {:ok, %{columns: ["col;name"], rows: [["test"]]}} = result
     end
 
     test "allows semicolon in line comments" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 1 as num -- comment with ; semicolon")
+      result = Runner.run_statement(@pg_adapter, "SELECT 1 as num -- comment with ; semicolon")
       assert {:ok, %{columns: ["num"], rows: [[1]]}} = result
     end
 
     test "allows semicolon in block comments" do
-      result = Runner.run_sql(@pg_adapter, "SELECT /* comment ; with semicolon */ 1 as num")
+      result = Runner.run_statement(@pg_adapter, "SELECT /* comment ; with semicolon */ 1 as num")
       assert {:ok, %{columns: ["num"], rows: [[1]]}} = result
     end
 
     test "allows semicolon in nested block comments" do
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "SELECT /* outer /* inner ; */ still outer ; */ 1 as num"
         )
@@ -316,7 +318,7 @@ defmodule Lotus.RunnerTest do
       # comment tracking the parser would exit at the first `*/` and miss the
       # trailing `; SELECT 2` that sits outside the comment.
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "SELECT 1 /* /* nested */ */ ; SELECT 2"
         )
@@ -325,17 +327,17 @@ defmodule Lotus.RunnerTest do
     end
 
     test "allows semicolon in PostgreSQL dollar-quoted strings" do
-      result = Runner.run_sql(@pg_adapter, "SELECT $$test;value$$ as text")
+      result = Runner.run_statement(@pg_adapter, "SELECT $$test;value$$ as text")
       assert {:ok, %{columns: ["text"], rows: [["test;value"]]}} = result
     end
 
     test "allows semicolon in tagged dollar-quoted strings" do
-      result = Runner.run_sql(@pg_adapter, "SELECT $tag$test;value$tag$ as text")
+      result = Runner.run_statement(@pg_adapter, "SELECT $tag$test;value$tag$ as text")
       assert {:ok, %{columns: ["text"], rows: [["test;value"]]}} = result
     end
 
     test "still rejects actual multiple statements" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 'test;ok' as text; SELECT 2")
+      result = Runner.run_statement(@pg_adapter, "SELECT 'test;ok' as text; SELECT 2")
       assert {:error, "Only a single statement is allowed"} = result
     end
 
@@ -349,7 +351,7 @@ defmodule Lotus.RunnerTest do
       WHERE name = 'Jack Kerouac';
       """
 
-      result = Runner.run_sql(@pg_adapter, query)
+      result = Runner.run_statement(@pg_adapter, query)
       assert {:ok, %{columns: columns, rows: rows}} = result
       assert "col;name" in columns
       refute Enum.empty?(rows)
@@ -363,24 +365,26 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM test
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:ok, %{columns: ["id"], rows: [[1]]}} = result
     end
 
     test "respects read_only: false option" do
       result =
-        Runner.run_sql(@pg_adapter, "SELECT COUNT(*) FROM test_users", [], read_only: false)
+        Runner.run_statement(@pg_adapter, "SELECT COUNT(*) FROM test_users", [], read_only: false)
 
       assert {:ok, %{columns: ["count"], rows: [[3]]}} = result
     end
 
     test "respects custom statement timeout" do
-      result = Runner.run_sql(@pg_adapter, "SELECT 1", [], statement_timeout_ms: 100)
+      result = Runner.run_statement(@pg_adapter, "SELECT 1", [], statement_timeout_ms: 100)
       assert {:ok, %{columns: ["?column?"], rows: [[1]]}} = result
     end
 
     test "respects custom database timeout" do
-      result = Runner.run_sql(@pg_adapter, "SELECT COUNT(*) FROM test_users", [], timeout: 1000)
+      result =
+        Runner.run_statement(@pg_adapter, "SELECT COUNT(*) FROM test_users", [], timeout: 1000)
+
       assert {:ok, %{columns: ["count"], rows: [[3]]}} = result
     end
   end
@@ -390,7 +394,7 @@ defmodule Lotus.RunnerTest do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
 
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "INSERT INTO test_users (name, email, age, active, metadata, inserted_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, name, email",
           ["Ada Lovelace", "ada@math.org", 36, true, %{}, now, now],
@@ -404,7 +408,7 @@ defmodule Lotus.RunnerTest do
 
     test "UPDATE succeeds with read_only: false and returns affected rows" do
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "UPDATE test_users SET age = age + 1 WHERE active = true RETURNING id, name, age",
           [],
@@ -417,7 +421,7 @@ defmodule Lotus.RunnerTest do
 
     test "DELETE succeeds with read_only: false and returns affected rows" do
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "DELETE FROM test_users WHERE active = false RETURNING id",
           [],
@@ -430,7 +434,7 @@ defmodule Lotus.RunnerTest do
 
     test "INSERT is still rejected with default opts (no regression)" do
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "INSERT INTO test_users (name, email) VALUES ('test', 'test@example.com')"
         )
@@ -440,7 +444,7 @@ defmodule Lotus.RunnerTest do
 
     test "single-statement validation still enforced with read_only: false" do
       result =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "INSERT INTO test_users (name, email) VALUES ('a', 'a@a.com'); DELETE FROM test_users",
           [],
@@ -453,14 +457,14 @@ defmodule Lotus.RunnerTest do
 
   describe "error handling" do
     test "handles syntax errors gracefully" do
-      result = Runner.run_sql(@pg_adapter, "SELECT * FROM")
+      result = Runner.run_statement(@pg_adapter, "SELECT * FROM")
       assert {:error, msg} = result
       assert msg =~ "SQL syntax error:"
       assert msg =~ "syntax error at end of input" or msg =~ "syntax error at or near"
     end
 
     test "handles invalid table references" do
-      result = Runner.run_sql(@pg_adapter, "SELECT * FROM non_existent_table")
+      result = Runner.run_statement(@pg_adapter, "SELECT * FROM non_existent_table")
       assert {:error, msg} = result
       assert msg =~ "SQL error:"
       assert msg =~ "non_existent_table"
@@ -468,9 +472,13 @@ defmodule Lotus.RunnerTest do
 
     test "handles invalid column references", %{users: %{kerouac: kerouac}} do
       result =
-        Runner.run_sql(@pg_adapter, "SELECT non_existent_column FROM test_users WHERE id = $1", [
-          kerouac.id
-        ])
+        Runner.run_statement(
+          @pg_adapter,
+          "SELECT non_existent_column FROM test_users WHERE id = $1",
+          [
+            kerouac.id
+          ]
+        )
 
       assert {:error, msg} = result
       assert msg =~ "SQL error:"
@@ -479,7 +487,9 @@ defmodule Lotus.RunnerTest do
 
     test "handles type mismatches" do
       result =
-        Runner.run_sql(@pg_adapter, "SELECT * FROM test_users WHERE id = $1", ["not_an_integer"])
+        Runner.run_statement(@pg_adapter, "SELECT * FROM test_users WHERE id = $1", [
+          "not_an_integer"
+        ])
 
       assert {:error, message} = result
       assert is_binary(message)
@@ -487,7 +497,7 @@ defmodule Lotus.RunnerTest do
     end
 
     test "handles empty result sets" do
-      result = Runner.run_sql(@pg_adapter, "SELECT * FROM test_users WHERE id = -999")
+      result = Runner.run_statement(@pg_adapter, "SELECT * FROM test_users WHERE id = -999")
       assert {:ok, %{columns: columns, rows: []}} = result
       assert "id" in columns
     end
@@ -496,20 +506,22 @@ defmodule Lotus.RunnerTest do
       user = Fixtures.insert_user(%{name: "Null Test", email: "null@test.com", age: nil})
 
       result =
-        Runner.run_sql(@pg_adapter, "SELECT name, age FROM test_users WHERE id = $1", [user.id])
+        Runner.run_statement(@pg_adapter, "SELECT name, age FROM test_users WHERE id = $1", [
+          user.id
+        ])
 
       assert {:ok, %{columns: ["name", "age"], rows: [["Null Test", nil]]}} = result
     end
 
     test "validates SQL string type" do
       assert_raise FunctionClauseError, fn ->
-        Runner.run_sql(@pg_adapter, 123, [])
+        Runner.run_statement(@pg_adapter, 123, [])
       end
     end
 
     test "validates params list type" do
       assert_raise FunctionClauseError, fn ->
-        Runner.run_sql(@pg_adapter, "SELECT 1", "not_a_list")
+        Runner.run_statement(@pg_adapter, "SELECT 1", "not_a_list")
       end
     end
   end
@@ -526,7 +538,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY rank
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["title", "view_count", "rank"], rows: rows}} = result
       assert length(rows) == 3
@@ -541,7 +553,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "type"], rows: rows}} = result
       assert length(rows) > 3
@@ -557,7 +569,7 @@ defmodule Lotus.RunnerTest do
       LIMIT 1
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name", "created_date", "year"], rows: [[_, _, year]]}} = result
       assert is_integer(year)
@@ -575,7 +587,7 @@ defmodule Lotus.RunnerTest do
       LIMIT 1
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok,
               %{
@@ -598,7 +610,7 @@ defmodule Lotus.RunnerTest do
       ORDER BY name
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name"], rows: rows}} = result
       assert ["Jack Kerouac"] in rows
@@ -611,7 +623,7 @@ defmodule Lotus.RunnerTest do
       SELECT DISTINCT active FROM test_users ORDER BY active
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["active"], rows: [[false], [true]]}} = result
     end
@@ -623,7 +635,7 @@ defmodule Lotus.RunnerTest do
       LIMIT 2 OFFSET 1
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok, %{columns: ["name"], rows: rows}} = result
       assert length(rows) == 2
@@ -669,7 +681,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_rows
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -683,7 +695,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM inserted_users
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -697,7 +709,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM updated_users
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -714,7 +726,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_inactive
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -729,7 +741,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM temp_data
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -741,7 +753,7 @@ defmodule Lotus.RunnerTest do
       SELECT 1
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -754,7 +766,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM truncated
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -769,7 +781,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM user_count
       """
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
       assert {:ok, %{columns: ["total"], rows: _}} = result
     end
   end
@@ -785,7 +797,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_rows
       """
 
-      result = Runner.run_sql(@sqlite_adapter, sql)
+      result = Runner.run_statement(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -800,7 +812,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM inserted_users
       """
 
-      result = Runner.run_sql(@sqlite_adapter, sql)
+      result = Runner.run_statement(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -815,7 +827,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM updated_users
       """
 
-      result = Runner.run_sql(@sqlite_adapter, sql)
+      result = Runner.run_statement(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -833,7 +845,7 @@ defmodule Lotus.RunnerTest do
       SELECT COUNT(*) FROM deleted_inactive
       """
 
-      result = Runner.run_sql(@sqlite_adapter, sql)
+      result = Runner.run_statement(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -849,7 +861,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM temp_data
       """
 
-      result = Runner.run_sql(@sqlite_adapter, sql)
+      result = Runner.run_statement(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -862,7 +874,7 @@ defmodule Lotus.RunnerTest do
       SELECT 1
       """
 
-      result = Runner.run_sql(@sqlite_adapter, sql)
+      result = Runner.run_statement(@sqlite_adapter, sql)
       assert {:error, "Only read-only queries are allowed"} = result
     end
 
@@ -878,7 +890,7 @@ defmodule Lotus.RunnerTest do
       SELECT * FROM user_count
       """
 
-      result = Runner.run_sql(@sqlite_adapter, sql)
+      result = Runner.run_statement(@sqlite_adapter, sql)
       assert {:ok, %{columns: ["total"], rows: _}} = result
     end
   end
@@ -916,7 +928,7 @@ defmodule Lotus.RunnerTest do
       sql =
         "SELECT id, name, email, age, active, metadata, inserted_at, updated_at FROM test_users"
 
-      result = Runner.run_sql(@pg_adapter, sql)
+      result = Runner.run_statement(@pg_adapter, sql)
 
       assert {:ok,
               %Lotus.Result{
@@ -972,9 +984,13 @@ defmodule Lotus.RunnerTest do
 
     test "returns raw UUID binaries in result rows", %{uuid1: uuid1} do
       {:ok, result} =
-        Runner.run_sql(@pg_adapter, "SELECT id, name FROM test_uuid_records WHERE name = $1", [
-          "Record A"
-        ])
+        Runner.run_statement(
+          @pg_adapter,
+          "SELECT id, name FROM test_uuid_records WHERE name = $1",
+          [
+            "Record A"
+          ]
+        )
 
       assert %{columns: ["id", "name"], rows: [[id_bin, "Record A"]]} = result
       # Postgrex returns UUIDs as raw 16-byte binaries
@@ -988,7 +1004,7 @@ defmodule Lotus.RunnerTest do
       uuid2: uuid2
     } do
       {:ok, result} =
-        Runner.run_sql(
+        Runner.run_statement(
           @pg_adapter,
           "SELECT id, name, ref_id FROM test_uuid_records ORDER BY name"
         )

--- a/test/lotus/search_path_test.exs
+++ b/test/lotus/search_path_test.exs
@@ -26,7 +26,7 @@ defmodule Lotus.SearchPathTest do
       sql = "SELECT COUNT(*) FROM customers"
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [], repo: "postgres", search_path: "reporting, public")
+               Lotus.run_statement(sql, [], repo: "postgres", search_path: "reporting, public")
 
       assert %Lotus.Result{columns: ["count"], rows: [[0]]} = result
     end
@@ -46,7 +46,7 @@ defmodule Lotus.SearchPathTest do
     test "query fails without search_path when table is in non-default schema" do
       sql = "SELECT COUNT(*) FROM customers"
 
-      assert {:error, error} = Lotus.run_sql(sql, [], repo: "postgres")
+      assert {:error, error} = Lotus.run_statement(sql, [], repo: "postgres")
       assert error =~ "relation \"customers\" does not exist"
     end
 
@@ -54,7 +54,7 @@ defmodule Lotus.SearchPathTest do
       sql = "SELECT * FROM customers WHERE email = $1"
 
       assert {:ok, _result} =
-               Lotus.run_sql(sql, ["test@example.com"],
+               Lotus.run_statement(sql, ["test@example.com"],
                  repo: "postgres",
                  search_path: "reporting, public"
                )
@@ -67,7 +67,7 @@ defmodule Lotus.SearchPathTest do
       sql = "SELECT COUNT(*) FROM products"
 
       assert {:ok, result} =
-               Lotus.run_sql(sql, [], repo: "sqlite", search_path: "ignored_schema")
+               Lotus.run_statement(sql, [], repo: "sqlite", search_path: "ignored_schema")
 
       assert %Lotus.Result{columns: ["COUNT(*)"], rows: [[0]]} = result
     end

--- a/test/lotus/telemetry_test.exs
+++ b/test/lotus/telemetry_test.exs
@@ -27,7 +27,7 @@ defmodule Lotus.TelemetryTest do
         nil
       )
 
-      {:ok, _result} = Runner.run_sql(@pg_adapter, "SELECT 1 AS num")
+      {:ok, _result} = Runner.run_statement(@pg_adapter, "SELECT 1 AS num")
 
       assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
                        %{repo: "postgres", sql: "SELECT 1 AS num"}}
@@ -56,7 +56,7 @@ defmodule Lotus.TelemetryTest do
         nil
       )
 
-      {:ok, _result} = Runner.run_sql(@pg_adapter, "SELECT 1 AS num", [], context: ctx)
+      {:ok, _result} = Runner.run_statement(@pg_adapter, "SELECT 1 AS num", [], context: ctx)
 
       assert_received {:telemetry, [:lotus, :query, :start], _,
                        %{repo: "postgres", context: ^ctx}}
@@ -79,7 +79,7 @@ defmodule Lotus.TelemetryTest do
         nil
       )
 
-      {:ok, _result} = Runner.run_sql(@pg_adapter, "SELECT 1 AS num")
+      {:ok, _result} = Runner.run_statement(@pg_adapter, "SELECT 1 AS num")
 
       assert_received {:telemetry, [:lotus, :query, :start], _, %{context: nil}}
       assert_received {:telemetry, [:lotus, :query, :stop], _, %{context: nil}}
@@ -101,7 +101,7 @@ defmodule Lotus.TelemetryTest do
         nil
       )
 
-      {:error, _} = Runner.run_sql(@pg_adapter, "DROP TABLE test_users", [], context: ctx)
+      {:error, _} = Runner.run_statement(@pg_adapter, "DROP TABLE test_users", [], context: ctx)
 
       assert_received {:telemetry, [:lotus, :query, :exception], _,
                        %{kind: :error, context: ^ctx}}
@@ -122,7 +122,7 @@ defmodule Lotus.TelemetryTest do
         nil
       )
 
-      {:error, _} = Runner.run_sql(@pg_adapter, "DROP TABLE test_users")
+      {:error, _} = Runner.run_statement(@pg_adapter, "DROP TABLE test_users")
 
       assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
                        %{repo: "postgres", sql: "DROP TABLE test_users"}}

--- a/test/lotus_test.exs
+++ b/test/lotus_test.exs
@@ -469,11 +469,11 @@ defmodule LotusTest do
     end
   end
 
-  describe "run_sql/3" do
+  describe "run_statement/3" do
     test "runs SQL directly with no params" do
       sql = "SELECT name FROM test_users WHERE active = true ORDER BY name"
 
-      assert {:ok, result} = Lotus.run_sql(sql)
+      assert {:ok, result} = Lotus.run_statement(sql)
       assert result.num_rows == 2
       assert result.rows == [["Hunter S. Thompson"], ["Jack Kerouac"]]
     end
@@ -482,7 +482,7 @@ defmodule LotusTest do
       sql = "SELECT name, age FROM test_users WHERE age > $1 AND active = $2 ORDER BY name"
       params = [30, true]
 
-      assert {:ok, result} = Lotus.run_sql(sql, params)
+      assert {:ok, result} = Lotus.run_statement(sql, params)
       assert result.num_rows == 2
       assert ["Hunter S. Thompson", 37] in result.rows
       assert ["Jack Kerouac", 47] in result.rows
@@ -493,7 +493,7 @@ defmodule LotusTest do
       params = []
       opts = [timeout: 10_000]
 
-      assert {:ok, result} = Lotus.run_sql(sql, params, opts)
+      assert {:ok, result} = Lotus.run_statement(sql, params, opts)
       assert result.num_rows == 1
       assert result.rows == [[3]]
     end
@@ -501,7 +501,7 @@ defmodule LotusTest do
     test "handles SQL errors" do
       sql = "SELECT * FROM nonexistent_table"
 
-      assert {:error, error} = Lotus.run_sql(sql)
+      assert {:error, error} = Lotus.run_statement(sql)
       assert error =~ "relation \"nonexistent_table\" does not exist"
     end
   end
@@ -717,7 +717,7 @@ defmodule LotusTest do
     test "run_sql applies windowing when window options provided" do
       sql = "SELECT name FROM test_users ORDER BY name"
 
-      assert {:ok, result} = Lotus.run_sql(sql, [], window: [limit: 1])
+      assert {:ok, result} = Lotus.run_statement(sql, [], window: [limit: 1])
       assert result.num_rows == 1
       assert result.rows == [["Charles Bukowski"]]
       assert result.meta.window == %{limit: 1, offset: 0}
@@ -726,7 +726,7 @@ defmodule LotusTest do
     test "run_sql does not apply windowing when no window options provided" do
       sql = "SELECT name FROM test_users ORDER BY name"
 
-      assert {:ok, result} = Lotus.run_sql(sql)
+      assert {:ok, result} = Lotus.run_statement(sql)
       assert result.num_rows == 3
       assert Map.get(result.meta, :window) == nil
     end


### PR DESCRIPTION
Rename Lotus.run_sql/3 → run_statement/3 and Lotus.Runner.run_sql/4 → run_statement/4, including the sql parameter → statement. Add @deprecated delegates for the old names so they keep working until v1.0. Migrate all internal callers and tests to the new names.

Closes https://github.com/elixir-lotus/lotus/issues/211