### PR TITLE
feat(adapter): add query_language, limit_query, and :schema_hierarchy…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
 
 ### Added
 
+- `query_language/0` callback in `Lotus.Source` behaviour and dispatch in `Lotus.Source.Adapter` — returns the query language identifier for a source (e.g. `"sql:postgres"`, `"sql:mysql"`) (#122)
+- `limit_query/2` callback in `Lotus.Source` behaviour and dispatch in `Lotus.Source.Adapter` — wraps a statement with a source-specific limit clause (#122)
+- `:schema_hierarchy` feature flag in `Lotus.Sources.supports_feature?/2` — true for Postgres, false for MySQL/SQLite (#122)
+- `Lotus.Sources.query_language/1` and `Lotus.Sources.limit_query/3` convenience functions accepting adapter structs or source name strings (#122)
 - `:preload` option on `Lotus.Dashboards.list_dashboards/1` and `list_dashboards_by/1` for eager-loading associations (e.g. `:cards`) in a single query. Fixes N+1 patterns in callers that need card counts or card lists alongside the dashboard list (see elixir-lotus/lotus_web#103).
 - Pluggable source adapter abstraction (`Lotus.Source.Adapter`) — behaviour and struct wrapping data sources behind a uniform callback interface with consistent `{:ok, _} | {:error, _}` return types
 - `Lotus.Source.Resolver` behaviour for configurable source resolution

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -145,6 +145,23 @@ defmodule Lotus.Source do
   @callback handled_errors() :: [module()]
 
   @doc """
+  Return the query language identifier for this source.
+
+  Examples:
+    * PostgreSQL → `"sql:postgres"`
+    * MySQL      → `"sql:mysql"`
+    * SQLite     → `"sql:sqlite"`
+  """
+  @callback query_language() :: String.t()
+
+  @doc """
+  Wrap a statement with a limit clause using source-specific syntax.
+
+  Used for preview queries where only a limited result set is needed.
+  """
+  @callback limit_query(statement :: String.t(), limit :: pos_integer()) :: String.t()
+
+  @doc """
   Lists all schemas in the given repository.
 
   Returns a list of schema names. For databases without schema support

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -193,13 +193,6 @@ defmodule Lotus.Source.Adapter do
             ) ::
               {String.t(), list(), map() | nil}
 
-  @optional_callbacks [
-    sanitize_query: 3,
-    transform_query: 4,
-    extract_accessed_resources: 4,
-    apply_window: 4
-  ]
-
   # ---------------------------------------------------------------------------
   # Callbacks — Safety & Visibility
   # ---------------------------------------------------------------------------
@@ -243,6 +236,22 @@ defmodule Lotus.Source.Adapter do
 
   @doc "Whether this adapter supports a given feature."
   @callback supports_feature?(state :: term(), atom()) :: boolean()
+
+  @doc "Return the query language identifier for this source (e.g. `\"sql:postgres\"`)."
+  @callback query_language(state :: term()) :: String.t()
+
+  @doc "Wrap a statement with a limit clause using source-specific syntax."
+  @callback limit_query(state :: term(), statement :: String.t(), limit :: pos_integer()) ::
+              String.t()
+
+  @optional_callbacks [
+    sanitize_query: 3,
+    transform_query: 4,
+    extract_accessed_resources: 4,
+    apply_window: 4,
+    query_language: 1,
+    limit_query: 3
+  ]
 
   # ---------------------------------------------------------------------------
   # Dispatch helpers — stateful (pass adapter.state as first arg)
@@ -418,5 +427,21 @@ defmodule Lotus.Source.Adapter do
   @spec supports_feature?(t(), atom()) :: boolean()
   def supports_feature?(%__MODULE__{module: mod, state: state}, feature) do
     mod.supports_feature?(state, feature)
+  end
+
+  @doc "Return the query language identifier via the adapter."
+  @spec query_language(t()) :: String.t()
+  def query_language(%__MODULE__{module: mod, state: state}) do
+    if function_exported?(mod, :query_language, 1),
+      do: mod.query_language(state),
+      else: "sql"
+  end
+
+  @doc "Wrap a statement with a limit clause via the adapter."
+  @spec limit_query(t(), String.t(), pos_integer()) :: String.t()
+  def limit_query(%__MODULE__{module: mod, state: state}, statement, limit) do
+    if function_exported?(mod, :limit_query, 3),
+      do: mod.limit_query(state, statement, limit),
+      else: "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
   end
 end

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -332,6 +332,12 @@ defmodule Lotus.Source.Adapters.Ecto do
     Lotus.Sources.supports_feature?(source, feature)
   end
 
+  @impl true
+  def query_language(repo), do: impl_for(repo).query_language()
+
+  @impl true
+  def limit_query(repo, statement, limit), do: impl_for(repo).limit_query(statement, limit)
+
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------

--- a/lib/lotus/sources.ex
+++ b/lib/lotus/sources.ex
@@ -89,15 +89,21 @@ defmodule Lotus.Sources do
   Whether a source type supports a specific feature.
   """
   @spec supports_feature?(atom(), atom()) :: boolean()
+  def supports_feature?(:postgres, :schema_hierarchy), do: true
+
   def supports_feature?(:postgres, :search_path), do: true
   def supports_feature?(:postgres, :make_interval), do: true
   def supports_feature?(:postgres, :arrays), do: true
   def supports_feature?(:postgres, :json), do: true
 
+  def supports_feature?(:mysql, :schema_hierarchy), do: false
+
   def supports_feature?(:mysql, :search_path), do: false
   def supports_feature?(:mysql, :make_interval), do: false
   def supports_feature?(:mysql, :arrays), do: false
   def supports_feature?(:mysql, :json), do: true
+
+  def supports_feature?(:sqlite, :schema_hierarchy), do: false
 
   def supports_feature?(:sqlite, :search_path), do: false
   def supports_feature?(:sqlite, :make_interval), do: false
@@ -105,6 +111,27 @@ defmodule Lotus.Sources do
   def supports_feature?(:sqlite, :json), do: true
 
   def supports_feature?(_, _), do: false
+
+  @doc """
+  Return the query language identifier for a source.
+  """
+  @spec query_language(Adapter.t() | String.t()) :: String.t()
+  def query_language(%Adapter{} = adapter), do: Adapter.query_language(adapter)
+
+  def query_language(source_name) when is_binary(source_name) do
+    source_name |> get_source!() |> Adapter.query_language()
+  end
+
+  @doc """
+  Wrap a statement with a limit clause using the source's syntax.
+  """
+  @spec limit_query(Adapter.t() | String.t(), String.t(), pos_integer()) :: String.t()
+  def limit_query(%Adapter{} = adapter, statement, limit),
+    do: Adapter.limit_query(adapter, statement, limit)
+
+  def limit_query(source_name, statement, limit) when is_binary(source_name) do
+    source_name |> get_source!() |> Adapter.limit_query(statement, limit)
+  end
 
   defp resolver, do: Config.source_resolver()
 end

--- a/lib/lotus/sources/default.ex
+++ b/lib/lotus/sources/default.ex
@@ -64,6 +64,14 @@ defmodule Lotus.Sources.Default do
   def handled_errors, do: []
 
   @impl true
+  def query_language, do: "sql"
+
+  @impl true
+  def limit_query(statement, limit) do
+    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  end
+
+  @impl true
   @doc """
   Returns conservative deny rules covering common system tables from various databases.
 

--- a/lib/lotus/sources/mysql.ex
+++ b/lib/lotus/sources/mysql.ex
@@ -171,6 +171,14 @@ defmodule Lotus.Sources.MySQL do
   def handled_errors, do: [MyXQL.Error]
 
   @impl true
+  def query_language, do: "sql:mysql"
+
+  @impl true
+  def limit_query(statement, limit) do
+    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  end
+
+  @impl true
   def builtin_denies(repo) do
     ms = repo.config()[:migration_source] || "schema_migrations"
     database = repo.config()[:database]

--- a/lib/lotus/sources/postgres.ex
+++ b/lib/lotus/sources/postgres.ex
@@ -94,6 +94,14 @@ defmodule Lotus.Sources.Postgres do
   def handled_errors, do: [Postgrex.Error]
 
   @impl true
+  def query_language, do: "sql:postgres"
+
+  @impl true
+  def limit_query(statement, limit) do
+    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  end
+
+  @impl true
   def builtin_denies(repo) do
     ms = repo.config()[:migration_source] || "schema_migrations"
     prefix = repo.config()[:migration_default_prefix] || "public"

--- a/lib/lotus/sources/sqlite.ex
+++ b/lib/lotus/sources/sqlite.ex
@@ -96,6 +96,14 @@ defmodule Lotus.Sources.SQLite3 do
   def handled_errors, do: [Exqlite.Error]
 
   @impl true
+  def query_language, do: "sql:sqlite"
+
+  @impl true
+  def limit_query(statement, limit) do
+    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  end
+
+  @impl true
   def builtin_denies(repo) do
     ms = repo.config()[:migration_source] || "schema_migrations"
 

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -240,5 +240,38 @@ defmodule Lotus.SourcesTest do
       assert Sources.supports_feature?(:sqlite, :unknown_feature) == false
       assert Sources.supports_feature?(:other, :unknown_feature) == false
     end
+
+    test "schema_hierarchy feature" do
+      assert Sources.supports_feature?(:postgres, :schema_hierarchy) == true
+      assert Sources.supports_feature?(:mysql, :schema_hierarchy) == false
+      assert Sources.supports_feature?(:sqlite, :schema_hierarchy) == false
+      assert Sources.supports_feature?(:other, :schema_hierarchy) == false
+    end
+  end
+
+  describe "query_language/1" do
+    test "returns query language from adapter struct" do
+      adapter = Sources.resolve!("postgres", nil)
+      assert Sources.query_language(adapter) == "sql:postgres"
+    end
+
+    test "returns query language from source name" do
+      assert Sources.query_language("postgres") == "sql:postgres"
+      assert Sources.query_language("mysql") == "sql:mysql"
+      assert Sources.query_language("sqlite") == "sql:sqlite"
+    end
+  end
+
+  describe "limit_query/3" do
+    test "wraps statement with limit from adapter struct" do
+      adapter = Sources.resolve!("postgres", nil)
+      result = Sources.limit_query(adapter, "SELECT * FROM users", 10)
+      assert result == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
+    end
+
+    test "wraps statement with limit from source name" do
+      result = Sources.limit_query("postgres", "SELECT * FROM users", 10)
+      assert result == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
+    end
   end
 end


### PR DESCRIPTION
Add adapter-level APIs so the web layer can stop calling repo.__adapter__() and pattern-matching on Ecto adapter modules directly.