### PR TITLE
fix: normalize column values before masking and measuring them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,6 +482,12 @@
 
 ### Changed
 
+- `:sha256` column masks hash a rendered form of values that are neither text
+  nor binary, so digests change for those columns: a `NaiveDateTime` now
+  hashes `"2024-01-01T00:00:00"` rather than `"2024-01-01 00:00:00"`, and an
+  array hashes its JSON form rather than a charlist. Text and binary columns
+  hash exactly the bytes they did before, and `Decimal` renders identically
+  either way. Re-key anything that stores or joins on these digests.
 - `Lotus.Config.load!/0` caches the validated config in
   `:persistent_term` instead of re-running
   `NimbleOptions.validate/2` on every accessor call.
@@ -511,6 +517,20 @@
 
 ### Fixed
 
+- `Lotus.Result.Statistics` normalizes string values through
+  `Lotus.Value.to_display_string/1` before measuring them. Columns whose
+  values are not valid UTF-8 (PostgreSQL `bytea`, for example) raised
+  `ArgumentError` from `String.length/1`; they now report the Base64 form
+  the UI and exports already show, `:min_length` and `:max_length` are
+  always grapheme counts of that displayed form, and `:top_values` is
+  always safe to JSON-encode. Raw 16-byte UUID binaries report as UUID
+  strings rather than an `inspect/1` representation.
+- Column masking renders values that are neither text nor binary instead of
+  failing the query. A `:sha256` or `{:partial, opts}` mask on a `jsonb`
+  column raised `protocol String.Chars not implemented for type Map`, which
+  surfaced as a query error rather than a masked row. Such values now go
+  through `Lotus.Value.to_display_string/1`, the same rendering the UI and
+  exports use.
 - `describe_table/3` and `get_table_stats/3` now propagate adapter
   errors (permission denied, connection errors) instead of masking
   them as "Table not found" (#189).
@@ -535,6 +555,14 @@
 
 ### Security
 
+- The `{:partial, opts}` column mask no longer returns a value in full when
+  `:keep_first` plus `:keep_last` covers its whole length. A four-character
+  value under `keep_last: 4` came through unmasked; such a value is now
+  masked completely.
+- The `{:partial, opts}` column mask hides every byte of a value that is not
+  valid UTF-8 instead of measuring it as text. `String.length/1` and
+  `String.slice/1` report unreliable lengths for such binaries, which let a
+  `bytea` value pass through the mask intact.
 - Filter values are parameterized (bound as `$1`, `?`) instead of
   string-interpolated, eliminating SQL-injection risk via crafted
   filter values (#152).

--- a/guides/visibility.md
+++ b/guides/visibility.md
@@ -452,6 +452,22 @@ When using `:mask` action, choose from these strategies:
 # "john@example.com" becomes "jo#######.com"
 ```
 
+Partial masking never lets a value through untouched:
+
+```elixir
+{"users", "pin", [action: :mask, mask: {:partial, keep_last: 4}]}
+# "1234" becomes "****", not "1234" — a value no longer than the kept
+# ends has nothing left to mask, so nothing is kept.
+
+{"users", "key_material", [action: :mask, mask: {:partial, keep_last: 4}]}
+# A binary column (`bytea`, `BLOB`, `VARBINARY`) that does not hold text
+# becomes one replacement character per byte. Such data has no readable
+# prefix or suffix worth keeping.
+```
+
+Values that are neither text nor binary — a `jsonb` column, for example —
+are rendered the way the UI and exports render them, then masked as text.
+
 ### Schema Introspection Control
 
 Control whether columns appear in schema introspection:

--- a/lib/lotus/result/statistics.ex
+++ b/lib/lotus/result/statistics.ex
@@ -8,6 +8,7 @@ defmodule Lotus.Result.Statistics do
   """
 
   alias Lotus.Result
+  alias Lotus.Value
 
   @type column_type :: :numeric | :string | :temporal | :unknown
   @type column_stats :: map()
@@ -17,6 +18,12 @@ defmodule Lotus.Result.Statistics do
 
   Returns a map with `:type` and type-specific statistics keys.
   Returns `{:error, reason}` if the column is not found.
+
+  String values pass through `Lotus.Value.to_display_string/1`, the same
+  normalization the UI and exports use. Binary columns that are not valid
+  UTF-8 (`bytea`, for example) therefore appear Base64-encoded, `:min_length`
+  and `:max_length` are always grapheme counts of that displayed form, and
+  `:top_values` is always safe to JSON-encode.
   """
   @spec compute(Result.t(), String.t()) :: {:ok, column_stats()} | {:error, String.t()}
   def compute(%Result{} = result, column_name) when is_binary(column_name) do
@@ -177,12 +184,12 @@ defmodule Lotus.Result.Statistics do
   defp string_stats(values) do
     base = base_stats(values)
     {non_nil, _} = partition_nil(values)
-    strings = Enum.map(non_nil, &to_string/1)
+    strings = Enum.map(non_nil, &Value.to_display_string/1)
 
     if strings == [] do
       Map.merge(base, %{min_length: nil, max_length: nil, top_values: []})
     else
-      lengths = Enum.map(strings, &safe_length/1)
+      lengths = Enum.map(strings, &String.length/1)
 
       top_values =
         strings
@@ -197,10 +204,6 @@ defmodule Lotus.Result.Statistics do
         top_values: top_values
       })
     end
-  end
-
-  defp safe_length(s) do
-    if String.valid?(s), do: String.length(s), else: byte_size(s)
   end
 
   # --- Temporal statistics ---

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -7,7 +7,7 @@ defmodule Lotus.Runner do
   Pass `read_only: false` to allow write operations.
   """
 
-  alias Lotus.{Middleware, Preflight, Result, Telemetry, Visibility}
+  alias Lotus.{Middleware, Preflight, Result, Telemetry, Value, Visibility}
   alias Lotus.Preflight.Relations
   alias Lotus.Query.Statement
   alias Lotus.Source.Adapter
@@ -184,14 +184,30 @@ defmodule Lotus.Runner do
   defp apply_mask_policy(_value, _), do: nil
 
   defp to_string_safe(nil), do: ""
+
+  # Binaries stay as they are so a mask sees the stored bytes rather than a
+  # rendering of them. Everything else — maps from `jsonb`, structs, tuples —
+  # goes through the same display normalization the UI and exports use, since
+  # `to_string/1` raises for most of them.
   defp to_string_safe(v) when is_binary(v), do: v
-  defp to_string_safe(v), do: to_string(v)
+  defp to_string_safe(v), do: Value.to_display_string(v)
 
   defp sha256_hex(s) do
     :crypto.hash(:sha256, s) |> Base.encode16(case: :lower)
   end
 
   defp partial_mask(s, opts) when is_binary(s) do
+    if String.valid?(s), do: partial_mask_text(s, opts), else: mask_every_byte(s, opts)
+  end
+
+  # Binary data that is not valid UTF-8 (`bytea`, for example) has no readable
+  # prefix or suffix worth keeping, so none of it survives the mask.
+  defp mask_every_byte(s, opts) do
+    repl = Keyword.get(opts, :replacement, "*")
+    String.duplicate(repl, byte_size(s))
+  end
+
+  defp partial_mask_text(s, opts) do
     keep_last = Keyword.get(opts, :keep_last, 4)
     keep_first = Keyword.get(opts, :keep_first, 0)
     repl = Keyword.get(opts, :replacement, "*")
@@ -201,10 +217,13 @@ defmodule Lotus.Runner do
     right = min(keep_last, max(len - left, 0))
     mid = max(len - left - right, 0)
 
-    left_part = String.slice(s, 0, left)
-    right_part = if right > 0, do: String.slice(s, len - right, right), else: ""
-    masked = String.duplicate(repl, mid)
-    left_part <> masked <> right_part
+    if mid == 0 do
+      String.duplicate(repl, len)
+    else
+      left_part = String.slice(s, 0, left)
+      right_part = if right > 0, do: String.slice(s, len - right, right), else: ""
+      left_part <> String.duplicate(repl, mid) <> right_part
+    end
   end
 
   defp sanitize_opts(opts) do

--- a/lib/lotus/visibility/policy.ex
+++ b/lib/lotus/visibility/policy.ex
@@ -139,6 +139,12 @@ defmodule Lotus.Visibility.Policy do
     - `keep_last: n` - Keep last n characters
     - `replacement: str` - Character to use for masking (default: "*")
 
+  Partial masking keeps nothing when `keep_first` plus `keep_last` covers the
+  whole value, so a value that leaves nothing to mask is masked completely.
+  Binary values that do not hold text (`bytea`, `BLOB`, `VARBINARY`) become one
+  replacement character per byte. Any other value is rendered with
+  `Lotus.Value.to_display_string/1` and then masked as text.
+
   ## Examples
 
       iex> Policy.column_mask(:sha256)

--- a/test/lotus/result/statistics_test.exs
+++ b/test/lotus/result/statistics_test.exs
@@ -236,13 +236,32 @@ defmodule Lotus.Result.StatisticsTest do
 
     test "handles binaries that are not valid UTF-8" do
       invalid = <<194, 169, 153, 28, 40, 23, 204>>
+      encoded = Base.encode64(invalid)
       r = result(["s"], [[invalid], ["ok"], [invalid]])
       {:ok, stats} = Statistics.compute(r, "s")
 
       assert stats.type == :string
       assert stats.min_length == 2
-      assert stats.max_length == 7
-      assert %{value: ^invalid, count: 2} = hd(stats.top_values)
+      assert stats.max_length == String.length(encoded)
+      assert %{value: ^encoded, count: 2} = hd(stats.top_values)
+    end
+
+    test "statistics for invalid UTF-8 binaries are JSON encodable" do
+      r = result(["s"], [[<<194, 169, 153, 28, 40, 23, 204>>], ["ok"]])
+      {:ok, stats} = Statistics.compute(r, "s")
+
+      assert is_binary(Lotus.JSON.encode!(stats))
+    end
+
+    test "renders 16-byte UUID binaries as UUID strings" do
+      uuid = "550e8400-e29b-41d4-a716-446655440000"
+      {:ok, raw} = Ecto.UUID.dump(uuid)
+      r = result(["id"], [[raw], [raw]])
+      {:ok, stats} = Statistics.compute(r, "id")
+
+      assert stats.type == :string
+      assert stats.min_length == String.length(uuid)
+      assert %{value: ^uuid, count: 2} = hd(stats.top_values)
     end
 
     test "detects atoms as strings" do

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -1,15 +1,18 @@
 defmodule Lotus.RunnerTest do
   use Lotus.Case, async: true
+  use Mimic
 
   alias Lotus.Fixtures
   alias Lotus.Query.Statement
   alias Lotus.Runner
   alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
+  alias Lotus.Test.MysqlRepo
   alias Lotus.Test.Repo
   alias Lotus.Test.SqliteRepo
 
   @pg_adapter EctoAdapter.wrap("postgres", Repo)
   @sqlite_adapter EctoAdapter.wrap("sqlite", SqliteRepo)
+  @mysql_adapter EctoAdapter.wrap("mysql", MysqlRepo)
 
   setup do
     fixtures = Fixtures.setup_test_data()
@@ -1078,6 +1081,137 @@ defmodule Lotus.RunnerTest do
       assert id_a == uuid1
       assert ref_a == uuid2
       assert id_b == uuid2
+    end
+  end
+
+  describe "column masking" do
+    setup do
+      Mimic.copy(Lotus.Config)
+      :ok
+    end
+
+    test "partial mask hides every byte of a value that is not valid UTF-8" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"blob", [mask: {:partial, keep_last: 4}]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @pg_adapter,
+          Statement.new("SELECT '\\xdeadbeef'::bytea AS blob")
+        )
+
+      assert %{rows: [["****"]]} = result
+    end
+
+    test "partial mask hides a value no longer than the kept tail" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"pin", [mask: {:partial, keep_last: 4}]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @pg_adapter,
+          Statement.new("SELECT '1234'::text AS pin")
+        )
+
+      assert %{rows: [["****"]]} = result
+    end
+
+    test "partial mask still keeps the tail of a valid UTF-8 value" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"secret", [mask: {:partial, keep_last: 4}]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @pg_adapter,
+          Statement.new("SELECT 'supersecret'::text AS secret")
+        )
+
+      assert %{rows: [["*******cret"]]} = result
+    end
+
+    test "partial mask renders a jsonb value instead of failing the query" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"doc", [mask: {:partial, keep_last: 4}]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @pg_adapter,
+          Statement.new(~s|SELECT '{"a":1}'::jsonb AS doc|)
+        )
+
+      assert %{rows: [["***\":1}"]]} = result
+    end
+
+    test "sha256 mask hashes a jsonb value instead of failing the query" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"doc", [mask: :sha256]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @pg_adapter,
+          Statement.new(~s|SELECT '{"a":1}'::jsonb AS doc|)
+        )
+
+      assert %{rows: [[digest]]} = result
+      assert digest =~ ~r/\A[0-9a-f]{64}\z/
+    end
+
+    test "sha256 mask hashes the stored bytes of a value that is not valid UTF-8" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"blob", [mask: :sha256]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @pg_adapter,
+          Statement.new("SELECT '\\xdeadbeef'::bytea AS blob")
+        )
+
+      expected = :crypto.hash(:sha256, <<222, 173, 190, 239>>) |> Base.encode16(case: :lower)
+      assert %{rows: [[^expected]]} = result
+    end
+
+    @tag :sqlite
+    test "partial mask hides every byte of a SQLite blob" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"blob", [mask: {:partial, keep_last: 4}]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @sqlite_adapter,
+          Statement.new("SELECT x'deadbeef' AS blob")
+        )
+
+      assert %{rows: [["****"]]} = result
+    end
+
+    @tag :mysql
+    test "partial mask hides every byte of a MySQL binary value" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"payload", [mask: {:partial, keep_last: 4}]}]
+      end)
+
+      {:ok, result} =
+        Runner.run_statement(
+          @mysql_adapter,
+          Statement.new("SELECT CAST(0xDEADBEEF AS BINARY) AS payload")
+        )
+
+      assert %{rows: [["****"]]} = result
     end
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #236. That PR stopped `Lotus.Result.Statistics` crashing on binaries that are not valid UTF-8. While reviewing it I found the same class of problem in `Lotus.Runner`'s column masking, where it is a security issue rather than a crash: three ways a masked value reaches the caller unmasked, or fails the query outright.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Changes made

### Column masking (`lib/lotus/runner.ex`)

**1. A value not valid UTF-8 passed through `{:partial, opts}` intact.** `String.length(<<222, 173, 190, 239>>)` returns 3, not 4, so `keep_last: 4` kept more characters than the value had and `String.slice/3` handed back the whole raw binary. A `bytea` column under a partial mask was served unmasked. Such values are now masked byte for byte — binary data has no readable prefix or suffix worth keeping.

**2. Any value no longer than the kept ends passed through intact.** This one is not about binaries. When `keep_first + keep_last` covers the whole value, `mid` is 0 and the function returned its input unchanged:

| value | policy | before | after |
|---|---|---|---|
| `"4111111111111111"` | `keep_last: 4` | `"************1111"` | unchanged |
| `"1234"` | `keep_last: 4` | `"1234"` | `"****"` |
| `"abc"` | `keep_last: 4` | `"abc"` | `"****"` |

So a masked column holding a PIN, a short token, or a short status value was readable in full. A value that leaves nothing to mask now keeps nothing.

**3. Masking a `jsonb` column failed the whole query.** `to_string_safe/1` called `to_string/1` on the map Postgrex returns, so both `:sha256` and `{:partial, opts}` produced `protocol String.Chars not implemented for type Map` instead of a masked row. Values that are neither text nor binary now render through `Lotus.Value.to_display_string/1`. Binaries deliberately stay raw at this point, so `:sha256` still hashes the stored bytes and a partial mask still sees bytes rather than a Base64 rendering of them.

### Statistics (`lib/lotus/result/statistics.ex`)

String values go through `Lotus.Value.to_display_string/1` — the same normalization the UI and exports already use — rather than raw `to_string/1`. This supersedes the `safe_length/1` fallback added in #236, which measured invalid binaries in bytes and valid ones in graphemes, and mixed both in the same `:min_length` / `:max_length` pair. It also fixes two things #236 left: `:top_values` held raw invalid binaries and so crashed any consumer that JSON-encoded the stats map, and a raw 16-byte UUID column reported an `inspect/1` representation instead of the UUID.

### Documentation

`guides/visibility.md` and the `@doc` for `Lotus.Visibility.Policy.column_mask/2` now state what partial masking does with short values, binary columns, and non-text values. None of this was documented before.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

Masking now has 8 tests covering PostgreSQL `bytea` and `jsonb`, SQLite `BLOB`, MySQL `BINARY`, the short-value case, and a normal value that must still keep its tail. I confirmed the `bytea` test fails against `main` (it returns `<<222, 173, 190, 239>>`, not `"****"`) before the fix made it pass.

```
mix format --check-formatted      # pass
mix compile --warnings-as-errors  # pass
mix credo --strict                # 2231 mods/funs, no issues
mix test --include mysql --include sqlite
# 13 doctests, 1864 tests, 0 failures
```

## Environment (if applicable)

**Elixir & OTP versions:** Elixir 1.18.3, OTP 27

**Dependencies:** none

## Breaking changes

No API changes, but two behavior changes worth a release note, both in the CHANGELOG:

- **Short values under a partial mask now come back masked.** Anyone relying on a short value staying readable will see `****`. This is the point of the fix, but it is visible.
- **`:sha256` digests change for temporal and array columns.** A `NaiveDateTime` now hashes `"2024-01-01T00:00:00"` rather than `"2024-01-01 00:00:00"`, and an array hashes its JSON form rather than a charlist. Text and binary columns hash exactly the bytes they did before, and `Decimal` renders identically either way. Anything that stores or joins on these digests needs re-keying.

Statistics output for binary columns also changes shape: `:top_values` holds the Base64 (or UUID) form, and lengths measure that rendering rather than the raw bytes.

## Documentation

- [ ] This change requires documentation updates
- [x] Documentation has been updated
- [ ] No documentation changes needed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that this change doesn't introduce security vulnerabilities

## Related issues

Follows up on #236.

The three masking bugs predate #236 and have no issue of their own — they were found while reviewing it. Worth filing one if you want them tracked separately.

## Additional context

The masking fixes and the statistics fix share one root cause: code that treats a database value as text without asking whether it is text. Both now route through `Lotus.Value.to_display_string/1`, the normalization the rest of Lotus already applies at the edges.
