### PR TITLE
feat(adapter): add supports_feature?, hierarchy_label, example_query …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
 - `limit_query/2` callback in `Lotus.Source` behaviour and dispatch in `Lotus.Source.Adapter` — wraps a statement with a source-specific limit clause (#122)
 - `:schema_hierarchy` feature flag in `Lotus.Sources.supports_feature?/2` — true for Postgres, false for MySQL/SQLite (#122)
 - `Lotus.Sources.query_language/1` and `Lotus.Sources.limit_query/3` convenience functions accepting adapter structs or source name strings (#122)
+- `supports_feature?/1`, `hierarchy_label/0`, and `example_query/2` optional callbacks in `Lotus.Source` behaviour — source implementations can define feature flags, UI hierarchy labels, and example query placeholders (#123)
+- `hierarchy_label/1` and `example_query/3` optional callbacks in `Lotus.Source.Adapter` with dispatch helpers (#123)
+- `Lotus.Sources.hierarchy_label/1` and `Lotus.Sources.example_query/3` public API wrappers (#123)
+- `Lotus.Sources.supports_feature?/2` now accepts `%Adapter{}` structs, delegating to the adapter callback (#123)
+- `Lotus.Source.Adapters.Ecto.supports_feature?/2` now delegates to the inner source implementation instead of calling back to `Lotus.Sources` (#123)
 - `:preload` option on `Lotus.Dashboards.list_dashboards/1` and `list_dashboards_by/1` for eager-loading associations (e.g. `:cards`) in a single query. Fixes N+1 patterns in callers that need card counts or card lists alongside the dashboard list (see elixir-lotus/lotus_web#103).
 - Pluggable source adapter abstraction (`Lotus.Source.Adapter`) — behaviour and struct wrapping data sources behind a uniform callback interface with consistent `{:ok, _} | {:error, _}` return types
 - `Lotus.Source.Resolver` behaviour for configurable source resolution

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -162,6 +162,34 @@ defmodule Lotus.Source do
   @callback limit_query(statement :: String.t(), limit :: pos_integer()) :: String.t()
 
   @doc """
+  Whether this source supports a given feature.
+
+  Examples of features: `:schema_hierarchy`, `:search_path`, `:arrays`, `:json`.
+  """
+  @callback supports_feature?(feature :: atom()) :: boolean()
+
+  @doc """
+  Return the human-readable label for the top-level hierarchy in this source.
+
+  Examples:
+    * PostgreSQL/MySQL → `"Tables"`
+    * Elasticsearch    → `"Indices"`
+    * MongoDB          → `"Collections"`
+  """
+  @callback hierarchy_label() :: String.t()
+
+  @doc """
+  Return an example query string suitable for placeholder text in the query editor.
+
+  The example should demonstrate the basic query syntax for this source.
+
+  ## Parameters
+    * `table` — an example table name to use in the query
+    * `schema` — an optional schema name (nil for schema-less sources)
+  """
+  @callback example_query(table :: String.t(), schema :: String.t() | nil) :: String.t()
+
+  @doc """
   Lists all schemas in the given repository.
 
   Returns a list of schema names. For databases without schema support
@@ -240,6 +268,12 @@ defmodule Lotus.Source do
   """
   @callback resolve_table_schema(repo, table :: String.t(), schemas :: [String.t()]) ::
               String.t() | nil
+
+  @optional_callbacks [
+    supports_feature?: 1,
+    hierarchy_label: 0,
+    example_query: 2
+  ]
 
   @impls %{
     Ecto.Adapters.Postgres => Lotus.Sources.Postgres,

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -244,13 +244,22 @@ defmodule Lotus.Source.Adapter do
   @callback limit_query(state :: term(), statement :: String.t(), limit :: pos_integer()) ::
               String.t()
 
+  @doc ~S'Return the human-readable label for the top-level hierarchy (e.g. "Tables", "Indices").'
+  @callback hierarchy_label(state :: term()) :: String.t()
+
+  @doc "Return an example query string for placeholder text in the query editor."
+  @callback example_query(state :: term(), table :: String.t(), schema :: String.t() | nil) ::
+              String.t()
+
   @optional_callbacks [
     sanitize_query: 3,
     transform_query: 4,
     extract_accessed_resources: 4,
     apply_window: 4,
     query_language: 1,
-    limit_query: 3
+    limit_query: 3,
+    hierarchy_label: 1,
+    example_query: 3
   ]
 
   # ---------------------------------------------------------------------------
@@ -443,5 +452,21 @@ defmodule Lotus.Source.Adapter do
     if function_exported?(mod, :limit_query, 3),
       do: mod.limit_query(state, statement, limit),
       else: "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  end
+
+  @doc "Return the hierarchy label via the adapter."
+  @spec hierarchy_label(t()) :: String.t()
+  def hierarchy_label(%__MODULE__{module: mod, state: state}) do
+    if function_exported?(mod, :hierarchy_label, 1),
+      do: mod.hierarchy_label(state),
+      else: "Tables"
+  end
+
+  @doc "Return an example query via the adapter."
+  @spec example_query(t(), String.t(), String.t() | nil) :: String.t()
+  def example_query(%__MODULE__{module: mod, state: state}, table, schema) do
+    if function_exported?(mod, :example_query, 3),
+      do: mod.example_query(state, table, schema),
+      else: "SELECT value_column FROM #{table}"
   end
 end

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -328,8 +328,11 @@ defmodule Lotus.Source.Adapters.Ecto do
 
   @impl true
   def supports_feature?(repo, feature) do
-    source = detect_source_type(repo)
-    Lotus.Sources.supports_feature?(source, feature)
+    impl = impl_for(repo)
+
+    if function_exported?(impl, :supports_feature?, 1),
+      do: impl.supports_feature?(feature),
+      else: false
   end
 
   @impl true
@@ -337,6 +340,24 @@ defmodule Lotus.Source.Adapters.Ecto do
 
   @impl true
   def limit_query(repo, statement, limit), do: impl_for(repo).limit_query(statement, limit)
+
+  @impl true
+  def hierarchy_label(repo) do
+    impl = impl_for(repo)
+
+    if function_exported?(impl, :hierarchy_label, 0),
+      do: impl.hierarchy_label(),
+      else: "Tables"
+  end
+
+  @impl true
+  def example_query(repo, table, schema) do
+    impl = impl_for(repo)
+
+    if function_exported?(impl, :example_query, 2),
+      do: impl.example_query(table, schema),
+      else: "SELECT value_column FROM #{table}"
+  end
 
   # ---------------------------------------------------------------------------
   # Private helpers

--- a/lib/lotus/sources.ex
+++ b/lib/lotus/sources.ex
@@ -86,9 +86,16 @@ defmodule Lotus.Sources do
   end
 
   @doc """
-  Whether a source type supports a specific feature.
+  Whether a source supports a specific feature.
+
+  Accepts an `%Adapter{}` struct (delegates to the adapter callback) or
+  a source type atom (uses hardcoded fallback for backward compatibility).
   """
-  @spec supports_feature?(atom(), atom()) :: boolean()
+  @spec supports_feature?(Adapter.t() | atom(), atom()) :: boolean()
+  def supports_feature?(%Adapter{} = adapter, feature) do
+    Adapter.supports_feature?(adapter, feature)
+  end
+
   def supports_feature?(:postgres, :schema_hierarchy), do: true
 
   def supports_feature?(:postgres, :search_path), do: true
@@ -111,6 +118,27 @@ defmodule Lotus.Sources do
   def supports_feature?(:sqlite, :json), do: true
 
   def supports_feature?(_, _), do: false
+
+  @doc """
+  Return the human-readable label for the top-level hierarchy in a source.
+  """
+  @spec hierarchy_label(Adapter.t() | String.t()) :: String.t()
+  def hierarchy_label(%Adapter{} = adapter), do: Adapter.hierarchy_label(adapter)
+
+  def hierarchy_label(source_name) when is_binary(source_name) do
+    source_name |> get_source!() |> Adapter.hierarchy_label()
+  end
+
+  @doc """
+  Return an example query string suitable for placeholder text.
+  """
+  @spec example_query(Adapter.t() | String.t(), String.t(), String.t() | nil) :: String.t()
+  def example_query(%Adapter{} = adapter, table, schema),
+    do: Adapter.example_query(adapter, table, schema)
+
+  def example_query(source_name, table, schema) when is_binary(source_name) do
+    source_name |> get_source!() |> Adapter.example_query(table, schema)
+  end
 
   @doc """
   Return the query language identifier for a source.

--- a/lib/lotus/sources/default.ex
+++ b/lib/lotus/sources/default.ex
@@ -107,6 +107,17 @@ defmodule Lotus.Sources.Default do
   end
 
   @impl true
+  def supports_feature?(_), do: false
+
+  @impl true
+  def hierarchy_label, do: "Tables"
+
+  @impl true
+  def example_query(table, _schema) do
+    "SELECT value_column FROM #{table}"
+  end
+
+  @impl true
   def builtin_schema_denies(_repo) do
     # Conservative denies covering common system schemas from various databases
     ["pg_catalog", "information_schema", "mysql", "performance_schema", "sys"]

--- a/lib/lotus/sources/mysql.ex
+++ b/lib/lotus/sources/mysql.ex
@@ -221,6 +221,22 @@ defmodule Lotus.Sources.MySQL do
   end
 
   @impl true
+  def supports_feature?(:schema_hierarchy), do: false
+  def supports_feature?(:search_path), do: false
+  def supports_feature?(:make_interval), do: false
+  def supports_feature?(:arrays), do: false
+  def supports_feature?(:json), do: true
+  def supports_feature?(_), do: false
+
+  @impl true
+  def hierarchy_label, do: "Tables"
+
+  @impl true
+  def example_query(table, _schema) do
+    "SELECT value_column FROM #{table}"
+  end
+
+  @impl true
   def builtin_schema_denies(_repo) do
     ["information_schema", "mysql", "performance_schema", "sys"]
   end

--- a/lib/lotus/sources/postgres.ex
+++ b/lib/lotus/sources/postgres.ex
@@ -125,6 +125,26 @@ defmodule Lotus.Sources.Postgres do
   end
 
   @impl true
+  def supports_feature?(:schema_hierarchy), do: true
+  def supports_feature?(:search_path), do: true
+  def supports_feature?(:make_interval), do: true
+  def supports_feature?(:arrays), do: true
+  def supports_feature?(:json), do: true
+  def supports_feature?(_), do: false
+
+  @impl true
+  def hierarchy_label, do: "Tables"
+
+  @impl true
+  def example_query(table, schema) when is_binary(schema) do
+    "SELECT value_column FROM #{schema}.#{table}"
+  end
+
+  def example_query(table, _schema) do
+    "SELECT value_column FROM #{table}"
+  end
+
+  @impl true
   def builtin_schema_denies(_repo) do
     ["pg_catalog", "information_schema", "pg_toast", ~r/^pg_temp/, ~r/^pg_toast/]
   end

--- a/lib/lotus/sources/sqlite.ex
+++ b/lib/lotus/sources/sqlite.ex
@@ -126,6 +126,22 @@ defmodule Lotus.Sources.SQLite3 do
   end
 
   @impl true
+  def supports_feature?(:schema_hierarchy), do: false
+  def supports_feature?(:search_path), do: false
+  def supports_feature?(:make_interval), do: false
+  def supports_feature?(:arrays), do: false
+  def supports_feature?(:json), do: true
+  def supports_feature?(_), do: false
+
+  @impl true
+  def hierarchy_label, do: "Tables"
+
+  @impl true
+  def example_query(table, _schema) do
+    "SELECT value_column FROM #{table}"
+  end
+
+  @impl true
   def builtin_schema_denies(_repo) do
     # SQLite doesn't have schemas
     []


### PR DESCRIPTION
Add adapter-level callbacks so the web layer can query source capabilities and UI labels without hardcoding SQL assumptions.