### PR TITLE
Fix/v1 api freeze

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,3 +1,6 @@
+# Run dialyzer with MIX_ENV=test, as CI does — `mix lint` and a bare
+# `mix dialyzer` use :dev, where test/support/* is not compiled and its
+# filters below are reported as "Unnecessary Skips". They are not stale.
 [
   # Return maps are intentionally typed as map() for API flexibility so that
   # adding new fields isn't a breaking change to the spec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,10 +268,11 @@
   keys. Extract via `statement.body` / `statement.params`.
 
 - **Telemetry `[:lotus, :query, :start | :stop | :exception]` metadata
-  carries `:statement`.** Handlers that indexed on `:sql` / `:params`
-  must switch. `:context` is also present (caller-supplied opaque
-  value, threaded from the `run_query/2` + `run_statement/3` options,
-  #175).
+  carries `:source` and `:statement`.** The source name moved from
+  `:repo` to `:source`, matching the middleware payloads; handlers that
+  indexed on `:repo`, `:sql` or `:params` must switch. `:context` is
+  also present (caller-supplied opaque value, threaded from the
+  `run_query/2` + `run_statement/3` options, #175).
 
 #### Visibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,14 @@
   `%Lotus.Query.Statement{}`) instead of separate `:sql` / `:params`
   keys. Extract via `statement.body` / `statement.params`.
 
+- **`:before_query` plugs can rewrite the statement.** Returning
+  `{:cont, %{payload | statement: rewritten}}` now changes what executes;
+  the runner used to discard the returned payload. This is what row-level
+  security and tenant predicates need. `:before_query` consequently runs
+  *before* statement sanitization and preflight, so the rewritten
+  statement is the one checked — a plug cannot rewrite its way onto a
+  denied table. Plugs that return the payload untouched are unaffected.
+
 - **Telemetry `[:lotus, :query, :start | :stop | :exception]` metadata
   carries `:source` and `:statement`.** The source name moved from
   `:repo` to `:source`, matching the middleware payloads; handlers that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
   is a public facade (not a behaviour) with `resolve!/2`, `list_sources/0`,
   `get_source!/1`, `default_source/0`, `source_type/1`,
   `supports_feature?/2`, `hierarchy_label/1`, `example_query/3`,
-  `query_language/1`, `limit_query/3`, `supported_filter_operators/1`,
+  `query_language/1`, `limit_query/3` (`%Statement{}` in, `%Statement{}`
+  out, optional with a passthrough default),
+  `supported_filter_operators/1`,
   `prepare_for_analysis/2`, `name_from_module!/1`. SQL-specific
   callbacks moved to `Lotus.Source.Adapters.Ecto.Dialect`. The
   `Lotus.Sources` module and all `Lotus.Sources.*` dialect modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,35 @@
   to the cache entry. `Lotus.invalidate_scope/1` clears both discovery
   and result cache entries for the given scope (#196).
 
+- **The SQL-shaped callbacks became optional, with defaults.**
+  `list_schemas/1`, `resolve_table_namespace/3`, `default_schemas/1`,
+  `builtin_schema_denies/1`, `quote_identifier/2`, `apply_filters/3`,
+  `apply_sorts/3`, `query_plan/3`, `supports_feature?/2`,
+  `db_type_to_lotus_type/2` and `editor_config/1` all have safe defaults
+  now, so a non-SQL adapter implements the ten callbacks it actually
+  needs instead of thirty, most of them stubs. Existing adapters are
+  unaffected — an implemented callback is still used.
+
+- **`%{adapter: MyAdapter, ...}` is the canonical data source entry.**
+  The named module is used directly, with no `can_handle?/1` probing. When
+  two adapters both claim a non-canonical entry, resolution now raises and
+  names them instead of silently picking whichever came first.
+
+- **An unresolvable data source is an error, not the default source.** A
+  typo in a saved query's `data_source`, or a source dropped from config,
+  used to fall through and run the query against the default database.
+  `Lotus.Source.resolve!/2` raises and the resolver returns
+  `{:error, :not_found}`. Only a caller that names no source at all gets
+  the default.
+
+- **`%Lotus.Query.Statement{}` params may be a map.** Positional binds stay
+  a list; engines with named binds carry `%{"since" => ~D[2026-01-01]}`
+  rather than inventing an order.
+
+- **`t:Lotus.Source.Adapter.feature/0` documents the feature atoms** that
+  `supports_feature?/2` is asked about: `:schema_hierarchy`,
+  `:search_path`, `:arrays`, `:json` and `:make_interval`.
+
 - **`Lotus.Source.Adapters.Ecto.Dialect` is public.** It was
   `@moduledoc false` while the adapter guide told external libraries to
   implement it; it now carries documentation and ships in the generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@
 
 - **Callback signatures take `state` as the first argument** for
   SQL-generation (`quote_identifier/2`, `query_plan/3`) and
-  error-handling (`format_error/2`, `handled_errors/1`) callbacks.
+  error-handling (`format_error/2`) callbacks.
 
 - **`execute_query/4` typespec widened** — `sql :: String.t()` →
   `sql :: term()`. This is the driver boundary; adapters receive the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,9 +105,10 @@
   word "schema" meant two things (namespace vs. column definitions).
   Hard renames, no aliases: `get_table_schema/3` → `describe_table/3`,
   `resolve_table_schema/3` → `resolve_table_namespace/3`,
-  `explain_plan/4` → `query_plan/4` (return widened to
-  `{:ok, String.t() | nil} | {:error, term()}` so non-SQL engines can
-  return `{:ok, nil}` without surfacing an error). Renames apply to
+  `explain_plan/4` → `query_plan/3` (now takes `(state, %Statement{},
+  opts)`; return widened to `{:ok, String.t() | nil} | {:error, term()}`
+  so non-SQL engines can return `{:ok, nil}` without surfacing an
+  error). Renames apply to
   `Lotus.Source.Adapter`, `Lotus.Source.Adapters.Ecto.Dialect`, all
   four built-in Ecto dialect impls, and the middle-layer
   `Lotus.Schema.get_table_schema/3`. `list_schemas/1` and
@@ -116,7 +117,7 @@
   double-meaning.
 
 - **Callback signatures take `state` as the first argument** for
-  SQL-generation (`quote_identifier/2`, `query_plan/4`) and
+  SQL-generation (`quote_identifier/2`, `query_plan/3`) and
   error-handling (`format_error/2`, `handled_errors/1`) callbacks.
 
 - **`execute_query/4` typespec widened** — `sql :: String.t()` →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,15 @@
 
 #### Visibility
 
+- **Scoped visibility is enforced at execution, not only in the explorer.**
+  `Lotus.Preflight.authorize/4` takes the caller's `:scope` and passes it to
+  the visibility resolver, and the runner threads `:scope` from
+  `Lotus.run_query/2` and `Lotus.run_statement/3` into both preflight and
+  column policies. Previously a resolver that denied a table for one tenant
+  hid it from the schema browser while a query against it still returned
+  rows. Resolvers that ignore scope (including the shipped
+  `Lotus.Visibility.Resolvers.Static`) behave exactly as before.
+
 - **`Lotus.Visibility.Resolver` callbacks gained a `scope` argument:**
   `schema_rules_for/2`, `table_rules_for/2`, `column_rules_for/2`.
   Existing custom resolvers must accept (and may ignore) the argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,13 @@
   to the cache entry. `Lotus.invalidate_scope/1` clears both discovery
   and result cache entries for the given scope (#196).
 
+- **`Lotus.Source.Adapters.Ecto.Dialect` is public.** It was
+  `@moduledoc false` while the adapter guide told external libraries to
+  implement it; it now carries documentation and ships in the generated
+  docs. `set_statement_timeout/2` and `set_search_path/2` moved to
+  `@optional_callbacks` — engines with no session timeout or search path
+  drop their no-op clauses.
+
 #### Middleware and telemetry
 
 - **Payload key `:repo` → `:source`** across every middleware event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,18 @@
   to the cache entry. `Lotus.invalidate_scope/1` clears both discovery
   and result cache entries for the given scope (#196).
 
+- **Optional `table_stats/3` callback.** `Lotus.get_table_stats/3` asks the
+  adapter first and only falls back to `SELECT COUNT(*)` when the adapter
+  does not implement it. Non-SQL sources can now answer with their engine's
+  own statistics, and may return keys beyond `:row_count`; the return type
+  widened from `%{row_count: non_neg_integer()}` to `map()`.
+
+- **`Lotus.run_statement/3` and the shared `opts` type are honest.** The
+  spec claimed `binary()` statements while non-SQL adapters take any term;
+  it now uses `Lotus.Query.Statement.body/0` and `params/0`. The `opts`
+  type gained `:scope` and `:sorts`, which the code already read but never
+  declared, and `:repo` accepts a module as well as a name.
+
 - **The SQL-shaped callbacks became optional, with defaults.**
   `list_schemas/1`, `resolve_table_namespace/3`, `default_schemas/1`,
   `builtin_schema_denies/1`, `quote_identifier/2`, `apply_filters/3`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,18 @@
   also present (caller-supplied opaque value, threaded from the
   `run_query/2` + `run_statement/3` options, #175).
 
+- **The AI layer carries the caller's actor.** `Lotus.AI.generate_query/1`,
+  `generate_query_with_context/1`, `explain_query/1` and
+  `suggest_optimizations/1` accept `:context` and `:scope`, and thread them
+  into every query and introspection call the AI makes.
+  `Lotus.AI.Tool.from_action/2` gained a `:context` option, which becomes
+  the second argument to the action's `run/2`; `Lotus.AI.Action.actor_opts/1`
+  turns it back into the `:context` / `:scope` options the `Lotus` functions
+  take. Previously every AI-initiated action reached middleware and the
+  visibility resolver with no actor, so the AI could see more than the user
+  it was acting for. Custom actions that ignore their `context` argument are
+  unaffected.
+
 - **AI map keys renamed from SQL-specific names.**
   `Lotus.AI.generate_query/1` and `generate_query_with_context/1` return
   `:statement` instead of `:sql`; `Lotus.AI.explain_query/1` takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,14 @@
   also present (caller-supplied opaque value, threaded from the
   `run_query/2` + `run_statement/3` options, #175).
 
+- **AI map keys renamed from SQL-specific names.**
+  `Lotus.AI.generate_query/1` and `generate_query_with_context/1` return
+  `:statement` instead of `:sql`; `Lotus.AI.explain_query/1` takes
+  `:statement` instead of `:sql`; `Lotus.AI.Conversation` messages carry
+  `:statement`; `Lotus.AI.ErrorDetector.analyze_error/4` returns
+  `:failed_statement`. The values are unchanged — only the key names,
+  which described SQL on a surface that is no longer SQL-only.
+
 #### Visibility
 
 - **`Lotus.Visibility.Resolver` callbacks gained a `scope` argument:**

--- a/guides/ai_query_generation.md
+++ b/guides/ai_query_generation.md
@@ -83,7 +83,7 @@ For simple, one-off queries without conversation context:
   data_source: "my_repo"
 )
 
-result.sql
+result.statement
 #=> "SELECT * FROM users WHERE created_at > NOW() - INTERVAL '7 days'"
 
 result.variables
@@ -104,7 +104,7 @@ When the user asks for parameterized queries, the AI also returns variable confi
   data_source: "my_repo"
 )
 
-result.sql
+result.statement
 #=> "SELECT * FROM orders WHERE status = {{status}}"
 
 result.variables
@@ -120,7 +120,7 @@ For iterative refinement and error fixing, see [Conversational Query Refinement]
 ```elixir
 case Lotus.AI.generate_query(prompt: prompt, data_source: repo) do
   {:ok, result} ->
-    # Success - use result.sql
+    # Success - use result.statement
 
   {:error, :not_configured} ->
     # AI features not enabled in config
@@ -233,10 +233,10 @@ Always review the generated SQL before using it in production:
 {:ok, result} = Lotus.AI.generate_query(prompt: prompt, data_source: repo)
 
 IO.puts("Generated SQL:")
-IO.puts(result.sql)
+IO.puts(result.statement)
 
 # Review before executing:
-Lotus.run_statement(result.sql, [], repo: repo)
+Lotus.run_statement(result.statement, [], repo: repo)
 ```
 
 ## Visibility and Security
@@ -362,12 +362,12 @@ conversation = Conversation.add_user_message(conversation, "Show active users")
 conversation = Conversation.add_assistant_response(
   conversation,
   "Here's your query:",
-  result.sql,
+  result.statement,
   result.variables
 )
 
 # If the query fails, add the error
-case Lotus.run_statement(result.sql, [], repo: "postgres") do
+case Lotus.run_statement(result.statement, [], repo: "postgres") do
   {:ok, _} ->
     :success
   {:error, error} ->
@@ -442,7 +442,7 @@ Lotus can explain what a SQL query does in plain language, powered by AI. This h
 
 ```elixir
 {:ok, result} = Lotus.AI.explain_query(
-  sql: """
+  statement: """
   SELECT d.name, COUNT(o.id), SUM(o.total)
   FROM departments d
   LEFT JOIN employees e ON e.department_id = d.id
@@ -468,7 +468,7 @@ Users can highlight a portion of SQL to explain just that part. The full query i
 
 ```elixir
 {:ok, result} = Lotus.AI.explain_query(
-  sql: "SELECT d.name FROM departments d LEFT JOIN employees e ON e.department_id = d.id",
+  statement: "SELECT d.name FROM departments d LEFT JOIN employees e ON e.department_id = d.id",
   fragment: "LEFT JOIN employees e ON e.department_id = d.id",
   data_source: "my_repo"
 )
@@ -485,7 +485,7 @@ The explainer understands Lotus-specific `{{variable}}` placeholders and `[[opti
 
 ```elixir
 {:ok, result} = Lotus.AI.explain_query(
-  sql: """
+  statement: """
   SELECT id, name, status FROM users
   WHERE 1=1
   [[AND status = {{status}}]]
@@ -504,7 +504,7 @@ The explainer understands Lotus-specific `{{variable}}` placeholders and `[[opti
 ### Error Handling
 
 ```elixir
-case Lotus.AI.explain_query(sql: sql, data_source: repo) do
+case Lotus.AI.explain_query(statement: statement, data_source: repo) do
   {:ok, %{explanation: explanation}} ->
     # Display explanation to user
 
@@ -524,7 +524,7 @@ Lotus can analyze your SQL queries and suggest performance improvements using AI
 
 ```elixir
 {:ok, result} = Lotus.AI.suggest_optimizations(
-  sql: "SELECT * FROM orders WHERE created_at > '2024-01-01'",
+  statement: "SELECT * FROM orders WHERE created_at > '2024-01-01'",
   data_source: "my_repo"
 )
 
@@ -583,7 +583,7 @@ Queries using Lotus-specific syntax (`{{variables}}` and `[[optional clauses]]`)
 ```elixir
 # Works with Lotus variable syntax
 {:ok, result} = Lotus.AI.suggest_optimizations(
-  sql: """
+  statement: """
   SELECT id, name FROM users
   WHERE 1=1
   [[AND status = {{status}}]]
@@ -596,7 +596,7 @@ Queries using Lotus-specific syntax (`{{variables}}` and `[[optional clauses]]`)
 
 ### Options
 
-- `:sql` (required) - The SQL query to optimize
+- `:statement` (required) - The statement to optimize
 - `:data_source` (required) - Name of the data source
 - `:params` (optional) - Query parameters (default: `[]`)
 - `:search_path` (optional) - PostgreSQL search path
@@ -604,7 +604,7 @@ Queries using Lotus-specific syntax (`{{variables}}` and `[[optional clauses]]`)
 ### Error Handling
 
 ```elixir
-case Lotus.AI.suggest_optimizations(sql: sql, data_source: repo) do
+case Lotus.AI.suggest_optimizations(statement: statement, data_source: repo) do
   {:ok, %{suggestions: []}} ->
     # Query is already well-optimized
 
@@ -637,7 +637,7 @@ Generates SQL from natural language (single-turn).
 
 **Returns:**
 
-- `{:ok, %{sql: String.t(), variables: [map()], model: String.t(), usage: map()}}` - Success
+- `{:ok, %{statement: String.t(), variables: [map()], model: String.t(), usage: map()}}` - Success
 - `{:error, :not_configured}` - AI not enabled
 - `{:error, :api_key_not_configured}` - Missing API key
 - `{:error, {:unable_to_generate, reason}}` - LLM refused
@@ -677,7 +677,7 @@ Explains a SQL query (or a selected fragment) in plain language.
 
 **Options:**
 
-- `:sql` (required) - The full SQL query
+- `:statement` (required) - The full statement to explain
 - `:fragment` (optional) - A selected portion of the query to explain
 - `:data_source` (required) - Repository name
 
@@ -694,7 +694,7 @@ Analyzes a SQL query and returns optimization suggestions.
 
 **Options:**
 
-- `:sql` (required) - The SQL query to optimize
+- `:statement` (required) - The statement to optimize
 - `:data_source` (required) - Repository name
 - `:params` (optional) - Query parameters (default: `[]`)
 - `:search_path` (optional) - PostgreSQL search path

--- a/guides/ai_query_generation.md
+++ b/guides/ai_query_generation.md
@@ -195,6 +195,35 @@ The AI checks first:
 WHERE status IN ('open', 'overdue')  -- ✅ uses actual values
 ```
 
+## Acting on Behalf of a User
+
+Every AI action — listing tables, describing a table, sampling column values,
+running a generated query — goes through the same `Lotus` functions a direct
+call would. Pass `:context` and `:scope` so those calls carry the actor:
+
+```elixir
+Lotus.AI.generate_query(
+  prompt: "Show orders from this month",
+  data_source: "my_repo",
+  context: %{user_id: current_user.id},
+  scope: %{tenant_id: current_user.tenant_id}
+)
+```
+
+`:context` reaches your middleware; `:scope` reaches your visibility
+resolver. Without them the AI runs unscoped, which means it can see tables
+your user cannot — and any access-control plug you wrote sees `nil` for
+every AI-initiated action.
+
+Custom actions receive the same map as the second argument to `run/2`, and
+should pass it on:
+
+```elixir
+def run(params, context) do
+  Lotus.Schema.list_tables(params.data_source, Lotus.AI.Action.actor_opts(context))
+end
+```
+
 ## Best Practices
 
 ### 1. Use Descriptive Prompts

--- a/guides/caching.md
+++ b/guides/caching.md
@@ -321,7 +321,7 @@ When no `key_builder` is configured, `Lotus.Cache.KeyBuilder.Default` is used, w
 All Lotus schema introspection functions are automatically cached:
 
 - `Lotus.list_tables/2` - Lists tables and views in database
-- `Lotus.get_table_schema/3` - Gets column information for tables
+- `Lotus.describe_table/3` - Gets column information for tables
 - `Lotus.get_table_stats/3` - Gets row counts and table statistics
 - `Lotus.list_relations/2` - Lists tables with schema information
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -384,7 +384,7 @@ config :lotus,
   }
 ```
 
-**Type**: `[module()]` — each module must implement `Lotus.Source.Adapter` with `can_handle?/1` and `wrap/2`. Validated at boot: unloaded modules or modules missing the behaviour raise at `Config.reload!/0` rather than at first query.
+**Type**: `[module()]` — each module must implement `Lotus.Source.Adapter` with `can_handle?/1` and `wrap/2`. Validated at boot: unloaded modules or modules missing the behaviour raise at `Lotus.Config.reload!/0` rather than at first query.
 **Default**: `[]`
 
 When resolving a data source, Lotus checks each `source_adapters` module's `can_handle?/1` against the entry (repo module or map) and dispatches to the first match. If none match, atom entries fall through to the built-in Ecto adapter; map entries raise a clear error. See the [source adapters guide](source-adapters.md) for the full contract and a walkthrough.

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -102,7 +102,7 @@ Everything lives under `lib/lotus/`. The library is roughly split into a public 
 - [`Lotus.Dashboards`](../lib/lotus/dashboards.ex) — CRUD and orchestration for dashboards (cards, filters, filter mappings). Uses the task supervisor to fan out card execution.
 - [`Lotus.Viz`](../lib/lotus/viz.ex) — CRUD and validation for per-query visualization configs.
 - [`Lotus.Query.Filter`](../lib/lotus/query/filter.ex) / [`Lotus.Query.Sort`](../lib/lotus/query/sort.ex) — Runtime filter/sort structs that the source adapters inject into already-prepared SQL.
-- [`Lotus.SQL.*`](../lib/lotus/sql/) — Low-level SQL helpers (sanitizer, identifier quoting, filter/sort injectors, validator, transformer).
+- `Lotus.Source.Adapters.Ecto.SQL.*` (`lib/lotus/source/adapters/ecto/sql/`) — Low-level SQL helpers (sanitizer, identifier quoting, filter/sort injectors, validator, transformer).
 
 **Introspection and visibility**
 
@@ -136,7 +136,7 @@ Everything lives under `lib/lotus/`. The library is roughly split into a public 
 - [`Lotus.AI.SQLGenerator`](../lib/lotus/ai/sql_generator.ex), [`QueryExplainer`](../lib/lotus/ai/query_explainer.ex), [`QueryOptimizer`](../lib/lotus/ai/query_optimizer.ex) — Request orchestration for each AI capability.
 - [`Lotus.AI.Conversation`](../lib/lotus/ai/conversation.ex) — Multi-turn conversation state used for iterative refinement.
 - [`Lotus.AI.Actions`](../lib/lotus/ai/actions.ex) and `lib/lotus/ai/actions/` — Tool definitions the LLM can call (schema listing, column value sampling, SQL validation/execution).
-- [`Lotus.AI.Prompts`](../lib/lotus/ai/prompts/) — Prompt templates for SQL generation, explanation, optimization, and variable inference.
+- `Lotus.AI.Prompts.*` (`lib/lotus/ai/prompts/`) — Prompt templates for SQL generation, explanation, optimization, and variable inference.
 - [`Lotus.AI.SchemaOptimizer`](../lib/lotus/ai/schema_optimizer.ex) — Trims schema context before it is sent to the LLM.
 
 ### Query Execution Pipeline

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -176,10 +176,10 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │ Lotus.Runner.run_statement                                           │
-│  1. assert_single_statement/1                                        │
-│  2. assert_not_denied/2 (skipped when read_only: false)              │
-│  3. Lotus.Preflight.authorize (EXPLAIN + visibility check)           │
-│  4. Middleware.run(:before_query, _)                                 │
+│  1. Middleware.run(:before_query, _) — may rewrite the statement     │
+│  2. assert_single_statement/1                                        │
+│  3. assert_not_denied/2 (skipped when read_only: false)              │
+│  4. Lotus.Preflight.authorize (EXPLAIN + visibility check)           │
 │  5. Adapter.transaction (read-only) → Adapter.execute_query          │
 │  6. Column policy enforcement (omit / mask / error)                  │
 │  7. Middleware.run(:after_query, _)                                  │
@@ -193,11 +193,11 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
 A few notes on the pipeline:
 
 - **Variable binding** happens inside `Lotus.Storage.Query.compile/2`, which also consults `Lotus.Storage.SchemaCache` for type-aware casting of user-supplied values.
-- **Filters and sorts** are injected through the source adapter, not concatenated naively — see `Lotus.SQL.FilterInjector` and `Lotus.SQL.SortInjector`.
+- **Filters and sorts** are injected through the source adapter, not concatenated naively — see `Lotus.Source.Adapters.Ecto.SQL.FilterInjector` and `Lotus.Source.Adapters.Ecto.SQL.SortInjector`.
 - **Windowed pagination** rewrites the SQL to fetch a page and (optionally) issue a separate `COUNT(*)` for the exact total.
 - **Caching** is optional. When no cache adapter is configured, `Lotus.Cache` is a pass-through and the fetcher always runs.
 - **Preflight** issues `EXPLAIN` against the target source. The relations it discovers are stashed in `Lotus.Preflight.Relations` so the runner can look up column visibility policies without re-parsing the SQL.
-- **Middleware** runs after preflight and before the actual execution — halting the pipeline from a `:before_query` plug yields `{:error, reason}` to the caller.
+- **Middleware** runs first, because a `:before_query` plug may rewrite the statement; sanitization and preflight then apply to whatever it returns. Halting the pipeline from a `:before_query` plug yields `{:error, reason}` to the caller.
 
 ### Schema Introspection Flow
 

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -25,8 +25,8 @@ Each middleware receives a payload map whose contents depend on the pipeline eve
 
 | Event | Triggered | Payload keys |
 |-------|-----------|--------------|
-| `:before_query` | After preflight visibility check, before SQL execution | `:sql`, `:params`, `:source`, `:context` |
-| `:after_query` | After execution, before result returned to caller | `:result`, `:sql`, `:params`, `:source`, `:context` |
+| `:before_query` | Before sanitization, preflight and execution | `:statement`, `:source`, `:context` |
+| `:after_query` | After execution, before result returned to caller | `:result`, `:statement`, `:source`, `:context` |
 | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
 | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |
 | `:after_get_table_schema` | After table schema introspection and column visibility | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
@@ -57,6 +57,35 @@ defmodule MyApp.DiscoveryAuditMiddleware do
   end
 end
 ```
+
+## Rewriting the Statement
+
+A `:before_query` plug may replace the `:statement` in its payload, and the
+statement it returns is the one Lotus executes:
+
+```elixir
+defmodule MyApp.TenantScope do
+  def init(opts), do: opts
+
+  def call(%{statement: statement, context: %{tenant_id: id}} = payload, _opts) do
+    scoped = %{statement | body: "SELECT * FROM (#{statement.body}) t WHERE tenant_id = $#{length(statement.params) + 1}",
+               params: statement.params ++ [id]}
+
+    {:cont, %{payload | statement: scoped}}
+  end
+
+  def call(payload, _opts), do: {:cont, payload}
+end
+```
+
+Because the rewritten statement is what runs, `:before_query` fires **before**
+statement sanitization and preflight authorization — both apply to the final
+statement, not the text the caller supplied. A plug cannot rewrite its way
+onto a denied table, and cannot turn a read into a write when `read_only` is
+in force.
+
+Returning the payload unchanged leaves the original statement in place, so
+existing audit and access-control plugs need no changes.
 
 ## Configuration
 

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -429,6 +429,7 @@ legitimately cannot support a feature.
 | `prepare_for_analysis/2` | `{:error, :unsupported}` | Produce a runnable statement for `query_plan/3` analysis — strips `[[ ... ]]`, neutralizes `{{var}}`. |
 | `hierarchy_label/1` | `"Tables"` | UI label for the top-level hierarchy (e.g. `"Indices"` for Elasticsearch). |
 | `example_query/3` | generic `SELECT` | Source-native example for the query editor's placeholder text. |
+| `table_stats/3` | `{:error, :unsupported}` | Relation statistics. Without it, core falls back to `SELECT COUNT(*)`, which only suits SQL sources. |
 | `limit_query/3` | statement unchanged | Cap a statement at a row limit for the UI's preview affordance — `%Statement{}` in, `%Statement{}` out. |
 | `list_schemas/1` | `{:ok, []}` | Sources with a namespace level. Flat sources omit it. |
 | `resolve_table_namespace/3` | `{:ok, nil}` | Resolve which namespace holds a table. |

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -430,6 +430,17 @@ legitimately cannot support a feature.
 | `hierarchy_label/1` | `"Tables"` | UI label for the top-level hierarchy (e.g. `"Indices"` for Elasticsearch). |
 | `example_query/3` | generic `SELECT` | Source-native example for the query editor's placeholder text. |
 | `limit_query/3` | statement unchanged | Cap a statement at a row limit for the UI's preview affordance — `%Statement{}` in, `%Statement{}` out. |
+| `list_schemas/1` | `{:ok, []}` | Sources with a namespace level. Flat sources omit it. |
+| `resolve_table_namespace/3` | `{:ok, nil}` | Resolve which namespace holds a table. |
+| `default_schemas/1` | `[]` | Namespaces browsed when the caller names none. |
+| `builtin_schema_denies/1` | `[]` | Namespaces always hidden (system catalogues). |
+| `quote_identifier/2` | identifier unchanged | Quote an identifier. Languages without quoting omit it. |
+| `apply_filters/3` | statement unchanged | Bake runtime filters into the statement. |
+| `apply_sorts/3` | statement unchanged | Bake runtime sorts into the statement. |
+| `query_plan/3` | `{:ok, nil}` | Execution plan, when the engine exposes one. |
+| `supports_feature?/2` | `false` | Declare capabilities. See `t:Lotus.Source.Adapter.feature/0`. |
+| `db_type_to_lotus_type/2` | `:text` | Map engine column types onto Lotus value types. |
+| `editor_config/1` | empty editor shape | Keywords, types and functions for editor completions. |
 
 ## The Security Boundaries
 

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -200,8 +200,8 @@ defmodule MyApp.Dialects.MSSQL do
   def query_language, do: "sql:tsql"
 
   @impl true
-  def limit_query(statement, limit),
-    do: "SELECT TOP #{limit} * FROM (#{statement}) AS t"
+  def limit_query(%Statement{body: body} = statement, limit),
+    do: %{statement | body: "SELECT TOP #{limit} * FROM (#{body}) AS t"}
 
   # -- Transaction & session --------------------------------------------------
   # execute_in_transaction/3, set_statement_timeout/2, set_search_path/2
@@ -385,9 +385,6 @@ defmodule MyApp.Adapters.Echo do
   def query_language(_state), do: "echo:dsl"
 
   @impl true
-  def limit_query(_state, statement, _limit), do: statement
-
-  @impl true
   def editor_config(_state),
     do: %{language: "echo:dsl", keywords: [], types: [], functions: [], context_boundaries: []}
 
@@ -433,6 +430,7 @@ legitimately cannot support a feature.
 | `prepare_for_analysis/2` | `{:error, :unsupported}` | Produce a runnable statement for `query_plan/3` analysis — strips `[[ ... ]]`, neutralizes `{{var}}`. |
 | `hierarchy_label/1` | `"Tables"` | UI label for the top-level hierarchy (e.g. `"Indices"` for Elasticsearch). |
 | `example_query/3` | generic `SELECT` | Source-native example for the query editor's placeholder text. |
+| `limit_query/3` | statement unchanged | Cap a statement at a row limit for the UI's preview affordance — `%Statement{}` in, `%Statement{}` out. |
 
 ## The Security Boundaries
 

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -211,7 +211,7 @@ defmodule MyApp.Dialects.MSSQL do
 
   # -- SQL generation ---------------------------------------------------------
   # quote_identifier/1, param_placeholder/3, limit_offset_placeholders/2,
-  # apply_filters/2, apply_sorts/2, query_plan/4
+  # apply_filters/2, apply_sorts/2, query_plan/3
 
   # -- Visibility & deny rules -----------------------------------------------
   # builtin_denies/1, builtin_schema_denies/1, default_schemas/1
@@ -248,7 +248,7 @@ implemented; optional callbacks have sensible defaults.
 | `limit_offset_placeholders/2` | SQL generation |
 | `apply_filters/2` | SQL generation |
 | `apply_sorts/2` | SQL generation |
-| `query_plan/4` | SQL generation |
+| `query_plan/3` | SQL generation |
 | `builtin_denies/1` | Visibility & deny rules |
 | `builtin_schema_denies/1` | Visibility & deny rules |
 | `default_schemas/1` | Visibility & deny rules |
@@ -348,7 +348,7 @@ defmodule MyApp.Adapters.Echo do
   def apply_sorts(_state, statement, _sorts), do: statement
 
   @impl true
-  def query_plan(_state, _sql, _params, _opts), do: {:ok, nil}
+  def query_plan(_state, _statement, _opts), do: {:ok, nil}
 
   # -- Safety & visibility ----------------------------------------------------
   @impl true
@@ -430,7 +430,7 @@ legitimately cannot support a feature.
 | `supported_filter_operators/1` | all of `Lotus.Query.Filter.operators/0` | Declare the subset of filter operators your `apply_filters/3` actually handles. |
 | `extract_accessed_resources/2` | `{:unrestricted, reason}` | Return `{:ok, MapSet}` of accessed `{schema, table}` tuples so visibility rules apply. **See below.** |
 | `ai_context/1` | `{:error, :ai_not_supported}` | Opt into Lotus.AI — language identifier, example query, syntax notes, error patterns, capability gates. |
-| `prepare_for_analysis/2` | `{:error, :unsupported}` | Produce a runnable statement for `query_plan/4` analysis — strips `[[ ... ]]`, neutralizes `{{var}}`. |
+| `prepare_for_analysis/2` | `{:error, :unsupported}` | Produce a runnable statement for `query_plan/3` analysis — strips `[[ ... ]]`, neutralizes `{{var}}`. |
 | `hierarchy_label/1` | `"Tables"` | UI label for the top-level hierarchy (e.g. `"Indices"` for Elasticsearch). |
 | `example_query/3` | generic `SELECT` | Source-native example for the query editor's placeholder text. |
 

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -421,7 +421,7 @@ legitimately cannot support a feature.
 | `substitute_variable/5` | `{:error, :unsupported}` | Support `{{var}}` in stored queries. **Security boundary — see below.** |
 | `substitute_list_variable/5` | `{:error, :unsupported}` | Support list variables. |
 | `validate_statement/3` | `:ok` (trust-on-execute) | Validate a draft via an engine's `_validate` endpoint without executing. |
-| `parse_qualified_name/2` | `{:ok, [name]}` | Adapters with multi-level namespace hierarchies (`schema.table`, `db.collection`). |
+| `parse_qualified_name/2` | `{:ok, [name]}` | Adapters with a two-level namespace (`schema.table`, `db.collection`). See [Relations are two-level](#relations-are-two-level). |
 | `validate_identifier/3` | `:ok` (permissive) | Enforce your query language's identifier grammar. |
 | `supported_filter_operators/1` | all of `Lotus.Query.Filter.operators/0` | Declare the subset of filter operators your `apply_filters/3` actually handles. |
 | `extract_accessed_resources/2` | `{:unrestricted, reason}` | Return `{:ok, MapSet}` of accessed `{schema, table}` tuples so visibility rules apply. **See below.** |
@@ -572,6 +572,34 @@ Fields:
 For large function lists, extract into a dedicated `EditorConfig` submodule
 (see `lotus_clickhouse` for an example with 300+ functions).
 
+## Relations are Two-Level
+
+Everywhere Lotus names a resource it uses exactly two levels:
+`{schema | nil, table}`. Visibility rules, deny lists, `describe_table/3`,
+`resolve_table_namespace/3`, the preflight relation set and
+`extract_accessed_resources/2` all speak this shape, and core never grows a
+third element.
+
+`nil` in the first position means unqualified — either a source with no
+namespace concept (SQLite tables, Elasticsearch indices) or a name the
+caller left unqualified.
+
+If your engine has a **deeper** hierarchy, flatten everything above the leaf
+into the schema part, keeping your query language's own separator:
+
+| Engine shape | Lotus relation |
+|---|---|
+| `schema.table` | `{"schema", "table"}` |
+| flat (`index`) | `{nil, "index"}` |
+| `project.dataset.table` | `{"project.dataset", "table"}` |
+| `catalog.schema.table` | `{"catalog.schema", "table"}` |
+
+Your adapter owns the flattening, in `parse_qualified_name/2` and
+`resolve_table_namespace/3`. Core treats the schema part as an opaque string
+and compares it verbatim against visibility rules — so a deny rule a host
+writes has to match the spelling your adapter emits. Document that spelling
+in your adapter's README.
+
 ## A Note on the "schema" Word
 
 Lotus's surface uses "schema" for two distinct concepts historically — in
@@ -614,7 +642,7 @@ established meaning and are kept for recognizability:
 - `Lotus.AI.Conversation.schema_context` field → `source_context`
   (internal). The field stores tables the AI has analyzed — "source
   context" is the accurate term now that non-SQL sources are first-class.
-- `Lotus.AI.Conversation.update_schema_context/2` →
+- `Lotus.AI.Conversation.update_source_context/2` →
   `update_source_context/2` (internal).
 - Optimization prompt type enum: `"schema"` → `"structure"` in suggestion
   JSON contract. LLMs now respond with

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -207,7 +207,7 @@ defmodule MyApp.Dialects.MSSQL do
   # execute_in_transaction/3, set_statement_timeout/2, set_search_path/2
 
   # -- Error handling ---------------------------------------------------------
-  # format_error/1, handled_errors/0
+  # format_error/1
 
   # -- SQL generation ---------------------------------------------------------
   # quote_identifier/1, param_placeholder/3, limit_offset_placeholders/2,
@@ -242,7 +242,6 @@ implemented; optional callbacks have sensible defaults.
 | `set_statement_timeout/2` | Transaction & session |
 | `set_search_path/2` | Transaction & session |
 | `format_error/1` | Error handling |
-| `handled_errors/0` | Error handling |
 | `quote_identifier/1` | SQL generation |
 | `param_placeholder/3` | SQL generation |
 | `limit_offset_placeholders/2` | SQL generation |
@@ -370,9 +369,6 @@ defmodule MyApp.Adapters.Echo do
   # -- Error handling ---------------------------------------------------------
   @impl true
   def format_error(_state, error), do: inspect(error)
-
-  @impl true
-  def handled_errors(_state), do: []
 
   # -- Identity & presentation ------------------------------------------------
   @impl true

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -230,6 +230,11 @@ end
 Callbacks are organized by category. All required callbacks must be
 implemented; optional callbacks have sensible defaults.
 
+`set_statement_timeout/2` and `set_search_path/2` are optional. Engines with
+no session-level timeout or schema search path omit them entirely rather than
+defining no-op clauses; Lotus falls back to the driver-level `:timeout` and
+ignores a caller-supplied `:search_path` for that source.
+
 **Required:**
 
 | Callback | Category |
@@ -239,8 +244,6 @@ implemented; optional callbacks have sensible defaults.
 | `query_language/0` | Identity |
 | `limit_query/2` | Identity |
 | `execute_in_transaction/3` | Transaction & session |
-| `set_statement_timeout/2` | Transaction & session |
-| `set_search_path/2` | Transaction & session |
 | `format_error/1` | Error handling |
 | `quote_identifier/1` | SQL generation |
 | `param_placeholder/3` | SQL generation |

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -10,12 +10,18 @@ with monitoring tools like Phoenix LiveDashboard, AppSignal, Datadog, and others
 
 | Event                         | Measurements                   | Metadata                                      |
 |-------------------------------|--------------------------------|-----------------------------------------------|
-| `[:lotus, :query, :start]`    | `system_time`                  | `repo`, `sql`, `params`, `context`                       |
-| `[:lotus, :query, :stop]`     | `duration`, `row_count`        | `repo`, `sql`, `params`, `context`, `result`             |
-| `[:lotus, :query, :exception]`| `duration`                     | `repo`, `sql`, `params`, `context`, `kind`, `reason`, `stacktrace` |
+| `[:lotus, :query, :start]`    | `system_time`                  | `source`, `statement`, `context`                         |
+| `[:lotus, :query, :stop]`     | `duration`, `row_count`        | `source`, `statement`, `context`, `result`               |
+| `[:lotus, :query, :exception]`| `duration`                     | `source`, `statement`, `context`, `kind`, `reason`, `stacktrace` |
 
 Duration is measured in native time units. Use `System.convert_time_unit/3` to
 convert to milliseconds or microseconds.
+
+The `source` field is the data source name (`"main"`, `"warehouse"`), not a
+repo module. The `statement` field is a `%Lotus.Query.Statement{}`: read
+`statement.body` for the adapter-native payload (SQL text for Ecto-backed
+sources, a JSON object or AST for others) and `statement.params` for the bound
+values.
 
 The `context` field carries whatever value the caller passed as the `:context`
 option to `Lotus.run_statement/3` or `Lotus.run_query/2`. It defaults to `nil` when
@@ -80,7 +86,7 @@ defmodule MyApp.LotusInstrumentation do
       "Lotus query completed",
       duration_ms: duration_ms,
       row_count: measurements.row_count,
-      repo: inspect(metadata.repo)
+      source: metadata.source
     )
   end
 
@@ -91,7 +97,7 @@ defmodule MyApp.LotusInstrumentation do
       "Lotus query failed",
       duration_ms: duration_ms,
       reason: inspect(metadata.reason),
-      repo: inspect(metadata.repo)
+      source: metadata.source
     )
   end
 

--- a/guides/upgrading-to-v1.md
+++ b/guides/upgrading-to-v1.md
@@ -272,6 +272,12 @@ changed:
   **optional**, defaulting to the statement unchanged. It used to be
   required and typed on raw statement text, which forced non-SQL adapters
   to implement a passthrough just to satisfy the behaviour.
+- **`handled_errors/1` was removed** from `Lotus.Source.Adapter`, and
+  `handled_errors/0` from `Lotus.Source.Adapters.Ecto.Dialect`. It was
+  documented as feeding the Runner's rescue clause, but the Runner always
+  routed every raised exception through `format_error/2`, which already
+  falls back to a generic message for types it does not recognise. Delete
+  the implementation from your adapter; nothing replaces it.
 - **New optional callbacks:** `needs_preflight?/2`, `validate_statement/3`,
   `parse_qualified_name/2`, `validate_identifier/3`,
   `supported_filter_operators/1`, `ai_context/1`, `prepare_for_analysis/2`.

--- a/guides/upgrading-to-v1.md
+++ b/guides/upgrading-to-v1.md
@@ -261,7 +261,9 @@ changed:
 - **`get_table_schema/3` → `describe_table/3`**, **`resolve_table_schema/3`
   → `resolve_table_namespace/3`**. The "schema" word was used with two
   distinct meanings; the new names disambiguate.
-- **`explain_plan/4` → `query_plan/4`** with return type widened to
+- **`explain_plan/4` → `query_plan/3`** — takes `(state, %Statement{}, opts)`,
+  not the old `(state, sql, params, opts)`; bound values travel in
+  `statement.params`. Return type widened to
   `{:ok, String.t() | nil} | {:error, term()}`. Non-SQL engines that don't
   expose a plan return `{:ok, nil}` without surfacing an error.
 - **`transform_bound_query/4` arity → `transform_bound_query/3`** — takes

--- a/guides/upgrading-to-v1.md
+++ b/guides/upgrading-to-v1.md
@@ -268,6 +268,10 @@ changed:
   expose a plan return `{:ok, nil}` without surfacing an error.
 - **`transform_bound_query/4` arity → `transform_bound_query/3`** — takes
   `(state, %Statement{}, opts)`, not the old `(state, sql, params, opts)`.
+- **`limit_query/3` is now `%Statement{}` in, `%Statement{}` out** and
+  **optional**, defaulting to the statement unchanged. It used to be
+  required and typed on raw statement text, which forced non-SQL adapters
+  to implement a passthrough just to satisfy the behaviour.
 - **New optional callbacks:** `needs_preflight?/2`, `validate_statement/3`,
   `parse_qualified_name/2`, `validate_identifier/3`,
   `supported_filter_operators/1`, `ai_context/1`, `prepare_for_analysis/2`.

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -1,10 +1,11 @@
 defmodule Lotus do
   @moduledoc """
-  Lotus is a lightweight Elixir library for saving and executing read-only SQL queries.
+  Lotus is a lightweight Elixir library for saving and executing read-only queries
+  against SQL and non-SQL data sources alike.
 
   This module provides the main public API, orchestrating between:
   - Storage: Query persistence and management
-  - Runner: SQL execution with safety checks
+  - Runner: statement execution with safety checks
   - Migrations: Database schema management
 
   ## Configuration
@@ -31,7 +32,7 @@ defmodule Lotus do
       # Execute a saved query
       {:ok, results} = Lotus.run_query(query)
 
-      # Execute SQL directly (read-only)
+      # Execute a statement directly (read-only)
       {:ok, results} = Lotus.run_statement("SELECT * FROM products WHERE price > $1", [100])
 
   ## Further reading
@@ -74,12 +75,14 @@ defmodule Lotus do
           statement_timeout_ms: non_neg_integer(),
           read_only: boolean(),
           search_path: binary() | nil,
-          repo: binary() | nil,
+          repo: binary() | module() | nil,
           vars: map(),
           cache: [cache_opt] | :bypass | :refresh | nil,
           window: window_opts,
           filters: [Filter.t()],
-          context: term()
+          sorts: [Sort.t()],
+          context: term(),
+          scope: term()
         ]
 
   def child_spec(opts), do: Lotus.Supervisor.child_spec(opts)
@@ -563,7 +566,10 @@ defmodule Lotus do
   end
 
   @doc """
-  Run ad-hoc SQL (bypassing storage), read-only by default and sandboxed.
+  Run an ad-hoc statement (bypassing storage), read-only by default and sandboxed.
+
+  The statement is the adapter-native payload: SQL text for Ecto-backed
+  sources, a decoded JSON object or DSL term for others.
 
   ## Options
 
@@ -594,17 +600,10 @@ defmodule Lotus do
 
   ### Windowed pagination
   Pass `window: [limit: pos_integer, offset: non_neg_integer, count: :none | :exact]` to
-  page results from the SQL. See `run_query/2` for details. The cache key automatically
+  page results from the statement. See `run_query/2` for details. The cache key automatically
   incorporates the window so different pages are cached independently.
   """
-  @spec run_statement(binary(), list(any()), [
-          {:read_only, boolean()}
-          | {:statement_timeout_ms, non_neg_integer()}
-          | {:timeout, non_neg_integer()}
-          | {:search_path, binary() | nil}
-          | {:repo, atom() | binary()}
-          | {:window, window_opts}
-        ]) ::
+  @spec run_statement(Statement.body(), Statement.params(), opts()) ::
           {:ok, Result.t()} | {:error, term()}
   def run_statement(statement, params \\ [], opts \\ []) do
     adapter = Source.resolve!(Keyword.get(opts, :repo), nil)

--- a/lib/lotus/ai.ex
+++ b/lib/lotus/ai.ex
@@ -30,7 +30,7 @@ defmodule Lotus.AI do
 
       # Returns:
       # %{
-      #   sql: "SELECT * FROM users WHERE created_at >= ...",
+      #   statement: "SELECT * FROM users WHERE created_at >= ...",
       #   variables: [],
       #   model: "openai:gpt-4o",
       #   usage: %{total_tokens: 150}
@@ -120,7 +120,7 @@ defmodule Lotus.AI do
            ) do
       {:ok,
        %{
-         sql: response.content,
+         statement: response.content,
          variables: Map.get(response, :variables, []),
          model: response.model,
          usage: response.usage
@@ -180,7 +180,7 @@ defmodule Lotus.AI do
            ) do
       {:ok,
        %{
-         sql: response.content,
+         statement: response.content,
          variables: Map.get(response, :variables, []),
          model: response.model,
          usage: response.usage
@@ -244,7 +244,7 @@ defmodule Lotus.AI do
 
       # Explain a full query
       {:ok, result} = Lotus.AI.explain_query(
-        sql: "SELECT d.name, COUNT(o.id) FROM departments d LEFT JOIN orders o ...",
+        statement: "SELECT d.name, COUNT(o.id) FROM departments d LEFT JOIN orders o ...",
         data_source: "postgres"
       )
 
@@ -253,7 +253,7 @@ defmodule Lotus.AI do
 
       # Explain a selected fragment
       {:ok, result} = Lotus.AI.explain_query(
-        sql: "SELECT d.name FROM departments d LEFT JOIN employees e ON e.department_id = d.id",
+        statement: "SELECT d.name FROM departments d LEFT JOIN employees e ON e.department_id = d.id",
         fragment: "LEFT JOIN employees e ON e.department_id = d.id",
         data_source: "postgres"
       )
@@ -263,7 +263,7 @@ defmodule Lotus.AI do
     with {:ok, config} <- get_ai_config(),
          :ok <- check_feature(opts[:data_source], :explanation) do
       QueryExplainer.explain_query(config.model,
-        sql: opts[:sql],
+        statement: opts[:statement],
         fragment: opts[:fragment],
         data_source: opts[:data_source],
         api_key: config.api_key

--- a/lib/lotus/ai.ex
+++ b/lib/lotus/ai.ex
@@ -191,7 +191,7 @@ defmodule Lotus.AI do
   @doc """
   Get AI-powered optimization suggestions for a statement.
 
-  Runs the adapter's `prepare_for_analysis/2` + `query_plan/4` to get an
+  Runs the adapter's `prepare_for_analysis/2` + `query_plan/3` to get an
   execution plan (when the engine exposes one), then asks the AI to
   review the statement and the plan for potential improvements. Adapters
   that can't produce a plan still get structural suggestions.

--- a/lib/lotus/ai.ex
+++ b/lib/lotus/ai.ex
@@ -110,13 +110,16 @@ defmodule Lotus.AI do
     with {:ok, config} <- get_ai_config(),
          :ok <- check_feature(opts[:data_source], :generation),
          {:ok, response} <-
-           QueryGenerator.generate_sql(config.model,
-             prompt: opts[:prompt],
-             data_source: opts[:data_source],
-             conversation: opts[:conversation],
-             query_context: opts[:query_context],
-             api_key: config.api_key,
-             read_only: Keyword.get(opts, :read_only, true)
+           QueryGenerator.generate_sql(
+             config.model,
+             [
+               prompt: opts[:prompt],
+               data_source: opts[:data_source],
+               conversation: opts[:conversation],
+               query_context: opts[:query_context],
+               api_key: config.api_key,
+               read_only: Keyword.get(opts, :read_only, true)
+             ] ++ actor_opts(opts)
            ) do
       {:ok,
        %{
@@ -172,11 +175,14 @@ defmodule Lotus.AI do
     with {:ok, config} <- get_ai_config(),
          :ok <- check_feature(opts[:data_source], :generation),
          {:ok, response} <-
-           QueryGenerator.generate_sql(config.model,
-             prompt: opts[:prompt],
-             data_source: opts[:data_source],
-             api_key: config.api_key,
-             read_only: Keyword.get(opts, :read_only, true)
+           QueryGenerator.generate_sql(
+             config.model,
+             [
+               prompt: opts[:prompt],
+               data_source: opts[:data_source],
+               api_key: config.api_key,
+               read_only: Keyword.get(opts, :read_only, true)
+             ] ++ actor_opts(opts)
            ) do
       {:ok,
        %{
@@ -213,11 +219,14 @@ defmodule Lotus.AI do
   def suggest_optimizations(opts) do
     with {:ok, config} <- get_ai_config(),
          :ok <- check_feature(opts[:data_source], :optimization) do
-      QueryOptimizer.suggest_optimizations(config.model,
-        statement: Keyword.fetch!(opts, :statement),
-        data_source: opts[:data_source],
-        search_path: opts[:search_path],
-        api_key: config.api_key
+      QueryOptimizer.suggest_optimizations(
+        config.model,
+        [
+          statement: Keyword.fetch!(opts, :statement),
+          data_source: opts[:data_source],
+          search_path: opts[:search_path],
+          api_key: config.api_key
+        ] ++ actor_opts(opts)
       )
     end
   end
@@ -262,11 +271,14 @@ defmodule Lotus.AI do
   def explain_query(opts) do
     with {:ok, config} <- get_ai_config(),
          :ok <- check_feature(opts[:data_source], :explanation) do
-      QueryExplainer.explain_query(config.model,
-        statement: opts[:statement],
-        fragment: opts[:fragment],
-        data_source: opts[:data_source],
-        api_key: config.api_key
+      QueryExplainer.explain_query(
+        config.model,
+        [
+          statement: opts[:statement],
+          fragment: opts[:fragment],
+          data_source: opts[:data_source],
+          api_key: config.api_key
+        ] ++ actor_opts(opts)
       )
     end
   end
@@ -397,4 +409,18 @@ defmodule Lotus.AI do
 
   defp resolve_secret(value) when is_binary(value), do: value
   defp resolve_secret(_), do: nil
+
+  # Forward the caller's actor to the AI layer. Every query the AI runs and
+  # every table it lists goes through Lotus with these options, so an
+  # access-control plug or a scoped visibility resolver sees the same actor
+  # for an AI-initiated action as for one the user made directly. Keys the
+  # caller omitted are left out rather than passed as nil.
+  defp actor_opts(opts) do
+    Enum.flat_map([:context, :scope], fn key ->
+      case Keyword.fetch(opts, key) do
+        {:ok, value} -> [{key, value}]
+        :error -> []
+      end
+    end)
+  end
 end

--- a/lib/lotus/ai/action.ex
+++ b/lib/lotus/ai/action.ex
@@ -62,4 +62,31 @@ defmodule Lotus.AI.Action do
   """
   @callback run(params :: map(), context :: map()) ::
               {:ok, map()} | {:error, term()}
+
+  @doc """
+  Turn an action's `context` into the `:context` / `:scope` options the
+  `Lotus` functions take.
+
+  An action that queries or introspects on the user's behalf must pass these
+  on, or middleware and the visibility resolver see no actor for anything the
+  AI does:
+
+      def run(params, context) do
+        Lotus.Schema.list_tables(params.data_source, Action.actor_opts(context))
+      end
+
+  Keys the caller did not supply are omitted rather than passed as `nil`, so
+  the behaviour matches calling the function without them.
+  """
+  @spec actor_opts(map()) :: keyword()
+  def actor_opts(context) when is_map(context) do
+    Enum.flat_map([:context, :scope], fn key ->
+      case Map.fetch(context, key) do
+        {:ok, value} -> [{key, value}]
+        :error -> []
+      end
+    end)
+  end
+
+  def actor_opts(_), do: []
 end

--- a/lib/lotus/ai/actions/describe_table.ex
+++ b/lib/lotus/ai/actions/describe_table.ex
@@ -8,6 +8,8 @@ defmodule Lotus.AI.Actions.DescribeTable do
 
   @behaviour Lotus.AI.Action
 
+  import Lotus.AI.Action, only: [actor_opts: 1]
+
   alias Lotus.Source
   alias Lotus.Source.Adapter
 
@@ -33,12 +35,12 @@ defmodule Lotus.AI.Actions.DescribeTable do
   end
 
   @impl true
-  def run(params, _context) do
+  def run(params, context) do
     adapter = Source.resolve!(params.data_source, nil)
 
     with {:ok, {schema, table}} <- parse_name(adapter, params.table_name),
          :ok <- validate_parts(adapter, schema, table) do
-      fetch_schema(params.data_source, schema, table, params.table_name)
+      fetch_schema(params.data_source, schema, table, params.table_name, actor_opts(context))
     end
   end
 
@@ -67,13 +69,13 @@ defmodule Lotus.AI.Actions.DescribeTable do
     end
   end
 
-  defp fetch_schema(data_source, nil, table, original_name) do
-    format_result(Lotus.Schema.describe_table(data_source, table), original_name)
+  defp fetch_schema(data_source, nil, table, original_name, opts) do
+    format_result(Lotus.Schema.describe_table(data_source, table, opts), original_name)
   end
 
-  defp fetch_schema(data_source, schema, table, original_name) do
+  defp fetch_schema(data_source, schema, table, original_name, opts) do
     format_result(
-      Lotus.Schema.describe_table(data_source, table, schema: schema),
+      Lotus.Schema.describe_table(data_source, table, [schema: schema] ++ opts),
       original_name
     )
   end

--- a/lib/lotus/ai/actions/execute_sql.ex
+++ b/lib/lotus/ai/actions/execute_sql.ex
@@ -9,6 +9,8 @@ defmodule Lotus.AI.Actions.ExecuteSQL do
 
   @behaviour Lotus.AI.Action
 
+  import Lotus.AI.Action, only: [actor_opts: 1]
+
   @max_preview_rows 50
 
   @impl true
@@ -38,10 +40,13 @@ defmodule Lotus.AI.Actions.ExecuteSQL do
   end
 
   @impl true
-  def run(params, _context) do
+  def run(params, context) do
     started_at = DateTime.utc_now()
 
-    case Lotus.run_statement(params.sql, [], repo: params.data_source, read_only: true) do
+    opts =
+      [repo: params.data_source, read_only: true] ++ actor_opts(context)
+
+    case Lotus.run_statement(params.sql, [], opts) do
       {:ok, result} ->
         preview_rows =
           result.rows

--- a/lib/lotus/ai/actions/get_column_values.ex
+++ b/lib/lotus/ai/actions/get_column_values.ex
@@ -8,6 +8,8 @@ defmodule Lotus.AI.Actions.GetColumnValues do
 
   @behaviour Lotus.AI.Action
 
+  import Lotus.AI.Action, only: [actor_opts: 1]
+
   alias Lotus.Source
   alias Lotus.Source.Adapter
 
@@ -43,13 +45,13 @@ defmodule Lotus.AI.Actions.GetColumnValues do
   end
 
   @impl true
-  def run(params, _context) do
+  def run(params, context) do
     adapter = Source.resolve!(params.data_source, nil)
 
     with {:ok, {schema, table}} <- parse_name(adapter, params.table_name),
          :ok <- validate_parts(adapter, schema, table),
          :ok <- Adapter.validate_identifier(adapter, :column, params.column_name) do
-      execute_query(schema, table, params)
+      execute_query(schema, table, params, actor_opts(context))
     end
   end
 
@@ -78,22 +80,22 @@ defmodule Lotus.AI.Actions.GetColumnValues do
     end
   end
 
-  defp execute_query(nil, table, params) do
+  defp execute_query(nil, table, params, opts) do
     query =
       ~s(SELECT DISTINCT "#{params.column_name}" FROM "#{table}" WHERE "#{params.column_name}" IS NOT NULL ORDER BY "#{params.column_name}" LIMIT 100)
 
-    run_and_format(query, params)
+    run_and_format(query, params, opts)
   end
 
-  defp execute_query(schema, table, params) do
+  defp execute_query(schema, table, params, opts) do
     query =
       ~s(SELECT DISTINCT "#{params.column_name}" FROM "#{schema}"."#{table}" WHERE "#{params.column_name}" IS NOT NULL ORDER BY "#{params.column_name}" LIMIT 100)
 
-    run_and_format(query, params)
+    run_and_format(query, params, opts)
   end
 
-  defp run_and_format(query, params) do
-    case Lotus.run_statement(query, [], repo: params.data_source) do
+  defp run_and_format(query, params, opts) do
+    case Lotus.run_statement(query, [], [repo: params.data_source] ++ opts) do
       {:ok, result} ->
         values = Enum.map(result.rows, fn [value] -> Lotus.Normalizer.normalize(value) end)
 

--- a/lib/lotus/ai/actions/list_schemas.ex
+++ b/lib/lotus/ai/actions/list_schemas.ex
@@ -8,6 +8,8 @@ defmodule Lotus.AI.Actions.ListSchemas do
 
   @behaviour Lotus.AI.Action
 
+  import Lotus.AI.Action, only: [actor_opts: 1]
+
   @impl true
   def name, do: "list_schemas"
 
@@ -23,8 +25,8 @@ defmodule Lotus.AI.Actions.ListSchemas do
   end
 
   @impl true
-  def run(params, _context) do
-    case Lotus.Schema.list_schemas(params.data_source) do
+  def run(params, context) do
+    case Lotus.Schema.list_schemas(params.data_source, actor_opts(context)) do
       {:ok, schemas} ->
         {:ok, %{schemas: schemas}}
 

--- a/lib/lotus/ai/actions/list_tables.ex
+++ b/lib/lotus/ai/actions/list_tables.ex
@@ -8,6 +8,8 @@ defmodule Lotus.AI.Actions.ListTables do
 
   @behaviour Lotus.AI.Action
 
+  import Lotus.AI.Action, only: [actor_opts: 1]
+
   @impl true
   def name, do: "list_tables"
 
@@ -25,8 +27,8 @@ defmodule Lotus.AI.Actions.ListTables do
   end
 
   @impl true
-  def run(params, _context) do
-    case Lotus.Schema.list_tables(params.data_source) do
+  def run(params, context) do
+    case Lotus.Schema.list_tables(params.data_source, actor_opts(context)) do
       {:ok, tables} ->
         {:ok, %{tables: format_table_names(tables)}}
 

--- a/lib/lotus/ai/conversation.ex
+++ b/lib/lotus/ai/conversation.ex
@@ -11,8 +11,8 @@ defmodule Lotus.AI.Conversation do
         messages: [
           %{role: :system, content: "...", timestamp: ~U[...]},
           %{role: :user, content: "Show active users", timestamp: ~U[...]},
-          %{role: :assistant, content: "I'll generate...", sql: "SELECT...", timestamp: ~U[...]},
-          %{role: :error, content: "column 'status' not found", sql: "...", timestamp: ~U[...]},
+          %{role: :assistant, content: "I'll generate...", statement: "SELECT...", timestamp: ~U[...]},
+          %{role: :error, content: "column 'status' not found", statement: "...", timestamp: ~U[...]},
           %{role: :user, content: "Fix the error", timestamp: ~U[...]}
         ],
         source_context: %{tables_analyzed: ["users", "orders"]},
@@ -36,7 +36,7 @@ defmodule Lotus.AI.Conversation do
   @type message :: %{
           role: :system | :user | :assistant | :error,
           content: String.t(),
-          sql: String.t() | nil,
+          statement: String.t() | nil,
           variables: [map()] | nil,
           timestamp: DateTime.t()
         }
@@ -93,7 +93,7 @@ defmodule Lotus.AI.Conversation do
     message = %{
       role: :user,
       content: content,
-      sql: nil,
+      statement: nil,
       variables: nil,
       timestamp: DateTime.utc_now()
     }
@@ -112,7 +112,7 @@ defmodule Lotus.AI.Conversation do
 
   - `conversation` - Current conversation state
   - `content` - Assistant's explanation or message
-  - `sql` - Generated SQL query
+  - `statement` - The generated statement
   - `variables` - Optional list of variable configurations (default: `[]`)
 
   ## Examples
@@ -122,15 +122,15 @@ defmodule Lotus.AI.Conversation do
       iex> message = List.last(conversation.messages)
       iex> message.role
       :assistant
-      iex> message.sql
+      iex> message.statement
       "SELECT * FROM users"
   """
   @spec add_assistant_response(t(), String.t(), String.t(), [map()]) :: t()
-  def add_assistant_response(conversation, content, sql, variables \\ []) do
+  def add_assistant_response(conversation, content, statement, variables \\ []) do
     message = %{
       role: :assistant,
       content: content,
-      sql: sql,
+      statement: statement,
       variables: variables,
       timestamp: DateTime.utc_now()
     }
@@ -165,16 +165,16 @@ defmodule Lotus.AI.Conversation do
   """
   @spec add_query_result(t(), {:ok, term()} | {:error, term()}) :: t()
   def add_query_result(conversation, {:error, error}) do
-    # Find the last SQL query from assistant
-    last_sql =
+    # Find the last statement the assistant produced
+    last_statement =
       conversation.messages
       |> Enum.reverse()
-      |> Enum.find_value(fn msg -> if msg.role == :assistant, do: msg.sql end)
+      |> Enum.find_value(fn msg -> if msg.role == :assistant, do: msg.statement end)
 
     error_message = %{
       role: :error,
       content: format_error(error),
-      sql: last_sql,
+      statement: last_statement,
       variables: nil,
       timestamp: DateTime.utc_now()
     }
@@ -232,8 +232,8 @@ defmodule Lotus.AI.Conversation do
           :error ->
             # Format error as user message asking for fix
             error_context =
-              if msg.sql do
-                "The previous query failed with an error:\n\nQuery: ```sql\n#{msg.sql}\n```\n\nError: #{msg.content}\n\nPlease fix this error and generate a corrected query."
+              if msg.statement do
+                "The previous query failed with an error:\n\nQuery: ```sql\n#{msg.statement}\n```\n\nError: #{msg.content}\n\nPlease fix this error and generate a corrected query."
               else
                 "An error occurred: #{msg.content}\n\nPlease help fix this."
               end
@@ -245,13 +245,14 @@ defmodule Lotus.AI.Conversation do
     [system_message] ++ context_messages ++ conversation_messages
   end
 
-  defp format_assistant_content(%{sql: sql, variables: variables, content: content})
-       when is_binary(sql) and is_list(variables) and variables != [] do
-    "#{content}\n\n```sql\n#{sql}\n```\n\n```variables\n#{Lotus.JSON.encode!(variables)}\n```"
+  defp format_assistant_content(%{statement: statement, variables: variables, content: content})
+       when is_binary(statement) and is_list(variables) and variables != [] do
+    "#{content}\n\n```sql\n#{statement}\n```\n\n```variables\n#{Lotus.JSON.encode!(variables)}\n```"
   end
 
-  defp format_assistant_content(%{sql: sql, content: content}) when is_binary(sql) do
-    "#{content}\n\n```sql\n#{sql}\n```"
+  defp format_assistant_content(%{statement: statement, content: content})
+       when is_binary(statement) do
+    "#{content}\n\n```sql\n#{statement}\n```"
   end
 
   defp format_assistant_content(%{content: content}), do: content
@@ -346,13 +347,13 @@ defmodule Lotus.AI.Conversation do
 
   defp build_query_context_messages(nil), do: []
 
-  defp build_query_context_messages(%{sql: sql, variables: variables})
-       when is_binary(sql) and sql != "" do
+  defp build_query_context_messages(%{statement: statement, variables: variables})
+       when is_binary(statement) and statement != "" do
     content =
       if is_list(variables) and variables != [] do
-        "The user already has this query in their editor:\n\n```sql\n#{sql}\n```\n\n```variables\n#{Lotus.JSON.encode!(variables)}\n```"
+        "The user already has this query in their editor:\n\n```sql\n#{statement}\n```\n\n```variables\n#{Lotus.JSON.encode!(variables)}\n```"
       else
-        "The user already has this query in their editor:\n\n```sql\n#{sql}\n```"
+        "The user already has this query in their editor:\n\n```sql\n#{statement}\n```"
       end
 
     [

--- a/lib/lotus/ai/error_detector.ex
+++ b/lib/lotus/ai/error_detector.ex
@@ -42,7 +42,7 @@ defmodule Lotus.AI.ErrorDetector do
   @type error_context :: %{
           error_type: error_type(),
           error_message: String.t(),
-          failed_sql: String.t() | nil,
+          failed_statement: String.t() | nil,
           suggestions: [String.t()]
         }
 
@@ -52,7 +52,7 @@ defmodule Lotus.AI.ErrorDetector do
   ## Parameters
 
   - `error_message` - The error message from the database
-  - `sql` - The SQL query that failed (optional)
+  - `statement` - The statement that failed (optional)
   - `source_context` - Context about tables analyzed (optional)
 
   ## Returns
@@ -70,7 +70,7 @@ defmodule Lotus.AI.ErrorDetector do
       :column_not_found
       iex> result.error_message
       "column 'status' does not exist"
-      iex> result.failed_sql
+      iex> result.failed_statement
       "SELECT status FROM users"
       iex> Enum.any?(result.suggestions, &String.contains?(&1, "describe_table"))
       true
@@ -88,15 +88,15 @@ defmodule Lotus.AI.ErrorDetector do
   is the generic classification + suggestion flow.
   """
   @spec analyze_error(String.t(), String.t() | nil, map(), map() | nil) :: error_context()
-  def analyze_error(error_message, sql \\ nil, source_context \\ %{}, ai_context \\ nil) do
+  def analyze_error(error_message, statement \\ nil, source_context \\ %{}, ai_context \\ nil) do
     error_type = classify_error(error_message)
-    generic_suggestions = suggest_fixes(error_type, error_message, sql, source_context)
+    generic_suggestions = suggest_fixes(error_type, error_message, statement, source_context)
     adapter_hints = match_adapter_error_patterns(ai_context, error_message)
 
     %{
       error_type: error_type,
       error_message: error_message,
-      failed_sql: sql,
+      failed_statement: statement,
       suggestions: adapter_hints ++ generic_suggestions
     }
   end
@@ -156,7 +156,7 @@ defmodule Lotus.AI.ErrorDetector do
 
   - `error_type` - Classified error type
   - `error_message` - Original error message
-  - `sql` - Failed SQL query (optional)
+  - `statement` - The failed statement (optional)
   - `source_context` - Source context map (optional)
 
   ## Returns
@@ -164,9 +164,9 @@ defmodule Lotus.AI.ErrorDetector do
   List of actionable suggestion strings.
   """
   @spec suggest_fixes(error_type(), String.t(), String.t() | nil, map()) :: [String.t()]
-  def suggest_fixes(error_type, error_message, sql, source_context)
+  def suggest_fixes(error_type, error_message, statement, source_context)
 
-  def suggest_fixes(:column_not_found, error_message, _sql, source_context) do
+  def suggest_fixes(:column_not_found, error_message, _statement, source_context) do
     # Try to extract column name from error
     column_name = extract_identifier(error_message, "column")
     tables = source_context[:tables_analyzed] || []
@@ -206,7 +206,7 @@ defmodule Lotus.AI.ErrorDetector do
     |> Enum.reject(&is_nil/1)
   end
 
-  def suggest_fixes(:table_not_found, error_message, _sql, _source_context) do
+  def suggest_fixes(:table_not_found, error_message, _statement, _source_context) do
     table_name = extract_identifier(error_message, "table", "relation")
 
     base_suggestions = [
@@ -228,14 +228,14 @@ defmodule Lotus.AI.ErrorDetector do
     base_suggestions ++ table_suggestions
   end
 
-  def suggest_fixes(:syntax_error, error_message, sql, _source_context) do
+  def suggest_fixes(:syntax_error, error_message, statement, _source_context) do
     base_suggestions = [
       "There's a SQL syntax error in the query",
       "Review the SQL syntax carefully - check for missing/extra commas, parentheses, or keywords"
     ]
 
-    sql_suggestions =
-      if sql do
+    statement_suggestions =
+      if statement do
         [
           "Review the generated SQL and fix any syntax issues",
           "Common issues: missing FROM clause, incorrect JOIN syntax, or misplaced keywords"
@@ -251,11 +251,11 @@ defmodule Lotus.AI.ErrorDetector do
         []
       end
 
-    (base_suggestions ++ sql_suggestions ++ error_suggestions)
+    (base_suggestions ++ statement_suggestions ++ error_suggestions)
     |> Enum.reject(&is_nil/1)
   end
 
-  def suggest_fixes(:type_mismatch, _error_message, _sql, _source_context) do
+  def suggest_fixes(:type_mismatch, _error_message, _statement, _source_context) do
     [
       "There's a data type mismatch in the query",
       "Check that you're comparing compatible types (e.g., don't compare strings to numbers without casting)",
@@ -264,7 +264,7 @@ defmodule Lotus.AI.ErrorDetector do
     ]
   end
 
-  def suggest_fixes(:ambiguous_column, error_message, _sql, _source_context) do
+  def suggest_fixes(:ambiguous_column, error_message, _statement, _source_context) do
     column_name = extract_identifier(error_message, "column")
 
     base_suggestions = [
@@ -284,7 +284,7 @@ defmodule Lotus.AI.ErrorDetector do
     base_suggestions ++ column_suggestions
   end
 
-  def suggest_fixes(:permission_denied, _error_message, _sql, _source_context) do
+  def suggest_fixes(:permission_denied, _error_message, _statement, _source_context) do
     [
       "You don't have permission to access this table or column",
       "Use list_tables() to see which tables are accessible",
@@ -293,7 +293,7 @@ defmodule Lotus.AI.ErrorDetector do
     ]
   end
 
-  def suggest_fixes(:unknown, error_message, _sql, _source_context) do
+  def suggest_fixes(:unknown, error_message, _statement, _source_context) do
     [
       "An unexpected error occurred: #{error_message}",
       "Review the error message carefully and adjust the query accordingly",

--- a/lib/lotus/ai/query_explainer.ex
+++ b/lib/lotus/ai/query_explainer.ex
@@ -45,7 +45,7 @@ defmodule Lotus.AI.QueryExplainer do
         Explanation.user_prompt(statement)
       end
 
-    tools = build_tools(data_source)
+    tools = build_tools(data_source, actor_from(opts))
     messages = build_messages(system_prompt, user_prompt)
     context = ReqLLM.Context.new(messages)
 
@@ -53,10 +53,21 @@ defmodule Lotus.AI.QueryExplainer do
     |> handle_response(model_string)
   end
 
-  defp build_tools(data_source) do
+  defp build_tools(data_source, actor) do
     [
-      Tool.from_action(Actions.DescribeTable, bind: %{data_source: data_source})
+      Tool.from_action(Actions.DescribeTable, bind: %{data_source: data_source}, context: actor)
     ]
+  end
+
+  # The actor the AI is working for, in the shape actions expect. Keys the
+  # caller did not supply are left out rather than passed as nil.
+  defp actor_from(opts) do
+    Enum.reduce([:context, :scope], %{}, fn key, acc ->
+      case Keyword.fetch(opts, key) do
+        {:ok, value} -> Map.put(acc, key, value)
+        :error -> acc
+      end
+    end)
   end
 
   defp build_messages(system_prompt, user_prompt) do

--- a/lib/lotus/ai/query_explainer.ex
+++ b/lib/lotus/ai/query_explainer.ex
@@ -15,7 +15,7 @@ defmodule Lotus.AI.QueryExplainer do
 
   ## Options
 
-  - `:sql` (required) - The full SQL query
+  - `:statement` (required) - The full statement to explain
   - `:fragment` (optional) - A selected portion of the query to explain
   - `:data_source` (required) - Name of the data source
   - `:api_key` (required) - API key for the LLM provider
@@ -29,7 +29,7 @@ defmodule Lotus.AI.QueryExplainer do
   @spec explain_query(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def explain_query(model_string, opts) do
     data_source = Keyword.fetch!(opts, :data_source)
-    sql = Keyword.fetch!(opts, :sql)
+    statement = Keyword.fetch!(opts, :statement)
     fragment = Keyword.get(opts, :fragment)
     api_key = Keyword.fetch!(opts, :api_key)
     temperature = Keyword.get(opts, :temperature, 0.2)
@@ -40,9 +40,9 @@ defmodule Lotus.AI.QueryExplainer do
 
     user_prompt =
       if fragment do
-        Explanation.fragment_prompt(fragment, sql)
+        Explanation.fragment_prompt(fragment, statement)
       else
-        Explanation.user_prompt(sql)
+        Explanation.user_prompt(statement)
       end
 
     tools = build_tools(data_source)

--- a/lib/lotus/ai/query_generator.ex
+++ b/lib/lotus/ai/query_generator.ex
@@ -7,6 +7,7 @@ defmodule Lotus.AI.QueryGenerator do
   string like `"openai:gpt-4o"` or `"anthropic:claude-opus-4"`.
   """
 
+  alias Lotus.AI.Action
   alias Lotus.AI.Actions
   alias Lotus.AI.Conversation
   alias Lotus.AI.Prompts.QueryGeneration
@@ -42,6 +43,9 @@ defmodule Lotus.AI.QueryGenerator do
   - `:query_context` - Additional context for the query
   - `:read_only` - Whether to restrict to read-only SQL (default: true)
   - `:temperature` - LLM temperature (default: 0.1)
+  - `:context` - Caller-supplied actor context, threaded into every query
+    and introspection call the AI makes
+  - `:scope` - Caller-supplied visibility scope, threaded the same way
   """
   @type sql_response :: %{
           content: String.t(),
@@ -63,19 +67,24 @@ defmodule Lotus.AI.QueryGenerator do
     read_only = Keyword.get(opts, :read_only, true)
     api_key = Keyword.fetch!(opts, :api_key)
     temperature = Keyword.get(opts, :temperature, 0.1)
+    actor = actor_from(opts)
+    actor_opts = Action.actor_opts(actor)
 
     adapter = Source.resolve!(data_source, nil)
 
     case Adapter.ai_context(adapter) do
       {:ok, ai_context} ->
-        {:ok, all_schemas} = Lotus.Schema.list_schemas(data_source)
-        {:ok, tables} = Lotus.Schema.list_tables(data_source, schemas: all_schemas)
+        {:ok, all_schemas} = Lotus.Schema.list_schemas(data_source, actor_opts)
+
+        {:ok, tables} =
+          Lotus.Schema.list_tables(data_source, [schemas: all_schemas] ++ actor_opts)
+
         table_names = extract_table_names(tables)
 
         system_prompt =
           QueryGeneration.system_prompt(ai_context, table_names, read_only: read_only)
 
-        tools = build_tools(data_source)
+        tools = build_tools(data_source, actor)
         messages = build_messages(conversation, prompt, system_prompt, query_context)
         context = build_context(messages)
 
@@ -125,16 +134,28 @@ defmodule Lotus.AI.QueryGenerator do
 
   # Tools
 
-  defp build_tools(data_source) do
+  defp build_tools(data_source, actor) do
     bind = %{data_source: data_source}
+    opts = [bind: bind, context: actor]
 
     [
-      Tool.from_action(Actions.ListSchemas, bind: bind),
-      Tool.from_action(Actions.ListTables, bind: bind),
-      Tool.from_action(Actions.DescribeTable, bind: bind),
-      Tool.from_action(Actions.GetColumnValues, bind: bind),
-      Tool.from_action(Actions.ValidateSQL, bind: bind)
+      Tool.from_action(Actions.ListSchemas, opts),
+      Tool.from_action(Actions.ListTables, opts),
+      Tool.from_action(Actions.DescribeTable, opts),
+      Tool.from_action(Actions.GetColumnValues, opts),
+      Tool.from_action(Actions.ValidateSQL, opts)
     ]
+  end
+
+  # The actor the AI is working for, in the shape actions expect. Keys the
+  # caller did not supply are left out rather than passed as nil.
+  defp actor_from(opts) do
+    Enum.reduce([:context, :scope], %{}, fn key, acc ->
+      case Keyword.fetch(opts, key) do
+        {:ok, value} -> Map.put(acc, key, value)
+        :error -> acc
+      end
+    end)
   end
 
   # Messages

--- a/lib/lotus/ai/query_optimizer.ex
+++ b/lib/lotus/ai/query_optimizer.ex
@@ -4,7 +4,7 @@ defmodule Lotus.AI.QueryOptimizer do
 
   Runs the adapter's `prepare_for_analysis/2` to resolve Lotus template
   syntax into a form parseable by the engine's diagnostic endpoint, calls
-  `query_plan/4` to get an execution plan (when available), and sends
+  `query_plan/3` to get an execution plan (when available), and sends
   both the statement and the plan to the LLM for review.
 
   The module is adapter-agnostic — SQL dialects produce EXPLAIN output,
@@ -87,7 +87,7 @@ defmodule Lotus.AI.QueryOptimizer do
   # suggestions.
   defp get_execution_plan(adapter, %Statement{} = statement, opts) do
     with {:ok, prepared} <- Adapter.prepare_for_analysis(adapter, statement),
-         {:ok, plan} <- Adapter.query_plan(adapter, prepared.body, prepared.params, opts) do
+         {:ok, plan} <- Adapter.query_plan(adapter, prepared, opts) do
       plan
     else
       _ -> nil

--- a/lib/lotus/ai/query_optimizer.ex
+++ b/lib/lotus/ai/query_optimizer.ex
@@ -65,7 +65,7 @@ defmodule Lotus.AI.QueryOptimizer do
         system_prompt = Optimization.system_prompt(ai_context)
         user_prompt = Optimization.user_prompt(statement.body, execution_plan)
 
-        tools = build_tools(data_source)
+        tools = build_tools(data_source, actor_from(opts))
         messages = build_messages(system_prompt, user_prompt)
         context = ReqLLM.Context.new(messages)
 
@@ -94,10 +94,21 @@ defmodule Lotus.AI.QueryOptimizer do
     end
   end
 
-  defp build_tools(data_source) do
+  defp build_tools(data_source, actor) do
     [
-      Tool.from_action(Actions.DescribeTable, bind: %{data_source: data_source})
+      Tool.from_action(Actions.DescribeTable, bind: %{data_source: data_source}, context: actor)
     ]
+  end
+
+  # The actor the AI is working for, in the shape actions expect. Keys the
+  # caller did not supply are left out rather than passed as nil.
+  defp actor_from(opts) do
+    Enum.reduce([:context, :scope], %{}, fn key, acc ->
+      case Keyword.fetch(opts, key) do
+        {:ok, value} -> Map.put(acc, key, value)
+        :error -> acc
+      end
+    end)
   end
 
   defp build_messages(system_prompt, user_prompt) do

--- a/lib/lotus/ai/tool.ex
+++ b/lib/lotus/ai/tool.ex
@@ -35,10 +35,17 @@ defmodule Lotus.AI.Tool do
   - `:bind` - Map of parameter values to inject into every call.
     Bound parameters are removed from the tool's parameter schema
     so the LLM doesn't see or fill them.
+  - `:context` - Map handed to the action's `run/2` as its second argument.
+    Carries the actor on whose behalf the AI is working — typically
+    `%{context: ..., scope: ...}` — so actions can pass it on to the
+    `Lotus` calls they make. Without it every AI-initiated query and
+    introspection call reaches middleware and the visibility resolver with
+    no actor, and the AI sees more than the user it is acting for.
   """
   @spec from_action(module(), keyword()) :: map()
   def from_action(action_module, opts \\ []) do
     bound_params = Keyword.get(opts, :bind, %{})
+    action_context = Keyword.get(opts, :context, %{})
 
     parameter_schema =
       action_module.schema()
@@ -52,7 +59,7 @@ defmodule Lotus.AI.Tool do
       callback: fn llm_args ->
         merged_params = merge_params(llm_args, bound_params)
 
-        case action_module.run(merged_params, %{}) do
+        case action_module.run(merged_params, action_context) do
           {:ok, result} ->
             {:ok, Lotus.JSON.encode!(result)}
 

--- a/lib/lotus/application.ex
+++ b/lib/lotus/application.ex
@@ -1,5 +1,11 @@
 defmodule Lotus.Application do
-  @moduledoc false
+  @moduledoc """
+  OTP application entry point for Lotus.
+
+  Starts `Lotus.Supervisor` when `:lotus` is listed in your application's
+  `:extra_applications` or started as a dependency. Hosts that would rather
+  own the supervision tree start `Lotus.Supervisor` themselves instead.
+  """
 
   use Application
 

--- a/lib/lotus/cache/key.ex
+++ b/lib/lotus/cache/key.ex
@@ -1,5 +1,11 @@
 defmodule Lotus.Cache.Key do
-  @moduledoc false
+  @moduledoc """
+  Cache key construction for query results and schema introspection.
+
+  Keys are opaque binaries built from the statement, its bound values, the
+  data source and any caller-supplied cache identity. `Lotus.Cache.KeyBuilder`
+  is the extension point for hosts that need a different scheme.
+  """
 
   @spec result(term(), map() | list(), keyword(), term() | nil) :: binary()
   def result(body, bound, opts, scope \\ nil) do

--- a/lib/lotus/json.ex
+++ b/lib/lotus/json.ex
@@ -1,5 +1,12 @@
 defmodule Lotus.JSON do
-  @moduledoc false
+  @moduledoc """
+  JSON encoding and decoding used across Lotus.
+
+  Delegates to Elixir's built-in `JSON` module on v1.18 and later, falling
+  back to `Jason` on earlier versions. Adapters that inline values into a
+  statement body should escape through here rather than interpolating raw
+  strings.
+  """
 
   # Delegates to JSON in Elixir v1.18+ or Jason for earlier versions
 

--- a/lib/lotus/preflight.ex
+++ b/lib/lotus/preflight.ex
@@ -25,10 +25,16 @@ defmodule Lotus.Preflight do
 
   Delegates resource extraction to the adapter, then validates each
   relation against the visibility rules.
+
+  `scope` is the opaque caller-supplied value handed to the visibility
+  resolver, the same one `Lotus.list_tables/2` and friends accept. Pass it
+  and a per-scope deny blocks execution; omit it and only the unscoped
+  rules apply. Without it a resolver that hides a table from one tenant
+  would hide it in the explorer while the query still returned its rows.
   """
-  @spec authorize(Adapter.t(), Statement.t(), String.t() | nil) ::
+  @spec authorize(Adapter.t(), Statement.t(), String.t() | nil, term()) ::
           :ok | {:error, String.t()}
-  def authorize(%Adapter{} = adapter, %Statement{} = statement, search_path \\ nil) do
+  def authorize(%Adapter{} = adapter, %Statement{} = statement, search_path \\ nil, scope \\ nil) do
     statement =
       if search_path,
         do: %{statement | meta: Map.put(statement.meta, :search_path, search_path)},
@@ -37,7 +43,7 @@ defmodule Lotus.Preflight do
     case Adapter.extract_accessed_resources(adapter, statement) do
       {:ok, relations} ->
         rels = MapSet.to_list(relations)
-        check_relations_visibility(rels, adapter.name)
+        check_relations_visibility(rels, adapter.name, scope)
 
       {:error, e} ->
         {:error, normalize_preflight_error(e, adapter)}
@@ -59,8 +65,9 @@ defmodule Lotus.Preflight do
     end
   end
 
-  defp check_relations_visibility(rels, source_name) do
-    {allowed, blocked} = Enum.split_with(rels, &Visibility.allowed_relation?(source_name, &1))
+  defp check_relations_visibility(rels, source_name, scope) do
+    {allowed, blocked} =
+      Enum.split_with(rels, &Visibility.allowed_relation?(source_name, &1, scope))
 
     if blocked == [] do
       Relations.put(allowed)

--- a/lib/lotus/query/statement.ex
+++ b/lib/lotus/query/statement.ex
@@ -35,13 +35,20 @@ defmodule Lotus.Query.Statement do
   """
 
   @typedoc """
+  The adapter-native query payload. SQL text for Ecto-backed adapters, a
+  decoded JSON object for Elasticsearch, an AST for a DSL adapter. Core
+  never inspects it.
+  """
+  @type body :: term()
+
+  @typedoc """
   Bound values: a list for positional placeholders, a map for named ones.
   """
   @type params :: list() | map()
 
   @type t :: %__MODULE__{
           adapter: module() | nil,
-          body: term(),
+          body: body(),
           params: params(),
           meta: map()
         }
@@ -56,7 +63,7 @@ defmodule Lotus.Query.Statement do
   (Runner integration tests, adapter-author examples) sometimes need to
   construct one directly.
   """
-  @spec new(body :: term(), params :: params()) :: t()
+  @spec new(body :: body(), params :: params()) :: t()
   def new(body, params \\ []) when is_list(params) or is_map(params) do
     %__MODULE__{body: body, params: params}
   end

--- a/lib/lotus/query/statement.ex
+++ b/lib/lotus/query/statement.ex
@@ -17,8 +17,11 @@ defmodule Lotus.Query.Statement do
       binaries for Ecto-backed adapters, decoded JSON for Elasticsearch, an
       AST for DSL-based adapters. Core never inspects this field.
 
-    * `:params` — bound parameter values in the order the adapter expects.
-      Adapters that inline values (no parameterization) keep this as `[]`.
+    * `:params` — bound parameter values. A list for positional binds, in
+      the order the adapter expects. A map for engines with *named* binds
+      (`%{"since" => ~D[2026-01-01]}`), where ordering is meaningless and a
+      list would force the adapter to invent one. Adapters that inline
+      values (no parameterization) keep this as `[]`.
 
     * `:meta` — adapter-specific metadata carried through the pipeline, e.g.
       a `count_spec` produced by `apply_pagination/3`, or search-path hints.
@@ -31,10 +34,15 @@ defmodule Lotus.Query.Statement do
   anyway; the contract is explicit to rule out external state side channels).
   """
 
+  @typedoc """
+  Bound values: a list for positional placeholders, a map for named ones.
+  """
+  @type params :: list() | map()
+
   @type t :: %__MODULE__{
           adapter: module() | nil,
           body: term(),
-          params: list(),
+          params: params(),
           meta: map()
         }
 
@@ -48,8 +56,8 @@ defmodule Lotus.Query.Statement do
   (Runner integration tests, adapter-author examples) sometimes need to
   construct one directly.
   """
-  @spec new(body :: term(), params :: list()) :: t()
-  def new(body, params \\ []) when is_list(params) do
+  @spec new(body :: term(), params :: params()) :: t()
+  def new(body, params \\ []) when is_list(params) or is_map(params) do
     %__MODULE__{body: body, params: params}
   end
 end

--- a/lib/lotus/query/statement.ex
+++ b/lib/lotus/query/statement.ex
@@ -44,9 +44,9 @@ defmodule Lotus.Query.Statement do
   @doc """
   Build a statement from a body and optional bound params.
 
-  Typically the pipeline builds statements via `Lotus.execute_with_options/7`,
-  but callers (Runner integration tests, adapter-author examples) sometimes
-  need to construct one directly.
+  Typically the execution pipeline builds statements itself, but callers
+  (Runner integration tests, adapter-author examples) sometimes need to
+  construct one directly.
   """
   @spec new(body :: term(), params :: list()) :: t()
   def new(body, params \\ []) when is_list(params) do

--- a/lib/lotus/result.ex
+++ b/lib/lotus/result.ex
@@ -1,6 +1,6 @@
 defmodule Lotus.Result do
   @moduledoc """
-  Represents the result of a SQL query execution.
+  Represents the result of a query execution.
 
   Contains the columns, rows, and metadata about the query result.
   """

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -18,7 +18,8 @@ defmodule Lotus.Runner do
           timeout: non_neg_integer(),
           statement_timeout_ms: non_neg_integer(),
           read_only: boolean(),
-          search_path: String.t() | nil
+          search_path: String.t() | nil,
+          scope: term()
         ]
 
   @spec run_statement(Adapter.t(), Statement.t(), opts()) ::
@@ -63,7 +64,7 @@ defmodule Lotus.Runner do
             Adapter.execute_query(adapter, body, params, opts ++ [timeout: timeout])
           end)
 
-        handle_query_result(res, elapsed_us, adapter)
+        handle_query_result(res, elapsed_us, adapter, Keyword.get(opts, :scope))
       end,
       opts
     )
@@ -78,7 +79,8 @@ defmodule Lotus.Runner do
   defp handle_query_result(
          {:ok, %{columns: cols, rows: rows} = raw},
          elapsed_us,
-         %Adapter{} = adapter
+         %Adapter{} = adapter,
+         scope
        ) do
     num_rows = Map.get(raw, :num_rows, length(rows || []))
     command = normalize_command(Map.get(raw, :command))
@@ -87,7 +89,9 @@ defmodule Lotus.Runner do
     rels = Relations.take()
 
     policies =
-      Enum.map(cols || [], fn c -> Visibility.column_policy_for(adapter.name, rels, c) end)
+      Enum.map(cols || [], fn c ->
+        Visibility.column_policy_for(adapter.name, rels, c, scope)
+      end)
 
     case enforce_column_policies(cols || [], rows || [], policies) do
       {:error, msg} ->
@@ -109,11 +113,11 @@ defmodule Lotus.Runner do
     end
   end
 
-  defp handle_query_result({:error, err}, _elapsed_us, _adapter) do
+  defp handle_query_result({:error, err}, _elapsed_us, _adapter, _scope) do
     {:error, err}
   end
 
-  defp handle_query_result(other, _elapsed_us, _adapter) do
+  defp handle_query_result(other, _elapsed_us, _adapter, _scope) do
     other
   end
 
@@ -256,8 +260,9 @@ defmodule Lotus.Runner do
   defp preflight_visibility(%Adapter{} = adapter, %Statement{} = statement, opts) do
     if Adapter.needs_preflight?(adapter, statement) do
       search_path = Keyword.get(opts, :search_path)
+      scope = Keyword.get(opts, :scope)
 
-      case Preflight.authorize(adapter, statement, search_path) do
+      case Preflight.authorize(adapter, statement, search_path, scope) do
         :ok -> :ok
         {:error, msg} -> {:error, msg}
       end

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -2,9 +2,13 @@ defmodule Lotus.Runner do
   @moduledoc """
   Statement execution with safety checks, param binding, and result shaping.
 
-  By default, all statements are read-only. Destructive operations (INSERT,
-  UPDATE, DELETE, DDL) are blocked at both the application and database level.
-  Pass `read_only: false` to allow write operations.
+  By default, all statements are read-only. Destructive operations (writes,
+  schema changes — INSERT, UPDATE, DELETE and DDL in SQL terms) are blocked
+  at both the application and database level. Pass `read_only: false` to
+  allow write operations.
+
+  What counts as a write is the adapter's judgement, via
+  `c:Lotus.Source.Adapter.sanitize_query/3`.
   """
 
   alias Lotus.{Middleware, Preflight, Result, Telemetry, Value, Visibility}

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -29,10 +29,14 @@ defmodule Lotus.Runner do
     telemetry_meta = %{source: adapter.name, statement: statement, context: context}
     start_time = Telemetry.query_start(telemetry_meta)
 
+    # `:before_query` runs first because a plug may rewrite the statement —
+    # that is the point of the hook, for row-level security and tenant
+    # predicates. Sanitization and preflight then apply to what will actually
+    # execute, rather than to the text the caller originally supplied.
     result =
-      with :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
+      with {:ok, %Statement{} = statement} <- run_before_query(adapter, statement, context),
+           :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
            :ok <- preflight_visibility(adapter, statement, opts),
-           :ok <- run_before_query(adapter, statement, context),
            {:ok, %Result{} = res} <- exec_read_only(adapter, statement, opts),
            {:ok, %Result{} = res} <- run_after_query(adapter, statement, res, context) do
         {:ok, res}
@@ -234,11 +238,16 @@ defmodule Lotus.Runner do
     Keyword.take(opts, [:read_only])
   end
 
+  # Returns the statement to execute. A plug that rewrites `:statement` in the
+  # payload has its version carried forward; one that returns the payload
+  # untouched leaves the original in place. Anything that is not a statement
+  # is ignored rather than trusted.
   defp run_before_query(%Adapter{} = adapter, %Statement{} = statement, context) do
     payload = %{source: adapter.name, statement: statement, context: context}
 
     case Middleware.run(:before_query, payload) do
-      {:cont, _} -> :ok
+      {:cont, %{statement: %Statement{} = rewritten}} -> {:ok, rewritten}
+      {:cont, _} -> {:ok, statement}
       {:halt, reason} -> {:error, reason}
     end
   end

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -25,7 +25,7 @@ defmodule Lotus.Runner do
           {:ok, query_result()} | {:error, term()}
   def run_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
     context = Keyword.get(opts, :context)
-    telemetry_meta = %{repo: adapter.name, statement: statement, context: context}
+    telemetry_meta = %{source: adapter.name, statement: statement, context: context}
     start_time = Telemetry.query_start(telemetry_meta)
 
     result =

--- a/lib/lotus/schema.ex
+++ b/lib/lotus/schema.ex
@@ -433,9 +433,13 @@ defmodule Lotus.Schema do
 
       {:ok, stats} = Lotus.Schema.get_table_stats("postgres", "customers", schema: "reporting")
       # Gets stats for reporting.customers
+
+  Sources whose adapter implements `c:Lotus.Source.Adapter.table_stats/3`
+  answer from that callback and may return additional keys alongside
+  `:row_count`. Everything else falls back to `SELECT COUNT(*)`.
   """
   @spec get_table_stats(module() | String.t(), String.t(), keyword()) ::
-          {:ok, %{row_count: non_neg_integer()}} | {:error, binary()}
+          {:ok, map()} | {:error, binary()}
   def get_table_stats(repo_or_name, table_name, opts \\ []) do
     adapter = Source.resolve!(repo_or_name, nil)
     scope = Keyword.get(opts, :scope)
@@ -492,31 +496,41 @@ defmodule Lotus.Schema do
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
       if Visibility.allowed_relation?(adapter.name, {resolved_schema, table_name}, scope) do
-        try do
-          count_sql =
-            if resolved_schema do
-              qi = &Adapter.quote_identifier(adapter, &1)
-              "SELECT COUNT(*) FROM #{qi.(resolved_schema)}.#{qi.(table_name)}"
-            else
-              qi = &Adapter.quote_identifier(adapter, &1)
-              "SELECT COUNT(*) FROM #{qi.(table_name)}"
-            end
-
-          case Adapter.execute_query(adapter, count_sql, [], []) do
-            {:ok, %{rows: [[count]]}} ->
-              {:ok, %{row_count: count}}
-
-            {:error, reason} ->
-              {:error, to_string(reason)}
-          end
-        rescue
-          e -> {:error, Exception.message(e)}
-        end
+        fetch_table_stats(adapter, resolved_schema, table_name)
       else
         {:error,
          "Table '#{if resolved_schema, do: "#{resolved_schema}.#{table_name}", else: table_name}' is not visible by Lotus policy"}
       end
     end)
+  end
+
+  # Adapters that can answer this themselves do. The COUNT(*) fallback below
+  # assumes SQL, so it is reached only by adapters that did not implement
+  # `table_stats/3`.
+  defp fetch_table_stats(adapter, resolved_schema, table_name) do
+    case Adapter.table_stats(adapter, resolved_schema, table_name) do
+      {:ok, stats} -> {:ok, stats}
+      {:error, :unsupported} -> count_rows(adapter, resolved_schema, table_name)
+      {:error, reason} -> {:error, to_string(reason)}
+    end
+  end
+
+  defp count_rows(adapter, resolved_schema, table_name) do
+    qi = &Adapter.quote_identifier(adapter, &1)
+
+    count_sql =
+      if resolved_schema do
+        "SELECT COUNT(*) FROM #{qi.(resolved_schema)}.#{qi.(table_name)}"
+      else
+        "SELECT COUNT(*) FROM #{qi.(table_name)}"
+      end
+
+    case Adapter.execute_query(adapter, count_sql, [], []) do
+      {:ok, %{rows: [[count]]}} -> {:ok, %{row_count: count}}
+      {:error, reason} -> {:error, to_string(reason)}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
   end
 
   @doc """

--- a/lib/lotus/source.ex
+++ b/lib/lotus/source.ex
@@ -8,6 +8,7 @@ defmodule Lotus.Source do
   """
 
   alias Lotus.Config
+  alias Lotus.Query.Statement
   alias Lotus.Source.Adapter
 
   # ---------------------------------------------------------------------------
@@ -146,7 +147,7 @@ defmodule Lotus.Source do
   @doc """
   Wrap a statement with a limit clause using the source's syntax.
   """
-  @spec limit_query(Adapter.t() | String.t(), String.t(), pos_integer()) :: String.t()
+  @spec limit_query(Adapter.t() | String.t(), Statement.t(), pos_integer()) :: Statement.t()
   def limit_query(%Adapter{} = adapter, statement, limit),
     do: Adapter.limit_query(adapter, statement, limit)
 

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -615,20 +615,22 @@ defmodule Lotus.Source.Adapter do
               {:ok, Statement.t()} | {:error, term()}
 
   @doc """
-  Wrap a raw statement string with a source-specific row limit.
+  Cap a statement at a source-specific row limit.
 
-  **SQL-shaped callback.** The `statement` argument is the raw statement
-  text (typically SQL) and the result is the same text wrapped with a
-  single-page `LIMIT` / `TOP` / `FETCH FIRST` clause (exact syntax varies
-  per dialect). Used by the UI's "preview this query" affordance to cap
-  returned rows without touching the underlying query.
+  Takes a `%Statement{}` and returns a `%Statement{}` whose body carries a
+  single-page limit — a `LIMIT` / `TOP` / `FETCH FIRST` clause for SQL
+  dialects, a `size` key for a JSON DSL, whatever the language calls it.
+  Used by the UI's "preview this query" affordance to cap returned rows
+  without touching the underlying query. `statement.params` is carried
+  through untouched unless the adapter binds the limit itself.
 
-  Non-SQL adapters whose languages don't have a textual limit clause may
-  return the input unchanged — Lotus core treats the callback as best-
-  effort and does not depend on it for correctness.
+  Default (when not implemented): the statement unchanged. Adapters whose
+  language has no notion of a row cap simply omit the callback — Lotus
+  core treats it as best-effort and does not depend on it for
+  correctness.
   """
-  @callback limit_query(state :: term(), statement :: String.t(), limit :: pos_integer()) ::
-              String.t()
+  @callback limit_query(state :: term(), statement :: Statement.t(), limit :: pos_integer()) ::
+              Statement.t()
 
   @doc ~S'Return the human-readable label for the top-level hierarchy (e.g. "Tables", "Indices").'
   @callback hierarchy_label(state :: term()) :: String.t()
@@ -832,7 +834,8 @@ defmodule Lotus.Source.Adapter do
     example_query: 3,
     can_handle?: 1,
     wrap: 2,
-    transform_statement: 2
+    transform_statement: 2,
+    limit_query: 3
   ]
 
   # Conservative fallback deny rules applied when no adapter can be resolved
@@ -1509,9 +1512,11 @@ defmodule Lotus.Source.Adapter do
   end
 
   @doc "Wrap a statement with a limit clause via the adapter."
-  @spec limit_query(t(), String.t(), pos_integer()) :: String.t()
-  def limit_query(%__MODULE__{module: mod, state: state}, statement, limit) do
-    mod.limit_query(state, statement, limit)
+  @spec limit_query(t(), Statement.t(), pos_integer()) :: Statement.t()
+  def limit_query(%__MODULE__{module: mod, state: state}, %Statement{} = statement, limit) do
+    if function_exported?(mod, :limit_query, 3),
+      do: mod.limit_query(state, statement, limit),
+      else: statement
   end
 
   @doc "Return the hierarchy label via the adapter."

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -36,13 +36,39 @@ defmodule Lotus.Source.Adapter do
   ## Pipeline Statement contract
 
   All pipeline callbacks operate on a `%Lotus.Query.Statement{}` struct that
-  carries the adapter-native payload (`:text`, opaque term), `:params`, and
+  carries the adapter-native payload (`:body`, an opaque term), `:params`, and
   adapter-specific `:meta`. Adapters return a new statement with the relevant
   field updated — the pipeline is a series of pure `statement -> statement`
   transforms.
 
   Introspection callbacks consistently return `{:ok, result} | {:error, reason}`
   tuples so callers can handle failures uniformly.
+
+  ## Relations are two-level
+
+  Everywhere Lotus names a resource it uses exactly two levels:
+  `{schema | nil, table}`. That shape is fixed — visibility rules, deny
+  lists, `describe_table/3`, `resolve_table_namespace/3`, the preflight
+  relation set and `extract_accessed_resources/2` all speak it, and core
+  never grows a third element.
+
+  `nil` in the first position means "unqualified" — a source with no
+  namespace concept at all (SQLite tables, Elasticsearch indices), or a
+  name the caller left unqualified.
+
+  Engines with a **deeper** hierarchy flatten everything above the leaf
+  into the schema part, keeping the separator their own query language
+  uses:
+
+    * BigQuery `project.dataset.table` → `{"project.dataset", "table"}`
+    * A catalog/schema/table engine → `{"catalog.schema", "table"}`
+
+  Adapters own that flattening in `parse_qualified_name/2` and
+  `resolve_table_namespace/3`; core treats the schema part as an opaque
+  string and compares it verbatim against visibility rules. The practical
+  consequence for adapter authors: a deny rule the host writes must match
+  the flattened form your adapter produces, so document the spelling your
+  adapter emits.
 
   ## Dispatch helpers
 
@@ -199,7 +225,7 @@ defmodule Lotus.Source.Adapter do
   @doc """
   Rewrite the statement after variable substitution.
 
-  Pipeline position: fires inside `Lotus.execute_with_options/7` **after**
+  Pipeline position: fires inside the execution pipeline **after**
   `{{var}}` placeholders have been resolved into `statement.params`, and
   **before** `apply_filters`, `apply_sorts`, and `apply_pagination` mutate
   the statement.
@@ -331,7 +357,7 @@ defmodule Lotus.Source.Adapter do
 
   **Security note.** Adapters that inline values are the only defense
   against injection at this layer. Never interpolate raw strings —
-  delegate to `Lotus.JSON.encode!/1` or an equivalent escaper for the target
+  delegate to `Lotus.JSON` or an equivalent escaper for the target
   language.
 
   Default (when not implemented): `{:error, :unsupported}`.
@@ -396,13 +422,16 @@ defmodule Lotus.Source.Adapter do
   Parse a qualified resource name into its hierarchy components.
 
   The return is an ordered list: the most-coarse component first, the leaf
-  last. Component count should match `hierarchy_label/1` depth.
+  last. At most two components — see "Relations are two-level" above; an
+  engine with a deeper hierarchy flattens the upper levels into the first
+  component.
 
   Examples across query languages:
 
     * SQL: `"public.users"` → `["public", "users"]`
     * Elasticsearch: `"logs-2025-01"` → `["logs-2025-01"]` (flat)
     * Mongo: `"mydb.users"` → `["mydb", "users"]`
+    * BigQuery: `"proj.ds.tbl"` → `["proj.ds", "tbl"]` (flattened)
 
   Used by discovery UIs and AI actions to route a user-supplied name to
   the right introspection call.
@@ -595,7 +624,7 @@ defmodule Lotus.Source.Adapter do
   Callers (`Lotus.AI.QueryOptimizer`) run this first so the adapter can
   resolve any `[[ ... ]]` optional clauses and replace `{{var}}`
   placeholders with language-appropriate null-ish literals (`NULL` for
-  SQL, `null` for JSON DSLs). The returned statement's `:text` must be
+  SQL, `null` for JSON DSLs). The returned statement's `:body` must be
   syntactically valid in the adapter's language without bound params
   so the engine's EXPLAIN / profile endpoint can parse it.
 

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -30,7 +30,7 @@ defmodule Lotus.Source.Adapter do
     * **Safety & visibility** — `builtin_denies/1`, `builtin_schema_denies/1`,
       `default_schemas/1`
     * **Lifecycle** — `health_check/1`, `disconnect/1`
-    * **Error handling** — `format_error/2`, `handled_errors/1`
+    * **Error handling** — `format_error/2`
     * **Source identity** — `source_type/1`, `supports_feature?/2`
 
   ## Pipeline Statement contract
@@ -491,15 +491,6 @@ defmodule Lotus.Source.Adapter do
   message. Called from `Lotus.Runner` when the execution phase raises.
   """
   @callback format_error(state :: term(), any()) :: String.t()
-
-  @doc """
-  Return the exception modules this adapter knows how to format.
-
-  Used by `Lotus.Runner`'s rescue clause to match a raised exception
-  against the adapter's `format_error/2`. Returning the narrow set the
-  adapter actually handles lets unrelated exceptions propagate.
-  """
-  @callback handled_errors(state :: term()) :: [module()]
 
   # ---------------------------------------------------------------------------
   # Callbacks — Source Identity
@@ -1158,12 +1149,6 @@ defmodule Lotus.Source.Adapter do
   @spec format_error(t(), any()) :: String.t()
   def format_error(%__MODULE__{module: mod, state: state}, error) do
     mod.format_error(state, error)
-  end
-
-  @doc "Return handled error modules via the adapter."
-  @spec handled_errors(t()) :: [module()]
-  def handled_errors(%__MODULE__{module: mod, state: state}) do
-    mod.handled_errors(state)
   end
 
   @doc "Return the source type via the adapter."

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -528,8 +528,45 @@ defmodule Lotus.Source.Adapter do
   @doc "Return the source type atom (e.g. `:postgres`, `:mysql`)."
   @callback source_type(state :: term()) :: source_type()
 
-  @doc "Whether this adapter supports a given feature."
-  @callback supports_feature?(state :: term(), atom()) :: boolean()
+  @typedoc """
+  A capability an adapter may declare through `supports_feature?/2`.
+
+  These are the atoms core and the built-in UI ask about. The type is open —
+  an adapter may answer questions about its own atoms, and callers that
+  invent one get `false` from any adapter that does not recognise it — but
+  these are the ones with defined meaning:
+
+    * `:schema_hierarchy` — the source has a real namespace level above
+      tables, so the UI shows a schema picker. False for flat sources
+      (SQLite, Elasticsearch); false for MySQL, whose databases are
+      configured per source rather than browsed.
+
+    * `:search_path` — the source honours a session-level namespace search
+      path, so a caller-supplied `:search_path` option is meaningful.
+
+    * `:arrays` — the query language has a first-class array type, so list
+      variables can bind as one value instead of being expanded into N
+      placeholders.
+
+    * `:json` — the source can store and query JSON documents, which the
+      editor uses to offer JSON-aware affordances.
+
+    * `:make_interval` — SQL-specific: the engine has a `make_interval`
+      function, so the transformer can rewrite `INTERVAL '{{n}} days'`
+      into a parameterized call instead of inlining the value.
+
+  Answer `false` for anything you do not recognise; the built-in dialects
+  all end with a catch-all clause that does exactly that.
+  """
+  @type feature ::
+          :schema_hierarchy | :search_path | :arrays | :json | :make_interval | atom()
+
+  @doc """
+  Whether this adapter supports a given feature.
+
+  See `t:feature/0` for the atoms core asks about and what each one means.
+  """
+  @callback supports_feature?(state :: term(), feature()) :: boolean()
 
   @doc """
   Return the query language identifier for this source.
@@ -855,7 +892,18 @@ defmodule Lotus.Source.Adapter do
     can_handle?: 1,
     wrap: 2,
     transform_statement: 2,
-    limit_query: 3
+    limit_query: 3,
+    list_schemas: 1,
+    resolve_table_namespace: 3,
+    query_plan: 3,
+    quote_identifier: 2,
+    apply_filters: 3,
+    apply_sorts: 3,
+    builtin_schema_denies: 1,
+    default_schemas: 1,
+    supports_feature?: 2,
+    db_type_to_lotus_type: 2,
+    editor_config: 1
   ]
 
   # Conservative fallback deny rules applied when no adapter can be resolved
@@ -930,7 +978,9 @@ defmodule Lotus.Source.Adapter do
   @doc "List all schemas via the adapter."
   @spec list_schemas(t()) :: {:ok, [String.t()]} | {:error, term()}
   def list_schemas(%__MODULE__{module: mod, state: state}) do
-    mod.list_schemas(state)
+    if function_exported?(mod, :list_schemas, 1),
+      do: mod.list_schemas(state),
+      else: {:ok, []}
   end
 
   @doc "List tables via the adapter."
@@ -951,14 +1001,18 @@ defmodule Lotus.Source.Adapter do
   @spec resolve_table_namespace(t(), String.t(), [String.t()]) ::
           {:ok, String.t() | nil} | {:error, term()}
   def resolve_table_namespace(%__MODULE__{module: mod, state: state}, table, schemas) do
-    mod.resolve_table_namespace(state, table, schemas)
+    if function_exported?(mod, :resolve_table_namespace, 3),
+      do: mod.resolve_table_namespace(state, table, schemas),
+      else: {:ok, nil}
   end
 
   @doc "Get the execution plan for a statement via the adapter."
   @spec query_plan(t(), Statement.t(), keyword()) ::
           {:ok, String.t() | nil} | {:error, term()}
   def query_plan(%__MODULE__{module: mod, state: state}, %Statement{} = statement, opts) do
-    mod.query_plan(state, statement, opts)
+    if function_exported?(mod, :query_plan, 3),
+      do: mod.query_plan(state, statement, opts),
+      else: {:ok, nil}
   end
 
   @doc "Return built-in deny rules via the adapter."
@@ -970,13 +1024,17 @@ defmodule Lotus.Source.Adapter do
   @doc "Return built-in schema denies via the adapter."
   @spec builtin_schema_denies(t()) :: [String.t() | Regex.t()]
   def builtin_schema_denies(%__MODULE__{module: mod, state: state}) do
-    mod.builtin_schema_denies(state)
+    if function_exported?(mod, :builtin_schema_denies, 1),
+      do: mod.builtin_schema_denies(state),
+      else: []
   end
 
   @doc "Return default schemas via the adapter."
   @spec default_schemas(t()) :: [String.t()]
   def default_schemas(%__MODULE__{module: mod, state: state}) do
-    mod.default_schemas(state)
+    if function_exported?(mod, :default_schemas, 1),
+      do: mod.default_schemas(state),
+      else: []
   end
 
   @doc "Check data source health via the adapter."
@@ -1066,7 +1124,9 @@ defmodule Lotus.Source.Adapter do
   @doc "Quote a SQL identifier via the adapter."
   @spec quote_identifier(t(), String.t()) :: String.t()
   def quote_identifier(%__MODULE__{module: mod, state: state}, identifier) do
-    mod.quote_identifier(state, identifier)
+    if function_exported?(mod, :quote_identifier, 2),
+      do: mod.quote_identifier(state, identifier),
+      else: identifier
   end
 
   @doc """
@@ -1163,7 +1223,9 @@ defmodule Lotus.Source.Adapter do
   def apply_filters(_adapter, %Statement{} = statement, []), do: statement
 
   def apply_filters(%__MODULE__{module: mod, state: state}, %Statement{} = statement, filters) do
-    mod.apply_filters(state, statement, filters)
+    if function_exported?(mod, :apply_filters, 3),
+      do: mod.apply_filters(state, statement, filters),
+      else: statement
   end
 
   @doc "Apply sorts to a statement via the adapter. Empty sorts short-circuit."
@@ -1171,7 +1233,9 @@ defmodule Lotus.Source.Adapter do
   def apply_sorts(_adapter, %Statement{} = statement, []), do: statement
 
   def apply_sorts(%__MODULE__{module: mod, state: state}, %Statement{} = statement, sorts) do
-    mod.apply_sorts(state, statement, sorts)
+    if function_exported?(mod, :apply_sorts, 3),
+      do: mod.apply_sorts(state, statement, sorts),
+      else: statement
   end
 
   @doc "Format an error via the adapter."
@@ -1189,7 +1253,7 @@ defmodule Lotus.Source.Adapter do
   @doc "Check feature support via the adapter."
   @spec supports_feature?(t(), atom()) :: boolean()
   def supports_feature?(%__MODULE__{module: mod, state: state}, feature) do
-    mod.supports_feature?(state, feature)
+    function_exported?(mod, :supports_feature?, 2) and mod.supports_feature?(state, feature)
   end
 
   @doc "Return the query language identifier via the adapter."
@@ -1412,6 +1476,16 @@ defmodule Lotus.Source.Adapter do
   @editor_config_max_context_schema_root 200
   @editor_config_max_context_schema_children 500
 
+  # Editor shape for adapters that declare no editor support: the query
+  # editor renders plain text with no completions rather than crashing.
+  @empty_editor_config %{
+    language: "",
+    keywords: [],
+    types: [],
+    functions: [],
+    context_boundaries: []
+  }
+
   @editor_config_known_keys [
     :language,
     :keywords,
@@ -1434,7 +1508,11 @@ defmodule Lotus.Source.Adapter do
   """
   @spec editor_config(t()) :: map()
   def editor_config(%__MODULE__{module: mod, state: state}) do
-    state |> mod.editor_config() |> sanitize_editor_config(mod)
+    if function_exported?(mod, :editor_config, 1) do
+      state |> mod.editor_config() |> sanitize_editor_config(mod)
+    else
+      @empty_editor_config
+    end
   end
 
   defp sanitize_editor_config(config, mod) when is_map(config) do
@@ -1563,6 +1641,8 @@ defmodule Lotus.Source.Adapter do
   @doc "Map a database type to a Lotus type via the adapter."
   @spec db_type_to_lotus_type(t(), String.t()) :: atom()
   def db_type_to_lotus_type(%__MODULE__{module: mod, state: state}, db_type) do
-    mod.db_type_to_lotus_type(state, db_type)
+    if function_exported?(mod, :db_type_to_lotus_type, 2),
+      do: mod.db_type_to_lotus_type(state, db_type),
+      else: :text
   end
 end

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -173,6 +173,26 @@ defmodule Lotus.Source.Adapter do
   # Callbacks — SQL Generation
   # ---------------------------------------------------------------------------
 
+  @doc """
+  Return statistics for a relation.
+
+  At minimum a `:row_count`; adapters may add their own keys (on-disk size,
+  segment counts, a last-analyzed timestamp) and callers should tolerate
+  extras.
+
+  `Lotus.Schema.get_table_stats/3` calls this when the adapter implements
+  it. Otherwise it falls back to `SELECT COUNT(*)` against the quoted
+  relation name, which only makes sense for SQL sources — a non-SQL adapter
+  should implement this callback rather than inherit that fallback.
+
+  Return `{:error, :unsupported}` for an engine that exposes no such
+  statistic; callers treat it as "no stats available".
+
+  Default (when not implemented): `{:error, :unsupported}`.
+  """
+  @callback table_stats(state :: term(), schema :: String.t() | nil, table :: String.t()) ::
+              {:ok, map()} | {:error, term()}
+
   @doc "Quote a SQL identifier (column, table, schema name) using source-specific syntax."
   @callback quote_identifier(state :: term(), String.t()) :: String.t()
 
@@ -903,7 +923,8 @@ defmodule Lotus.Source.Adapter do
     default_schemas: 1,
     supports_feature?: 2,
     db_type_to_lotus_type: 2,
-    editor_config: 1
+    editor_config: 1,
+    table_stats: 3
   ]
 
   # Conservative fallback deny rules applied when no adapter can be resolved
@@ -1027,6 +1048,14 @@ defmodule Lotus.Source.Adapter do
     if function_exported?(mod, :builtin_schema_denies, 1),
       do: mod.builtin_schema_denies(state),
       else: []
+  end
+
+  @doc "Return statistics for a relation via the adapter."
+  @spec table_stats(t(), String.t() | nil, String.t()) :: {:ok, map()} | {:error, term()}
+  def table_stats(%__MODULE__{module: mod, state: state}, schema, table) do
+    if function_exported?(mod, :table_stats, 3),
+      do: mod.table_stats(state, schema, table),
+      else: {:error, :unsupported}
   end
 
   @doc "Return default schemas via the adapter."

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -19,7 +19,7 @@ defmodule Lotus.Source.Adapter do
     * **Query execution** — `execute_query/4`, `transaction/3`
     * **Introspection** — `list_schemas/1`, `list_tables/3`, `describe_table/3`,
       `resolve_table_namespace/3`
-    * **SQL generation** — `quote_identifier/2`, `query_plan/4`
+    * **SQL generation** — `quote_identifier/2`, `query_plan/3`
     * **Pipeline** — `transform_statement/2`, `transform_bound_query/3`,
       `apply_filters/3`, `apply_sorts/3`, `apply_pagination/3`,
       `needs_preflight?/2`, `sanitize_query/3`,
@@ -170,8 +170,11 @@ defmodule Lotus.Source.Adapter do
   cheaply) may legitimately return `{:ok, nil}` or `{:error, :unsupported}`;
   Lotus callers treat both as "no plan available" without surfacing an
   error to the user.
+
+  The statement carries its own bound values in `statement.params`; there is
+  no separate params argument.
   """
-  @callback query_plan(state :: term(), sql :: String.t(), params :: list(), opts :: keyword()) ::
+  @callback query_plan(state :: term(), statement :: Statement.t(), opts :: keyword()) ::
               {:ok, String.t() | nil} | {:error, term()}
 
   # ---------------------------------------------------------------------------
@@ -595,7 +598,7 @@ defmodule Lotus.Source.Adapter do
   @callback ai_context(state :: term()) :: {:ok, ai_context_map()} | {:error, term()}
 
   @doc """
-  Return a statement safe to pass to `query_plan/4` for optimization
+  Return a statement safe to pass to `query_plan/3` for optimization
   analysis.
 
   Callers (`Lotus.AI.QueryOptimizer`) run this first so the adapter can
@@ -928,11 +931,11 @@ defmodule Lotus.Source.Adapter do
     mod.resolve_table_namespace(state, table, schemas)
   end
 
-  @doc "Get the execution plan for a query via the adapter."
-  @spec query_plan(t(), String.t(), list(), keyword()) ::
+  @doc "Get the execution plan for a statement via the adapter."
+  @spec query_plan(t(), Statement.t(), keyword()) ::
           {:ok, String.t() | nil} | {:error, term()}
-  def query_plan(%__MODULE__{module: mod, state: state}, sql, params, opts) do
-    mod.query_plan(state, sql, params, opts)
+  def query_plan(%__MODULE__{module: mod, state: state}, %Statement{} = statement, opts) do
+    mod.query_plan(state, statement, opts)
   end
 
   @doc "Return built-in deny rules via the adapter."

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -204,8 +204,8 @@ defmodule Lotus.Source.Adapters.Ecto do
       def apply_sorts(_repo, statement, sorts), do: @dialect.apply_sorts(statement, sorts)
 
       @impl true
-      def query_plan(repo, sql, params, opts),
-        do: @dialect.query_plan(repo, sql, params, opts)
+      def query_plan(repo, statement, opts),
+        do: @dialect.query_plan(repo, statement, opts)
     end
   end
 
@@ -523,8 +523,8 @@ defmodule Lotus.Source.Adapters.Ecto do
   end
 
   @impl true
-  def query_plan(repo, sql, params, opts) do
-    @default_dialect.query_plan(repo, sql, params, opts)
+  def query_plan(repo, statement, opts) do
+    @default_dialect.query_plan(repo, statement, opts)
   end
 
   # ---------------------------------------------------------------------------
@@ -865,7 +865,7 @@ defmodule Lotus.Source.Adapters.Ecto do
   def do_validate_statement(
         dialect,
         repo,
-        %Statement{body: sql, params: params},
+        %Statement{body: sql} = statement,
         _opts
       )
       when is_binary(sql) do
@@ -874,7 +874,7 @@ defmodule Lotus.Source.Adapters.Ecto do
       |> OptionalClause.strip_brackets()
       |> Variables.neutralize("NULL")
 
-    case dialect.query_plan(repo, neutralized, params, []) do
+    case dialect.query_plan(repo, %{statement | body: neutralized}, []) do
       {:ok, _plan} -> :ok
       {:error, reason} when is_binary(reason) -> {:error, reason}
       {:error, reason} -> {:error, inspect(reason)}

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -676,7 +676,7 @@ defmodule Lotus.Source.Adapters.Ecto do
     dialect.execute_in_transaction(
       repo,
       fn ->
-        if search_path do
+        if search_path && function_exported?(dialect, :set_search_path, 2) do
           dialect.set_search_path(repo, search_path)
         end
 

--- a/lib/lotus/source/adapters/ecto.ex
+++ b/lib/lotus/source/adapters/ecto.ex
@@ -232,9 +232,6 @@ defmodule Lotus.Source.Adapters.Ecto do
 
       @impl true
       def format_error(_repo, error), do: @dialect.format_error(error)
-
-      @impl true
-      def handled_errors(_repo), do: @dialect.handled_errors()
     end
   end
 
@@ -566,11 +563,6 @@ defmodule Lotus.Source.Adapters.Ecto do
   @impl true
   def format_error(_repo, error) do
     @default_dialect.format_error(error)
-  end
-
-  @impl true
-  def handled_errors(_repo) do
-    @default_dialect.handled_errors()
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/lotus/source/adapters/ecto/dialect.ex
+++ b/lib/lotus/source/adapters/ecto/dialect.ex
@@ -1,5 +1,53 @@
 defmodule Lotus.Source.Adapters.Ecto.Dialect do
-  @moduledoc false
+  @moduledoc """
+  The SQL-specific half of an Ecto-backed data source.
+
+  `Lotus.Source.Adapter` is the adapter-agnostic contract every data source
+  implements. A dialect is narrower: it supplies the parts that differ between
+  *SQL* engines behind an `Ecto.Repo` — identifier quoting, parameter
+  placeholders, `EXPLAIN` syntax, catalogue introspection queries, and the
+  built-in deny rules for each engine's system tables.
+
+  Pair a dialect with the `Lotus.Source.Adapters.Ecto` macro and the adapter
+  is a one-liner:
+
+      defmodule LotusMSSql.Dialect do
+        @behaviour Lotus.Source.Adapters.Ecto.Dialect
+
+        # ... callbacks ...
+      end
+
+      defmodule LotusMSSql.Adapter do
+        use Lotus.Source.Adapters.Ecto, dialect: LotusMSSql.Dialect
+      end
+
+  The macro injects every `Lotus.Source.Adapter` callback, routing the shared
+  Ecto plumbing through `Lotus.Source.Adapters.Ecto` and the engine-specific
+  parts through your dialect. All of them are `defoverridable`, so a dialect
+  that needs to escape the macro's assumptions can implement the adapter
+  callback directly.
+
+  ## When not to write a dialect
+
+  A dialect is for SQL over Ecto. A data source that is not SQL, or not
+  reached through an `Ecto.Repo`, implements `Lotus.Source.Adapter` directly
+  instead — see the [Source Adapters guide](source-adapters.md). Elasticsearch
+  is the worked example of that path.
+
+  ## Statement shape
+
+  Pipeline callbacks take and return `%Lotus.Query.Statement{}`. For a
+  dialect, `statement.body` is always SQL text and `statement.params` the
+  bound values in the order the driver expects.
+
+  ## Optional callbacks
+
+  Everything in `@optional_callbacks` has a safe default, so a minimal
+  dialect only implements what its engine actually needs. Notably
+  `set_statement_timeout/2` and `set_search_path/2` are optional: engines
+  with no session-level timeout or schema search path simply omit them
+  rather than defining no-op clauses.
+  """
 
   alias Lotus.Query.Statement
 
@@ -10,7 +58,22 @@ defmodule Lotus.Source.Adapters.Ecto.Dialect do
   # ---------------------------------------------------------------------------
 
   @callback execute_in_transaction(repo, (-> any()), keyword()) :: {:ok, any()} | {:error, any()}
+
+  @doc """
+  Apply a session-level statement timeout.
+
+  Optional. Engines with no such notion omit it and Lotus relies on the
+  driver-level `:timeout` passed to `execute_query/4` instead.
+  """
   @callback set_statement_timeout(repo, non_neg_integer()) :: :ok | no_return()
+
+  @doc """
+  Apply a session-level schema search path.
+
+  Optional. Called inside the query transaction when the caller supplies
+  `:search_path`. Engines without a search path omit it, and Lotus ignores
+  the option for that source.
+  """
   @callback set_search_path(repo, String.t()) :: :ok | no_return()
 
   # ---------------------------------------------------------------------------
@@ -175,6 +238,8 @@ defmodule Lotus.Source.Adapters.Ecto.Dialect do
   @callback ai_context() :: {:ok, Lotus.Source.Adapter.ai_context_map()} | {:error, term()}
 
   @optional_callbacks [
+    set_statement_timeout: 2,
+    set_search_path: 2,
     supports_feature?: 1,
     hierarchy_label: 0,
     example_query: 2,

--- a/lib/lotus/source/adapters/ecto/dialect.ex
+++ b/lib/lotus/source/adapters/ecto/dialect.ex
@@ -18,8 +18,6 @@ defmodule Lotus.Source.Adapters.Ecto.Dialect do
   # ---------------------------------------------------------------------------
 
   @callback format_error(any()) :: String.t()
-  @callback handled_errors() :: [module()]
-
   # ---------------------------------------------------------------------------
   # Required callbacks — SQL generation
   # ---------------------------------------------------------------------------

--- a/lib/lotus/source/adapters/ecto/dialect.ex
+++ b/lib/lotus/source/adapters/ecto/dialect.ex
@@ -88,7 +88,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialect do
   @callback source_type() :: :postgres | :mysql | :sqlite | :other | atom()
   @callback ecto_adapter() :: module() | nil
   @callback query_language() :: String.t()
-  @callback limit_query(statement :: String.t(), limit :: pos_integer()) :: String.t()
+  @callback limit_query(statement :: Statement.t(), limit :: pos_integer()) :: Statement.t()
 
   # ---------------------------------------------------------------------------
   # Optional callbacks — Source identity

--- a/lib/lotus/source/adapters/ecto/dialect.ex
+++ b/lib/lotus/source/adapters/ecto/dialect.ex
@@ -44,7 +44,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialect do
   @callback apply_sorts(statement :: Statement.t(), sorts :: [Lotus.Query.Sort.t()]) ::
               Statement.t()
 
-  @callback query_plan(repo, sql :: String.t(), params :: list(), opts :: keyword()) ::
+  @callback query_plan(repo, statement :: Statement.t(), opts :: keyword()) ::
               {:ok, String.t() | nil} | {:error, term()}
 
   # ---------------------------------------------------------------------------

--- a/lib/lotus/source/adapters/ecto/dialects/default.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/default.ex
@@ -121,8 +121,8 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Default do
   def query_language, do: "sql"
 
   @impl true
-  def limit_query(statement, limit) do
-    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  def limit_query(%Statement{body: body} = statement, limit) do
+    %{statement | body: "SELECT * FROM (#{body}) AS limited_query LIMIT #{limit}"}
   end
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/default.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/default.ex
@@ -115,9 +115,6 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Default do
   end
 
   @impl true
-  def handled_errors, do: []
-
-  @impl true
   def query_language, do: "sql"
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/default.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/default.ex
@@ -163,7 +163,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Default do
   end
 
   @impl true
-  def query_plan(_repo, _sql, _params, _opts) do
+  def query_plan(_repo, %Statement{}, _opts) do
     {:error, "EXPLAIN not supported for this database adapter"}
   end
 

--- a/lib/lotus/source/adapters/ecto/dialects/default.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/default.ex
@@ -15,7 +15,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Default do
     * `set_statement_timeout/2` is a no-op, so user-configured statement
       timeouts have no effect.
     * `extract_accessed_resources/4` is not implemented, so
-      `Lotus.Preflight.authorize/4` short-circuits to `:ok` — visibility rules
+      `Lotus.Preflight.authorize/3` short-circuits to `:ok` — visibility rules
       are **not** checked against the tables the query touches.
     * `list_schemas/1`, `list_tables/3`, and `describe_table/3` return
       empty lists — the schema browser will be blank.

--- a/lib/lotus/source/adapters/ecto/dialects/mysql.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/mysql.ex
@@ -184,9 +184,6 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.MySQL do
   end
 
   @impl true
-  def handled_errors, do: [MyXQL.Error]
-
-  @impl true
   def query_language, do: "sql:mysql"
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/mysql.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/mysql.ex
@@ -145,9 +145,6 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.MySQL do
   end
 
   @impl true
-  def set_search_path(_repo, _search_path), do: :ok
-
-  @impl true
   def format_error(%{__struct__: mod} = e) when mod == MyXQL.Error do
     case e do
       %{mysql: %{code: code, message: message}} when is_integer(code) and is_binary(message) ->

--- a/lib/lotus/source/adapters/ecto/dialects/mysql.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/mysql.ex
@@ -353,7 +353,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.MySQL do
   end
 
   @impl true
-  def query_plan(repo, sql, params, _opts) do
+  def query_plan(repo, %Statement{body: sql, params: params}, _opts) do
     explain_sql = "EXPLAIN FORMAT=JSON " <> sql
 
     case repo.query(explain_sql, params) do

--- a/lib/lotus/source/adapters/ecto/dialects/mysql.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/mysql.ex
@@ -1,5 +1,15 @@
 defmodule Lotus.Source.Adapters.Ecto.Dialects.MySQL do
-  @moduledoc false
+  @moduledoc """
+  MySQL dialect for `Lotus.Source.Adapters.Ecto`.
+
+  MySQL has no schema-within-database concept, so databases serve as
+  namespaces. Query plans come from `EXPLAIN FORMAT=JSON`, and the
+  statement timeout is applied as `max_execution_time`. There is no search
+  path, so `set_search_path/2` is not implemented.
+
+  Read alongside `Lotus.Source.Adapters.Ecto.Dialect` when writing a dialect
+  for another SQL engine — this module is the reference implementation.
+  """
 
   @behaviour Lotus.Source.Adapters.Ecto.Dialect
 

--- a/lib/lotus/source/adapters/ecto/dialects/mysql.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/mysql.ex
@@ -219,8 +219,8 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.MySQL do
   end
 
   @impl true
-  def limit_query(statement, limit) do
-    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  def limit_query(%Statement{body: body} = statement, limit) do
+    %{statement | body: "SELECT * FROM (#{body}) AS limited_query LIMIT #{limit}"}
   end
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/postgres.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/postgres.ex
@@ -1,5 +1,14 @@
 defmodule Lotus.Source.Adapters.Ecto.Dialects.Postgres do
-  @moduledoc false
+  @moduledoc """
+  PostgreSQL dialect for `Lotus.Source.Adapters.Ecto`.
+
+  Namespaces are PostgreSQL schemas. Query plans come from
+  `EXPLAIN (FORMAT JSON)`, run inside a read-only transaction.
+  `set_search_path/2` and `set_statement_timeout/2` are both honoured.
+
+  Read alongside `Lotus.Source.Adapters.Ecto.Dialect` when writing a dialect
+  for another SQL engine — this module is the reference implementation.
+  """
 
   @behaviour Lotus.Source.Adapters.Ecto.Dialect
 

--- a/lib/lotus/source/adapters/ecto/dialects/postgres.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/postgres.ex
@@ -138,8 +138,8 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Postgres do
   end
 
   @impl true
-  def limit_query(statement, limit) do
-    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  def limit_query(%Statement{body: body} = statement, limit) do
+    %{statement | body: "SELECT * FROM (#{body}) AS limited_query LIMIT #{limit}"}
   end
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/postgres.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/postgres.ex
@@ -268,7 +268,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Postgres do
   end
 
   @impl true
-  def query_plan(repo, sql, params, opts) do
+  def query_plan(repo, %Statement{body: sql, params: params}, opts) do
     explain_sql = "EXPLAIN (FORMAT JSON) " <> sql
     search_path = Keyword.get(opts, :search_path)
 

--- a/lib/lotus/source/adapters/ecto/dialects/postgres.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/postgres.ex
@@ -98,9 +98,6 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Postgres do
   end
 
   @impl true
-  def handled_errors, do: [Postgrex.Error]
-
-  @impl true
   def query_language, do: "sql:postgres"
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
@@ -83,12 +83,6 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
   end
 
   @impl true
-  def set_statement_timeout(_repo, _timeout_ms), do: :ok
-
-  @impl true
-  def set_search_path(_repo, _search_path), do: :ok
-
-  @impl true
   def format_error(%{__struct__: mod} = e) when mod == Exqlite.Error do
     "SQLite Error: " <> (Map.get(e, :message) || Exception.message(e))
   end

--- a/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
@@ -139,8 +139,8 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
   end
 
   @impl true
-  def limit_query(statement, limit) do
-    "SELECT * FROM (#{statement}) AS limited_query LIMIT #{limit}"
+  def limit_query(%Statement{body: body} = statement, limit) do
+    %{statement | body: "SELECT * FROM (#{body}) AS limited_query LIMIT #{limit}"}
   end
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
@@ -104,9 +104,6 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
   end
 
   @impl true
-  def handled_errors, do: [Exqlite.Error]
-
-  @impl true
   def query_language, do: "sql:sqlite"
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
@@ -1,5 +1,15 @@
 defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
-  @moduledoc false
+  @moduledoc """
+  SQLite dialect for `Lotus.Source.Adapters.Ecto`.
+
+  SQLite has a flat namespace: `list_schemas/1` returns `[]` and every
+  relation is `{nil, table}`. Query plans come from `EXPLAIN QUERY PLAN`.
+  Neither a session timeout nor a search path exists, so both hooks are
+  omitted.
+
+  Read alongside `Lotus.Source.Adapters.Ecto.Dialect` when writing a dialect
+  for another SQL engine — this module is the reference implementation.
+  """
 
   @behaviour Lotus.Source.Adapters.Ecto.Dialect
 

--- a/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
@@ -230,7 +230,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
   end
 
   @impl true
-  def query_plan(repo, sql, params, _opts) do
+  def query_plan(repo, %Statement{body: sql, params: params}, _opts) do
     explain_sql = "EXPLAIN QUERY PLAN " <> sql
 
     case repo.query(explain_sql, params) do

--- a/lib/lotus/source/adapters/ecto/sql/validator.ex
+++ b/lib/lotus/source/adapters/ecto/sql/validator.ex
@@ -8,6 +8,7 @@ defmodule Lotus.Source.Adapters.Ecto.SQL.Validator do
   """
 
   alias Lotus.Query.OptionalClause
+  alias Lotus.Query.Statement
   alias Lotus.Source
   alias Lotus.Source.Adapter
   alias Lotus.Variables
@@ -44,7 +45,7 @@ defmodule Lotus.Source.Adapters.Ecto.SQL.Validator do
     # through Source.name_from_module!/1 first.
     adapter = resolve_adapter(data_source)
 
-    case Adapter.query_plan(adapter, neutralized, [], []) do
+    case Adapter.query_plan(adapter, Statement.new(neutralized), []) do
       {:ok, _plan} -> :ok
       {:error, reason} when is_binary(reason) -> {:error, reason}
       {:error, reason} -> {:error, inspect(reason)}

--- a/lib/lotus/source/adapters/mysql.ex
+++ b/lib/lotus/source/adapters/mysql.ex
@@ -1,5 +1,14 @@
 defmodule Lotus.Source.Adapters.MySQL do
-  @moduledoc false
+  @moduledoc """
+  MySQL data source, built on `Lotus.Source.Adapters.Ecto`.
+
+  Resolved automatically for any repo whose Ecto adapter is
+  `Ecto.Adapters.MyXQL`, so hosts normally never name this module —
+  they configure the repo and Lotus wraps it.
+
+  Dialect behaviour comes from
+  `Lotus.Source.Adapters.Ecto.Dialects.MySQL`: databases-as-schemas, `EXPLAIN FORMAT=JSON` query plans, and `max_execution_time` as the statement timeout.
+  """
 
   use Lotus.Source.Adapters.Ecto,
     dialect: Lotus.Source.Adapters.Ecto.Dialects.MySQL

--- a/lib/lotus/source/adapters/postgres.ex
+++ b/lib/lotus/source/adapters/postgres.ex
@@ -1,5 +1,14 @@
 defmodule Lotus.Source.Adapters.Postgres do
-  @moduledoc false
+  @moduledoc """
+  PostgreSQL data source, built on `Lotus.Source.Adapters.Ecto`.
+
+  Resolved automatically for any repo whose Ecto adapter is
+  `Ecto.Adapters.Postgres`, so hosts normally never name this module —
+  they configure the repo and Lotus wraps it.
+
+  Dialect behaviour comes from
+  `Lotus.Source.Adapters.Ecto.Dialects.Postgres`: schemas, `EXPLAIN (FORMAT JSON)` query plans, a session `search_path`, and `statement_timeout`.
+  """
 
   use Lotus.Source.Adapters.Ecto,
     dialect: Lotus.Source.Adapters.Ecto.Dialects.Postgres

--- a/lib/lotus/source/adapters/sqlite.ex
+++ b/lib/lotus/source/adapters/sqlite.ex
@@ -1,5 +1,14 @@
 defmodule Lotus.Source.Adapters.SQLite3 do
-  @moduledoc false
+  @moduledoc """
+  SQLite data source, built on `Lotus.Source.Adapters.Ecto`.
+
+  Resolved automatically for any repo whose Ecto adapter is
+  `Ecto.Adapters.SQLite3`, so hosts normally never name this module —
+  they configure the repo and Lotus wraps it.
+
+  Dialect behaviour comes from
+  `Lotus.Source.Adapters.Ecto.Dialects.SQLite3`: a flat namespace (no schemas) and `EXPLAIN QUERY PLAN` query plans.
+  """
 
   use Lotus.Source.Adapters.Ecto,
     dialect: Lotus.Source.Adapters.Ecto.Dialects.SQLite3

--- a/lib/lotus/source/resolvers/static.ex
+++ b/lib/lotus/source/resolvers/static.ex
@@ -2,7 +2,7 @@ defmodule Lotus.Source.Resolvers.Static do
   @moduledoc """
   Default source resolver that reads from static `data_sources` configuration.
 
-  Preserves the resolution priority logic from `Lotus.Sources.resolve!/2`:
+  Resolution priority:
 
     1. `source_opt` as string name — lookup in data_sources, wrap in adapter
     2. `source_opt` as module — reverse lookup (find name for module), wrap in adapter
@@ -10,6 +10,23 @@ defmodule Lotus.Source.Resolvers.Static do
     4. `fallback` as module — reverse lookup
     5. Both nil — use `Config.default_data_source()`
     6. Not found — `{:error, :not_found}`
+
+  ## Entry forms
+
+  A `:data_sources` entry is one of:
+
+    * an `Ecto.Repo` module — matched against the built-in Ecto adapters by
+      the repo's Ecto adapter, falling back to the generic Ecto adapter.
+
+    * `%{adapter: MyAdapter, ...}` — the **canonical** form. The named module
+      is used directly; the whole map is passed to its `wrap/2` as state.
+      Prefer this: it is explicit, skips `can_handle?/1` probing, and cannot
+      become ambiguous.
+
+    * any other term — offered to each module in `:source_adapters` via
+      `can_handle?/1`. Exactly one must claim it. If several do, resolution
+      raises rather than silently picking the first; name the adapter in the
+      entry to settle it.
   """
 
   @behaviour Lotus.Source.Resolver
@@ -36,8 +53,18 @@ defmodule Lotus.Source.Resolvers.Static do
       source_module?(fallback) ->
         lookup_by_module(fallback)
 
-      true ->
+      is_nil(source_opt) and is_nil(fallback) ->
         {:ok, default_adapter()}
+
+      # Neither position could be resolved, but at least one of them named
+      # something. Falling through to the default source here would run the
+      # query against the wrong database: a typo in a saved query's
+      # `data_source`, or a source dropped from config, would quietly
+      # return rows from somewhere else. Callers see :not_found instead,
+      # which `Lotus.Source.resolve!/2` turns into a message listing the
+      # configured source names.
+      true ->
+        {:error, :not_found}
     end
   end
 
@@ -82,7 +109,49 @@ defmodule Lotus.Source.Resolvers.Static do
     end
   end
 
-  defp wrap_entry(name, entry) do
+  # An entry may name its adapter outright — `%{adapter: MyAdapter, ...}` —
+  # which is the canonical form: no `can_handle?/1` probing, no ambiguity,
+  # and the whole entry is handed to the adapter as its state.
+  defp wrap_entry(name, %{adapter: adapter_mod} = entry) when is_atom(adapter_mod) do
+    if module_name?(adapter_mod) do
+      wrap_named_adapter(name, adapter_mod, entry)
+    else
+      wrap_by_probing(name, entry)
+    end
+  end
+
+  defp wrap_entry(name, entry), do: wrap_by_probing(name, entry)
+
+  defp wrap_named_adapter(name, adapter_mod, entry) do
+    unless Code.ensure_loaded?(adapter_mod) and function_exported?(adapter_mod, :wrap, 2) do
+      raise ArgumentError, """
+      Data source #{inspect(name)} names #{inspect(adapter_mod)} as its adapter,
+      but that module is not loaded or does not export `wrap/2`.
+
+      The configured entry was:
+
+          #{inspect(entry)}
+
+      Check the module name for typos and make sure the library providing it
+      is listed in your dependencies.
+      """
+    end
+
+    adapter_mod.wrap(name, entry)
+  end
+
+  # Distinguishes `%{adapter: MyApp.Adapter}` — a module reference — from
+  # `%{adapter: :some_tag}`, where the host is using `:adapter` as its own
+  # discriminator and expects `can_handle?/1` probing. Elixir module atoms
+  # are `Elixir.`-prefixed, so Module.split/1 succeeds only for those.
+  defp module_name?(atom) do
+    Module.split(atom)
+    true
+  rescue
+    ArgumentError -> false
+  end
+
+  defp wrap_by_probing(name, entry) do
     case find_adapter(entry) do
       {:ok, adapter_mod} ->
         adapter_mod.wrap(name, entry)
@@ -92,6 +161,22 @@ defmodule Lotus.Source.Resolvers.Static do
         # dialects by wrapping them with a default source_type.
         EctoAdapter.wrap(name, entry)
 
+      {:ambiguous, mods} ->
+        raise ArgumentError, """
+        More than one source adapter claims data source #{inspect(name)}.
+
+        These adapters all returned true from `can_handle?/1`:
+
+        #{Enum.map_join(mods, "\n", &"    * #{inspect(&1)}")}
+
+        Probing cannot decide between them. Name the adapter you want in the
+        entry itself:
+
+            #{inspect(name)} => %{adapter: #{inspect(hd(mods))}, ...}
+
+        A named adapter is used directly and skips `can_handle?/1` entirely.
+        """
+
       :none ->
         raise ArgumentError, """
         No source adapter can handle data source #{inspect(name)}.
@@ -100,9 +185,10 @@ defmodule Lotus.Source.Resolvers.Static do
 
             #{inspect(entry)}
 
-        For non-Ecto sources (maps, tuples, etc.), configure a matching
-        adapter in `:lotus, :source_adapters` and ensure its `can_handle?/1`
-        returns true for this entry.
+        For non-Ecto sources (maps, tuples, etc.), either name the adapter in
+        the entry — `%{adapter: MyAdapter, ...}` — or configure it in
+        `:lotus, :source_adapters` with a `can_handle?/1` that returns true
+        for this entry.
         """
     end
   end
@@ -110,9 +196,10 @@ defmodule Lotus.Source.Resolvers.Static do
   defp find_adapter(entry) do
     all_adapters = Config.source_adapters() ++ EctoAdapter.builtin_adapters()
 
-    case Enum.find(all_adapters, & &1.can_handle?(entry)) do
-      nil -> :none
-      mod -> {:ok, mod}
+    case Enum.filter(all_adapters, & &1.can_handle?(entry)) do
+      [] -> :none
+      [mod] -> {:ok, mod}
+      mods -> {:ambiguous, mods}
     end
   end
 

--- a/lib/lotus/telemetry.ex
+++ b/lib/lotus/telemetry.ex
@@ -18,9 +18,9 @@ defmodule Lotus.Telemetry do
 
   **Metadata:**
 
-    * `:repo` - The Ecto repo module
-    * `:sql` - The SQL statement being executed
-    * `:params` - The query parameters
+    * `:source` - The data source name (e.g. `"main"`, `"warehouse"`)
+    * `:statement` - The `Lotus.Query.Statement` being executed. Its `:body`
+      is the adapter-native payload and `:params` the bound values.
     * `:context` - The caller-supplied context (or `nil`)
 
   ### `[:lotus, :query, :stop]`
@@ -34,9 +34,8 @@ defmodule Lotus.Telemetry do
 
   **Metadata:**
 
-    * `:repo` - The Ecto repo module
-    * `:sql` - The SQL statement that was executed
-    * `:params` - The query parameters
+    * `:source` - The data source name
+    * `:statement` - The `Lotus.Query.Statement` that was executed
     * `:context` - The caller-supplied context (or `nil`)
     * `:result` - The `Lotus.Result` struct
 
@@ -50,9 +49,8 @@ defmodule Lotus.Telemetry do
 
   **Metadata:**
 
-    * `:repo` - The Ecto repo module
-    * `:sql` - The SQL statement that was executed
-    * `:params` - The query parameters
+    * `:source` - The data source name
+    * `:statement` - The `Lotus.Query.Statement` that was executed
     * `:context` - The caller-supplied context (or `nil`)
     * `:kind` - The kind of exception (`:error`, `:exit`, or `:throw`)
     * `:reason` - The exception or error reason

--- a/mix.exs
+++ b/mix.exs
@@ -100,7 +100,13 @@ defmodule Lotus.MixProject do
         "Query Storage": [Lotus.Storage, Lotus.Storage.Query, Lotus.Storage.QueryVariable],
         "Query Execution": [Lotus.Runner, Lotus.Result, Lotus.Preflight],
         "Data Export": [Lotus.Export, ~r/Lotus\.Export\..+/],
-        "Data Sources": [Lotus.Source, Lotus.Sources, ~r/Lotus\.Sources\..+/],
+        "Data Sources": [Lotus.Source, Lotus.Source.Adapter, Lotus.Source.Resolver],
+        "Adapter Authoring": [
+          Lotus.Query.Statement,
+          Lotus.Source.Adapters.Ecto,
+          Lotus.Source.Adapters.Ecto.Dialect,
+          ~r/Lotus\.Source\.Adapters\..+/
+        ],
         "Schema Introspection": [Lotus.Schema, Lotus.Visibility],
         Telemetry: [Lotus.Telemetry],
         Caching: [Lotus.Cache, ~r/Lotus\.Cache\..+/],

--- a/test/lotus/ai/actions/describe_table_test.exs
+++ b/test/lotus/ai/actions/describe_table_test.exs
@@ -7,7 +7,7 @@ defmodule Lotus.AI.Actions.DescribeTableTest do
 
   describe "run/2" do
     test "returns column details for a table" do
-      stub(Lotus.Schema, :describe_table, fn _source, _table ->
+      stub(Lotus.Schema, :describe_table, fn _source, _table, _opts ->
         {:ok, users_table_schema()}
       end)
 
@@ -51,7 +51,7 @@ defmodule Lotus.AI.Actions.DescribeTableTest do
     end
 
     test "returns error when table not found" do
-      stub(Lotus.Schema, :describe_table, fn _source, _table ->
+      stub(Lotus.Schema, :describe_table, fn _source, _table, _opts ->
         {:error, "Table not found"}
       end)
 

--- a/test/lotus/ai/actions/list_schemas_test.exs
+++ b/test/lotus/ai/actions/list_schemas_test.exs
@@ -5,7 +5,7 @@ defmodule Lotus.AI.Actions.ListSchemasTest do
 
   describe "run/2" do
     test "returns list of schemas" do
-      stub(Lotus.Schema, :list_schemas, fn _source ->
+      stub(Lotus.Schema, :list_schemas, fn _source, _opts ->
         {:ok, ["public", "reporting", "analytics"]}
       end)
 
@@ -14,7 +14,7 @@ defmodule Lotus.AI.Actions.ListSchemasTest do
     end
 
     test "returns error when schema introspection fails" do
-      stub(Lotus.Schema, :list_schemas, fn _source ->
+      stub(Lotus.Schema, :list_schemas, fn _source, _opts ->
         {:error, "Connection failed"}
       end)
 

--- a/test/lotus/ai/actions/list_tables_test.exs
+++ b/test/lotus/ai/actions/list_tables_test.exs
@@ -7,7 +7,7 @@ defmodule Lotus.AI.Actions.ListTablesTest do
 
   describe "run/2" do
     test "returns schema-qualified table names" do
-      stub(Lotus.Schema, :list_tables, fn _source ->
+      stub(Lotus.Schema, :list_tables, fn _source, _opts ->
         {:ok, table_list()}
       end)
 
@@ -22,7 +22,7 @@ defmodule Lotus.AI.Actions.ListTablesTest do
     end
 
     test "returns plain table names for schema-less databases" do
-      stub(Lotus.Schema, :list_tables, fn _source ->
+      stub(Lotus.Schema, :list_tables, fn _source, _opts ->
         {:ok, sqlite_table_list()}
       end)
 
@@ -31,7 +31,7 @@ defmodule Lotus.AI.Actions.ListTablesTest do
     end
 
     test "returns error when listing fails" do
-      stub(Lotus.Schema, :list_tables, fn _source ->
+      stub(Lotus.Schema, :list_tables, fn _source, _opts ->
         {:error, "Connection failed"}
       end)
 

--- a/test/lotus/ai/actor_threading_test.exs
+++ b/test/lotus/ai/actor_threading_test.exs
@@ -1,0 +1,130 @@
+defmodule Lotus.AI.ActorThreadingTest do
+  @moduledoc """
+  AI actions run queries and list tables on behalf of a user. If the actor's
+  `:context` and `:scope` do not reach those calls, an access-control plug or
+  a scoped visibility resolver sees `nil` for every AI-initiated action — the
+  AI would see more than the user it is acting for.
+  """
+
+  use Lotus.Case, async: true
+
+  alias Lotus.AI.Actions
+  alias Lotus.AI.Tool
+
+  @actor %{context: %{user_id: 7}, scope: %{tenant_id: 2}}
+
+  describe "Tool.from_action/2" do
+    defmodule ContextCapturingAction do
+      @moduledoc false
+      @behaviour Lotus.AI.Action
+
+      @impl true
+      def name, do: "capture_context"
+
+      @impl true
+      def description, do: "Captures the context it was run with"
+
+      @impl true
+      def schema, do: [thing: [type: :string, required: true, doc: "anything"]]
+
+      @impl true
+      def run(_params, context) do
+        send(self(), {:action_context, context})
+        {:ok, %{ok: true}}
+      end
+    end
+
+    test "passes the caller's context through to the action" do
+      tool = Tool.from_action(ContextCapturingAction, bind: %{}, context: @actor)
+
+      tool.callback.(%{"thing" => "x"})
+
+      assert_received {:action_context, captured}
+      assert captured.context == %{user_id: 7}
+      assert captured.scope == %{tenant_id: 2}
+    end
+
+    test "defaults to an empty context when the caller supplies none" do
+      tool = Tool.from_action(ContextCapturingAction, bind: %{})
+
+      tool.callback.(%{"thing" => "x"})
+
+      assert_received {:action_context, captured}
+      assert captured == %{}
+    end
+  end
+
+  describe "built-in actions forward the actor" do
+    test "ListTables passes :context and :scope to Lotus.Schema" do
+      assert {:ok, _} = Actions.ListTables.run(%{data_source: "postgres"}, @actor)
+    end
+
+    test "ListSchemas passes :context and :scope to Lotus.Schema" do
+      assert {:ok, _} = Actions.ListSchemas.run(%{data_source: "postgres"}, @actor)
+    end
+
+    test "DescribeTable passes :context and :scope to Lotus.Schema" do
+      assert {:ok, _} =
+               Actions.DescribeTable.run(
+                 %{data_source: "postgres", table_name: "test_users"},
+                 @actor
+               )
+    end
+  end
+
+  describe "a scoped deny reaches AI-initiated execution" do
+    defmodule DenyAllResolver do
+      @moduledoc false
+      @behaviour Lotus.Visibility.Resolver
+
+      @impl true
+      def schema_rules_for(_source, _scope), do: []
+
+      @impl true
+      def table_rules_for(_source, %{tenant_id: 2}), do: [deny: [{"public", "test_users"}]]
+      def table_rules_for(_source, _scope), do: []
+
+      @impl true
+      def column_rules_for(_source, _scope), do: []
+    end
+
+    setup do
+      previous = Application.get_env(:lotus, :visibility_resolver)
+      Application.put_env(:lotus, :visibility_resolver, DenyAllResolver)
+      Lotus.Config.reload!()
+
+      on_exit(fn ->
+        if previous do
+          Application.put_env(:lotus, :visibility_resolver, previous)
+        else
+          Application.delete_env(:lotus, :visibility_resolver)
+        end
+
+        Lotus.Config.reload!()
+      end)
+
+      :ok
+    end
+
+    test "ExecuteSql under a denied scope is blocked" do
+      # ExecuteSQL reports failures inside an :ok tuple so the LLM can read
+      # them; what matters here is that the scoped deny stopped the query.
+      assert {:ok, %{error: error}} =
+               Actions.ExecuteSQL.run(
+                 %{data_source: "postgres", sql: "SELECT id FROM test_users", label: "check"},
+                 @actor
+               )
+
+      assert error =~ "blocked table"
+      assert error =~ "test_users"
+    end
+
+    test "ExecuteSql under an allowed scope runs" do
+      assert {:ok, _} =
+               Actions.ExecuteSQL.run(
+                 %{data_source: "postgres", sql: "SELECT id FROM test_users", label: "check"},
+                 %{context: %{user_id: 7}, scope: %{tenant_id: 1}}
+               )
+    end
+  end
+end

--- a/test/lotus/ai/conversation_test.exs
+++ b/test/lotus/ai/conversation_test.exs
@@ -28,7 +28,7 @@ defmodule Lotus.AI.ConversationTest do
 
       assert message.role == :user
       assert message.content == "Show active users"
-      assert message.sql == nil
+      assert message.statement == nil
       assert %DateTime{} = message.timestamp
     end
 
@@ -55,7 +55,7 @@ defmodule Lotus.AI.ConversationTest do
 
       assert message.role == :assistant
       assert message.content == "Here's your query:"
-      assert message.sql == "SELECT * FROM users"
+      assert message.statement == "SELECT * FROM users"
       assert %DateTime{} = message.timestamp
     end
 
@@ -110,7 +110,7 @@ defmodule Lotus.AI.ConversationTest do
 
       assert error_message.role == :error
       assert error_message.content == "column 'status' does not exist"
-      assert error_message.sql == "SELECT status FROM users"
+      assert error_message.statement == "SELECT status FROM users"
     end
 
     test "does not add message when query succeeds" do

--- a/test/lotus/ai/error_detector_test.exs
+++ b/test/lotus/ai/error_detector_test.exs
@@ -71,7 +71,7 @@ defmodule Lotus.AI.ErrorDetectorTest do
 
       assert result.error_type == :column_not_found
       assert result.error_message == "column 'status' does not exist"
-      assert result.failed_sql == "SELECT status FROM users"
+      assert result.failed_statement == "SELECT status FROM users"
       assert result.suggestions != []
       assert Enum.any?(result.suggestions, &String.contains?(&1, "describe_table"))
     end
@@ -131,7 +131,7 @@ defmodule Lotus.AI.ErrorDetectorTest do
       result = ErrorDetector.analyze_error("some error", nil, %{})
 
       assert result.error_type == :unknown
-      assert result.failed_sql == nil
+      assert result.failed_statement == nil
       assert result.suggestions != []
     end
   end

--- a/test/lotus/ai/query_explainer_test.exs
+++ b/test/lotus/ai/query_explainer_test.exs
@@ -20,7 +20,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, result} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: "SELECT * FROM orders WHERE created_at > '2024-01-01'",
+                 statement: "SELECT * FROM orders WHERE created_at > '2024-01-01'",
                  data_source: "postgres",
                  api_key: "sk-test"
                )
@@ -37,7 +37,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, result} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql:
+                 statement:
                    "SELECT d.name FROM departments d LEFT JOIN employees e ON e.department_id = d.id",
                  fragment: "LEFT JOIN employees e ON e.department_id = d.id",
                  data_source: "postgres",
@@ -57,7 +57,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, _} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: "SELECT * FROM orders JOIN users ON users.id = orders.user_id",
+                 statement: "SELECT * FROM orders JOIN users ON users.id = orders.user_id",
                  fragment: "JOIN users ON users.id = orders.user_id",
                  data_source: "postgres",
                  api_key: "sk-test"
@@ -74,7 +74,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, _} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: "SELECT * FROM orders",
+                 statement: "SELECT * FROM orders",
                  data_source: "postgres",
                  api_key: "sk-test"
                )
@@ -87,7 +87,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, _} =
                QueryExplainer.explain_query("anthropic:claude-opus-4",
-                 sql: "SELECT * FROM orders",
+                 statement: "SELECT * FROM orders",
                  data_source: "postgres",
                  api_key: "sk-test"
                )
@@ -104,7 +104,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, _} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: "SELECT * FROM orders",
+                 statement: "SELECT * FROM orders",
                  data_source: "postgres",
                  api_key: "sk-test"
                )
@@ -124,7 +124,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, _} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: original_sql,
+                 statement: original_sql,
                  data_source: "postgres",
                  api_key: "sk-test"
                )
@@ -141,7 +141,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:ok, _} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: "SELECT * FROM users WHERE 1=1 [[AND status = {{status}}]]",
+                 statement: "SELECT * FROM users WHERE 1=1 [[AND status = {{status}}]]",
                  fragment: "[[AND status = {{status}}]]",
                  data_source: "postgres",
                  api_key: "sk-test"
@@ -153,7 +153,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:error, %Lotus.AI.Error.ServiceError{}} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: "SELECT * FROM orders",
+                 statement: "SELECT * FROM orders",
                  data_source: "postgres",
                  api_key: "sk-invalid"
                )
@@ -164,7 +164,7 @@ defmodule Lotus.AI.QueryExplainerTest do
 
       assert {:error, %Lotus.AI.Error.ServiceError{}} =
                QueryExplainer.explain_query("openai:gpt-4o",
-                 sql: "SELECT * FROM orders",
+                 statement: "SELECT * FROM orders",
                  data_source: "postgres",
                  api_key: "sk-test"
                )

--- a/test/lotus/ai/query_generator_test.exs
+++ b/test/lotus/ai/query_generator_test.exs
@@ -8,7 +8,7 @@ defmodule Lotus.AI.QueryGeneratorTest do
       setup_mocks()
 
       stub(Lotus.Source, :source_type, fn _ -> :postgres end)
-      stub(Lotus.Schema, :list_tables, fn _ -> {:ok, table_list()} end)
+      stub(Lotus.Schema, :list_tables, fn _, _opts -> {:ok, table_list()} end)
 
       :ok
     end

--- a/test/lotus/ai/query_optimizer_test.exs
+++ b/test/lotus/ai/query_optimizer_test.exs
@@ -20,7 +20,7 @@ defmodule Lotus.AI.QueryOptimizerTest do
         }
       end)
 
-      stub(Lotus.Source.Adapter, :query_plan, fn _adapter, _sql, _params, _opts ->
+      stub(Lotus.Source.Adapter, :query_plan, fn _adapter, %Statement{}, _opts ->
         {:ok, postgres_explain_plan()}
       end)
 
@@ -67,7 +67,7 @@ defmodule Lotus.AI.QueryOptimizerTest do
     end
 
     test "works when execution plan is unavailable" do
-      stub(Lotus.Source.Adapter, :query_plan, fn _adapter, _sql, _params, _opts ->
+      stub(Lotus.Source.Adapter, :query_plan, fn _adapter, %Statement{}, _opts ->
         {:error, "permission denied"}
       end)
 
@@ -136,7 +136,7 @@ defmodule Lotus.AI.QueryOptimizerTest do
     end
 
     test "sanitizes Lotus variable syntax before calling query_plan" do
-      expect(Lotus.Source.Adapter, :query_plan, fn _adapter, sql, _params, _opts ->
+      expect(Lotus.Source.Adapter, :query_plan, fn _adapter, %Statement{body: sql}, _opts ->
         refute sql =~ "{{"
         refute sql =~ "}}"
         assert sql =~ "NULL"
@@ -157,7 +157,7 @@ defmodule Lotus.AI.QueryOptimizerTest do
     end
 
     test "sanitizes optional clause brackets before calling query_plan" do
-      expect(Lotus.Source.Adapter, :query_plan, fn _adapter, sql, _params, _opts ->
+      expect(Lotus.Source.Adapter, :query_plan, fn _adapter, %Statement{body: sql}, _opts ->
         refute sql =~ "[["
         refute sql =~ "]]"
         assert sql =~ "AND name ILIKE"
@@ -182,7 +182,7 @@ defmodule Lotus.AI.QueryOptimizerTest do
     end
 
     test "sends original SQL with Lotus syntax to AI prompt" do
-      stub(Lotus.Source.Adapter, :query_plan, fn _adapter, _sql, _params, _opts ->
+      stub(Lotus.Source.Adapter, :query_plan, fn _adapter, %Statement{}, _opts ->
         {:ok, postgres_explain_plan()}
       end)
 

--- a/test/lotus/ai/tool_test.exs
+++ b/test/lotus/ai/tool_test.exs
@@ -6,7 +6,7 @@ defmodule Lotus.AI.ToolTest do
 
   describe "from_action/2" do
     test "converts an action module to a ReqLLM tool" do
-      stub(Lotus.Schema, :list_schemas, fn _source ->
+      stub(Lotus.Schema, :list_schemas, fn _source, _opts ->
         {:ok, ["public", "reporting"]}
       end)
 
@@ -37,7 +37,7 @@ defmodule Lotus.AI.ToolTest do
     end
 
     test "callback injects bound params and calls action" do
-      stub(Lotus.Schema, :list_tables, fn source ->
+      stub(Lotus.Schema, :list_tables, fn source, _opts ->
         assert source == "postgres"
         {:ok, [{"public", "users"}]}
       end)
@@ -50,7 +50,7 @@ defmodule Lotus.AI.ToolTest do
     end
 
     test "callback handles LLM args with string keys" do
-      stub(Lotus.Schema, :describe_table, fn _source, _table ->
+      stub(Lotus.Schema, :describe_table, fn _source, _table, _opts ->
         {:ok, [%{name: "id", type: "integer", nullable: false, primary_key: true}]}
       end)
 
@@ -62,7 +62,7 @@ defmodule Lotus.AI.ToolTest do
     end
 
     test "callback returns JSON error on action failure" do
-      stub(Lotus.Schema, :list_schemas, fn _source ->
+      stub(Lotus.Schema, :list_schemas, fn _source, _opts ->
         {:error, "Connection refused"}
       end)
 
@@ -74,7 +74,7 @@ defmodule Lotus.AI.ToolTest do
     end
 
     test "callback handles unknown LLM parameter keys gracefully" do
-      stub(Lotus.Schema, :list_schemas, fn _source ->
+      stub(Lotus.Schema, :list_schemas, fn _source, _opts ->
         {:ok, ["public"]}
       end)
 

--- a/test/lotus/ai_test.exs
+++ b/test/lotus/ai_test.exs
@@ -52,7 +52,7 @@ defmodule Lotus.AITest do
 
       # Mock schema introspection
       stub(Lotus.Source, :source_type, fn _ -> :postgres end)
-      stub(Lotus.Schema, :list_tables, fn _ -> {:ok, table_list()} end)
+      stub(Lotus.Schema, :list_tables, fn _, _opts -> {:ok, table_list()} end)
 
       set_ai_config(enabled: true, api_key: "sk-test")
 
@@ -190,7 +190,7 @@ defmodule Lotus.AITest do
       setup_mocks()
 
       stub(Lotus.Source, :source_type, fn _ -> :postgres end)
-      stub(Lotus.Schema, :list_tables, fn _ -> {:ok, table_list()} end)
+      stub(Lotus.Schema, :list_tables, fn _, _opts -> {:ok, table_list()} end)
 
       set_ai_config(enabled: true, api_key: "sk-test")
 

--- a/test/lotus/ai_test.exs
+++ b/test/lotus/ai_test.exs
@@ -68,8 +68,8 @@ defmodule Lotus.AITest do
                  data_source: "postgres"
                )
 
-      assert result.sql =~ "SELECT * FROM users"
-      assert result.sql =~ "created_at >= NOW()"
+      assert result.statement =~ "SELECT * FROM users"
+      assert result.statement =~ "created_at >= NOW()"
       assert result.variables == []
       assert result.model == "openai:gpt-4o"
       assert result.usage.total_tokens == 200
@@ -84,7 +84,7 @@ defmodule Lotus.AITest do
                  data_source: "postgres"
                )
 
-      assert result.sql =~ "SELECT * FROM orders"
+      assert result.statement =~ "SELECT * FROM orders"
       assert length(result.variables) == 1
       assert hd(result.variables)["name"] == "status"
     end
@@ -98,7 +98,7 @@ defmodule Lotus.AITest do
                  data_source: "postgres"
                )
 
-      assert result.sql == "SELECT COUNT(*) FROM users WHERE status = 'active'"
+      assert result.statement == "SELECT COUNT(*) FROM users WHERE status = 'active'"
     end
 
     test "handles complex SQL with JOINs" do
@@ -110,9 +110,9 @@ defmodule Lotus.AITest do
                  data_source: "postgres"
                )
 
-      assert result.sql =~ "SELECT"
-      assert result.sql =~ "JOIN"
-      assert result.sql =~ "GROUP BY"
+      assert result.statement =~ "SELECT"
+      assert result.statement =~ "JOIN"
+      assert result.statement =~ "GROUP BY"
     end
 
     test "returns structured error when AI not configured" do
@@ -206,7 +206,7 @@ defmodule Lotus.AITest do
                  data_source: "postgres"
                )
 
-      assert result.sql =~ "SELECT * FROM orders"
+      assert result.statement =~ "SELECT * FROM orders"
       assert length(result.variables) == 1
       assert hd(result.variables)["name"] == "status"
     end

--- a/test/lotus/middleware_statement_rewrite_test.exs
+++ b/test/lotus/middleware_statement_rewrite_test.exs
@@ -1,0 +1,87 @@
+defmodule Lotus.MiddlewareStatementRewriteTest do
+  @moduledoc """
+  A `:before_query` plug can rewrite the statement it is handed, and the
+  rewritten statement is what gets sanitized, authorized and executed.
+
+  This is what row-level security and tenant predicates need: the plug adds a
+  restriction, and core must not execute the original text it was given.
+  """
+
+  use Lotus.Case
+
+  alias Lotus.Middleware
+  alias Lotus.Test.Schemas.User
+
+  defmodule TenantPredicatePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{statement: statement} = payload, _opts) do
+      rewritten = %{statement | body: statement.body <> " WHERE id = 1"}
+      {:cont, %{payload | statement: rewritten}}
+    end
+  end
+
+  defmodule PassthroughPlug do
+    @moduledoc false
+    def init(opts), do: opts
+    def call(payload, _opts), do: {:cont, payload}
+  end
+
+  defmodule RewriteToBlockedTablePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{statement: statement} = payload, _opts) do
+      rewritten = %{statement | body: "SELECT * FROM lotus_queries"}
+      {:cont, %{payload | statement: rewritten}}
+    end
+  end
+
+  setup do
+    # Middleware.compile(%{}) hits the no-op clause and leaves the previously
+    # compiled pipeline in place, so reset by erasing the term itself.
+    on_exit(fn ->
+      :persistent_term.erase({Lotus.Middleware, :compiled})
+    end)
+
+    Repo.insert!(%User{id: 1, name: "Ada", email: "ada@example.test"})
+    Repo.insert!(%User{id: 2, name: "Grace", email: "grace@example.test"})
+
+    :ok
+  end
+
+  test "a rewritten statement is the one executed" do
+    {:ok, unfiltered} =
+      Lotus.run_statement("SELECT id FROM test_users ORDER BY id", [], repo: "postgres")
+
+    Middleware.compile(%{before_query: [{TenantPredicatePlug, []}]})
+
+    assert {:ok, filtered} =
+             Lotus.run_statement("SELECT id FROM test_users", [], repo: "postgres")
+
+    # The plug appended WHERE id = 1, so the result must be narrower than the
+    # same statement run without the plug.
+    assert unfiltered.num_rows == 2
+    assert filtered.num_rows == 1
+    assert filtered.rows == [[1]]
+  end
+
+  test "a plug that returns the payload untouched still works" do
+    Middleware.compile(%{before_query: [{PassthroughPlug, []}]})
+
+    assert {:ok, result} =
+             Lotus.run_statement("SELECT id FROM test_users", [], repo: "postgres")
+
+    assert is_integer(result.num_rows)
+  end
+
+  test "a rewrite onto a blocked table is caught, not executed" do
+    Middleware.compile(%{before_query: [{RewriteToBlockedTablePlug, []}]})
+
+    assert {:error, message} =
+             Lotus.run_statement("SELECT id FROM test_users", [], repo: "postgres")
+
+    assert message =~ "blocked table"
+  end
+end

--- a/test/lotus/preflight_test.exs
+++ b/test/lotus/preflight_test.exs
@@ -25,6 +25,81 @@ defmodule Lotus.PreflightTest do
     end
   end
 
+  describe "scoped visibility at execution time" do
+    setup :set_mimic_from_context
+
+    setup do
+      Mimic.copy(Lotus.Config)
+      :ok
+    end
+
+    defmodule TenantResolver do
+      @moduledoc """
+      Denies `test_users` for tenant 2 only. Models the per-tenant rules a
+      host plugs in: the same source, different visible tables per actor.
+      """
+      @behaviour Lotus.Visibility.Resolver
+
+      @impl true
+      def schema_rules_for(_source, _scope), do: []
+
+      @impl true
+      def table_rules_for(_source, %{tenant_id: 2}),
+        do: [deny: [{"public", "test_users"}]]
+
+      def table_rules_for(_source, _scope), do: []
+
+      @impl true
+      def column_rules_for(_source, _scope), do: []
+    end
+
+    test "a scoped deny blocks the query, it does not only hide the table" do
+      stub(Lotus.Config, :visibility_resolver, fn -> TenantResolver end)
+
+      statement = Statement.new("SELECT id FROM test_users", [])
+
+      assert {:error, message} =
+               Preflight.authorize(@pg_adapter, statement, nil, %{tenant_id: 2})
+
+      assert message =~ "blocked table"
+      assert message =~ "test_users"
+    end
+
+    test "a scope the rules allow runs normally" do
+      stub(Lotus.Config, :visibility_resolver, fn -> TenantResolver end)
+
+      statement = Statement.new("SELECT id FROM test_users", [])
+
+      assert :ok = Preflight.authorize(@pg_adapter, statement, nil, %{tenant_id: 1})
+    end
+
+    test "omitting the scope keeps the previous unscoped behaviour" do
+      stub(Lotus.Config, :visibility_resolver, fn -> TenantResolver end)
+
+      statement = Statement.new("SELECT id FROM test_users", [])
+
+      assert :ok = Preflight.authorize(@pg_adapter, statement)
+    end
+
+    test "Lotus.run_statement/3 carries :scope all the way into preflight" do
+      stub(Lotus.Config, :visibility_resolver, fn -> TenantResolver end)
+
+      assert {:error, message} =
+               Lotus.run_statement("SELECT id FROM test_users", [],
+                 repo: "postgres",
+                 scope: %{tenant_id: 2}
+               )
+
+      assert message =~ "test_users"
+
+      assert {:ok, _result} =
+               Lotus.run_statement("SELECT id FROM test_users", [],
+                 repo: "postgres",
+                 scope: %{tenant_id: 1}
+               )
+    end
+  end
+
   describe "unrestricted adapter behavior" do
     setup :set_mimic_from_context
 

--- a/test/lotus/query/statement_test.exs
+++ b/test/lotus/query/statement_test.exs
@@ -1,0 +1,31 @@
+defmodule Lotus.Query.StatementTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Query.Statement
+
+  describe "new/2" do
+    test "defaults params to an empty list" do
+      assert %Statement{body: "SELECT 1", params: []} = Statement.new("SELECT 1")
+    end
+
+    test "accepts positional params as a list" do
+      assert %Statement{params: [1, "a"]} = Statement.new("SELECT $1, $2", [1, "a"])
+    end
+
+    test "accepts named params as a map" do
+      params = %{"since" => ~D[2026-01-01], "limit" => 10}
+
+      assert %Statement{params: ^params} = Statement.new("SELECT :since", params)
+    end
+
+    test "keeps a non-binary body opaque" do
+      body = %{"query" => %{"match_all" => %{}}}
+
+      assert %Statement{body: ^body} = Statement.new(body)
+    end
+
+    test "rejects params that are neither a list nor a map" do
+      assert_raise FunctionClauseError, fn -> Statement.new("SELECT 1", :nope) end
+    end
+  end
+end

--- a/test/lotus/source/adapter_test.exs
+++ b/test/lotus/source/adapter_test.exs
@@ -516,6 +516,68 @@ defmodule Lotus.Source.AdapterTest do
     end
   end
 
+  describe "table_stats/3" do
+    defmodule StatsAdapter do
+      @moduledoc false
+      @behaviour Lotus.Source.Adapter
+
+      @impl true
+      def execute_query(_state, _body, _params, _opts),
+        do: {:ok, %{columns: [], rows: [], num_rows: 0}}
+
+      @impl true
+      def transaction(state, fun, _opts), do: {:ok, fun.(state)}
+
+      @impl true
+      def list_tables(_state, _schemas, _opts), do: {:ok, []}
+
+      @impl true
+      def describe_table(_state, _schema, _table), do: {:ok, []}
+
+      @impl true
+      def builtin_denies(_state), do: []
+
+      @impl true
+      def health_check(_state), do: :ok
+
+      @impl true
+      def disconnect(_state), do: :ok
+
+      @impl true
+      def format_error(_state, error), do: inspect(error)
+
+      @impl true
+      def source_type(_state), do: :other
+
+      @impl true
+      def table_stats(_state, schema, table),
+        do: {:ok, %{row_count: 42, schema: schema, table: table}}
+    end
+
+    test "dispatches to the adapter when it implements the callback" do
+      adapter = %Adapter{
+        name: "stats",
+        module: StatsAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      assert {:ok, %{row_count: 42, schema: "logs", table: "events"}} =
+               Adapter.table_stats(adapter, "logs", "events")
+    end
+
+    test "reports :unsupported when the adapter does not implement it" do
+      adapter = %Adapter{
+        name: "stub",
+        module: Lotus.Test.StubAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      assert {:error, :unsupported} = Adapter.table_stats(adapter, nil, "events")
+    end
+  end
+
   describe "SQL-shaped callbacks are optional" do
     defmodule MinimalAdapter do
       @moduledoc """

--- a/test/lotus/source/adapter_test.exs
+++ b/test/lotus/source/adapter_test.exs
@@ -132,7 +132,8 @@ defmodule Lotus.Source.AdapterTest do
     def supports_feature?(_state, _), do: false
 
     @impl true
-    def limit_query(_state, statement, limit), do: "#{statement} LIMIT #{limit}"
+    def limit_query(_state, %Statement{body: body} = statement, limit),
+      do: %{statement | body: "#{body} LIMIT #{limit}"}
 
     @impl true
     def db_type_to_lotus_type(_state, "integer"), do: :integer
@@ -518,6 +519,41 @@ defmodule Lotus.Source.AdapterTest do
 
       assert {:ok, ctx} = Adapter.ai_context(adapter)
       assert ctx.language == "unknown"
+    end
+  end
+
+  describe "limit_query/3" do
+    setup do
+      {:ok,
+       adapter: %Adapter{
+         name: "main",
+         module: MockAdapter,
+         state: %{db: "test_db"},
+         source_type: :postgres
+       }}
+    end
+
+    test "dispatches the statement to the module and returns a statement", %{adapter: adapter} do
+      statement = Statement.new("SELECT 1", [:bound])
+
+      assert %Statement{body: body, params: params} =
+               Adapter.limit_query(adapter, statement, 10)
+
+      assert body == "SELECT 1 LIMIT 10"
+      assert params == [:bound]
+    end
+
+    test "returns the statement unchanged when the adapter does not implement it" do
+      stub = %Adapter{
+        name: "stub",
+        module: Lotus.Test.StubAdapter,
+        state: nil,
+        source_type: :other
+      }
+
+      statement = Statement.new(%{"query" => %{"match_all" => %{}}})
+
+      assert Adapter.limit_query(stub, statement, 10) == statement
     end
   end
 

--- a/test/lotus/source/adapter_test.exs
+++ b/test/lotus/source/adapter_test.exs
@@ -516,6 +516,101 @@ defmodule Lotus.Source.AdapterTest do
     end
   end
 
+  describe "SQL-shaped callbacks are optional" do
+    defmodule MinimalAdapter do
+      @moduledoc """
+      The smallest adapter a non-SQL source can get away with: it executes
+      statements and says who it is. Everything SQL-shaped is left out.
+      """
+      @behaviour Lotus.Source.Adapter
+
+      @impl true
+      def execute_query(_state, _body, _params, _opts),
+        do: {:ok, %{columns: [], rows: [], num_rows: 0}}
+
+      @impl true
+      def transaction(state, fun, _opts), do: {:ok, fun.(state)}
+
+      @impl true
+      def list_tables(_state, _schemas, _opts), do: {:ok, []}
+
+      @impl true
+      def describe_table(_state, _schema, _table), do: {:ok, []}
+
+      @impl true
+      def builtin_denies(_state), do: []
+
+      @impl true
+      def health_check(_state), do: :ok
+
+      @impl true
+      def disconnect(_state), do: :ok
+
+      @impl true
+      def format_error(_state, error), do: inspect(error)
+
+      @impl true
+      def source_type(_state), do: :other
+    end
+
+    setup do
+      {:ok,
+       adapter: %Adapter{
+         name: "minimal",
+         module: MinimalAdapter,
+         state: nil,
+         source_type: :other
+       }}
+    end
+
+    test "quote_identifier/2 returns the identifier unchanged", %{adapter: adapter} do
+      assert Adapter.quote_identifier(adapter, "users") == "users"
+    end
+
+    test "query_plan/3 reports no plan", %{adapter: adapter} do
+      assert {:ok, nil} = Adapter.query_plan(adapter, Statement.new("anything"), [])
+    end
+
+    test "apply_filters/3 and apply_sorts/3 pass the statement through", %{adapter: adapter} do
+      statement = Statement.new(%{"match_all" => %{}})
+
+      assert Adapter.apply_filters(adapter, statement, [:a_filter]) == statement
+      assert Adapter.apply_sorts(adapter, statement, [:a_sort]) == statement
+    end
+
+    test "list_schemas/1 reports a flat namespace", %{adapter: adapter} do
+      assert {:ok, []} = Adapter.list_schemas(adapter)
+    end
+
+    test "resolve_table_namespace/3 resolves to no namespace", %{adapter: adapter} do
+      assert {:ok, nil} = Adapter.resolve_table_namespace(adapter, "logs", [])
+    end
+
+    test "default_schemas/1 and builtin_schema_denies/1 are empty", %{adapter: adapter} do
+      assert Adapter.default_schemas(adapter) == []
+      assert Adapter.builtin_schema_denies(adapter) == []
+    end
+
+    test "supports_feature?/2 answers false for everything", %{adapter: adapter} do
+      refute Adapter.supports_feature?(adapter, :schema_hierarchy)
+      refute Adapter.supports_feature?(adapter, :search_path)
+      refute Adapter.supports_feature?(adapter, :anything_at_all)
+    end
+
+    test "db_type_to_lotus_type/2 falls back to :text", %{adapter: adapter} do
+      assert Adapter.db_type_to_lotus_type(adapter, "whatever") == :text
+    end
+
+    test "editor_config/1 returns an empty editor shape", %{adapter: adapter} do
+      config = Adapter.editor_config(adapter)
+
+      assert config.keywords == []
+      assert config.types == []
+      assert config.functions == []
+      assert config.context_boundaries == []
+    end
+  end
+
   describe "limit_query/3" do
     setup do
       {:ok,

--- a/test/lotus/source/adapter_test.exs
+++ b/test/lotus/source/adapter_test.exs
@@ -120,9 +120,6 @@ defmodule Lotus.Source.AdapterTest do
     @impl true
     def format_error(_state, error), do: "Mock error: #{inspect(error)}"
 
-    @impl true
-    def handled_errors(_state), do: [RuntimeError]
-
     # --- Source Identity ---
     @impl true
     def source_type(_state), do: :postgres
@@ -313,8 +310,9 @@ defmodule Lotus.Source.AdapterTest do
       assert "Mock error: :boom" == Adapter.format_error(adapter, :boom)
     end
 
-    test "handled_errors/1 dispatches with state", %{adapter: adapter} do
-      assert [RuntimeError] = Adapter.handled_errors(adapter)
+    test "handled_errors/1 is not part of the behaviour" do
+      refute Enum.any?(Adapter.behaviour_info(:callbacks), &match?({:handled_errors, _}, &1))
+      refute function_exported?(Adapter, :handled_errors, 1)
     end
   end
 
@@ -356,8 +354,6 @@ defmodule Lotus.Source.AdapterTest do
       def disconnect(_), do: :ok
       @impl true
       def format_error(_, e), do: inspect(e)
-      @impl true
-      def handled_errors(_), do: []
       @impl true
       def source_type(_), do: :other
       @impl true
@@ -475,8 +471,6 @@ defmodule Lotus.Source.AdapterTest do
       def disconnect(_), do: :ok
       @impl true
       def format_error(_, e), do: inspect(e)
-      @impl true
-      def handled_errors(_), do: []
       @impl true
       def source_type(_), do: :other
       @impl true
@@ -609,8 +603,6 @@ defmodule Lotus.Source.AdapterTest do
       @impl true
       def format_error(_, e), do: inspect(e)
       @impl true
-      def handled_errors(_), do: []
-      @impl true
       def source_type(_), do: :other
       @impl true
       def supports_feature?(_, _), do: false
@@ -719,7 +711,6 @@ defmodule Lotus.Source.AdapterTest do
         @impl true
         def format_error(_, e), do: inspect(e)
         @impl true
-        def handled_errors(_), do: []
         @impl true
         def source_type(_), do: :other
         @impl true

--- a/test/lotus/source/adapter_test.exs
+++ b/test/lotus/source/adapter_test.exs
@@ -96,7 +96,8 @@ defmodule Lotus.Source.AdapterTest do
     end
 
     @impl true
-    def query_plan(_state, sql, _params, _opts), do: {:ok, "Seq Scan on #{sql}"}
+    def query_plan(_state, %Statement{body: sql, params: params}, _opts),
+      do: {:ok, "Seq Scan on #{sql} with #{length(params)} params"}
 
     # --- Safety & Visibility ---
     @impl true
@@ -203,9 +204,11 @@ defmodule Lotus.Source.AdapterTest do
       assert :ok = Adapter.health_check(adapter)
     end
 
-    test "query_plan/4 dispatches to module with state", %{adapter: adapter} do
-      assert {:ok, plan} = Adapter.query_plan(adapter, "SELECT 1", [], [])
-      assert plan =~ "Seq Scan"
+    test "query_plan/3 dispatches the statement to module with state", %{adapter: adapter} do
+      statement = Statement.new("SELECT 1 WHERE id = $1", [7])
+
+      assert {:ok, plan} = Adapter.query_plan(adapter, statement, [])
+      assert plan == "Seq Scan on SELECT 1 WHERE id = $1 with 1 params"
     end
 
     test "describe_table/3 dispatches to module with state", %{adapter: adapter} do
@@ -339,7 +342,7 @@ defmodule Lotus.Source.AdapterTest do
       @impl true
       def apply_sorts(_, s, _), do: s
       @impl true
-      def query_plan(_, _, _, _), do: {:ok, ""}
+      def query_plan(_, _, _), do: {:ok, ""}
       @impl true
       def builtin_denies(_), do: []
       @impl true
@@ -458,7 +461,7 @@ defmodule Lotus.Source.AdapterTest do
       @impl true
       def apply_sorts(_, s, _), do: s
       @impl true
-      def query_plan(_, _, _, _), do: {:ok, ""}
+      def query_plan(_, _, _), do: {:ok, ""}
       @impl true
       def builtin_denies(_), do: []
       @impl true
@@ -556,7 +559,7 @@ defmodule Lotus.Source.AdapterTest do
       @impl true
       def apply_sorts(_, s, _), do: s
       @impl true
-      def query_plan(_, _, _, _), do: {:ok, ""}
+      def query_plan(_, _, _), do: {:ok, ""}
       @impl true
       def builtin_denies(_), do: []
       @impl true
@@ -666,7 +669,7 @@ defmodule Lotus.Source.AdapterTest do
         @impl true
         def apply_sorts(_, s, _), do: s
         @impl true
-        def query_plan(_, _, _, _), do: {:ok, ""}
+        def query_plan(_, _, _), do: {:ok, ""}
         @impl true
         def builtin_denies(_), do: []
         @impl true

--- a/test/lotus/source/adapters/ecto/dialect_test.exs
+++ b/test/lotus/source/adapters/ecto/dialect_test.exs
@@ -1,0 +1,99 @@
+defmodule Lotus.Source.Adapters.Ecto.DialectTest do
+  @moduledoc """
+  The Dialect behaviour is a published extension point that external dialect
+  libraries implement from outside this repo. These tests pin the parts of the
+  contract those dialects depend on.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Lotus.Source.Adapters.Ecto.Dialect
+
+  describe "published contract" do
+    test "the behaviour carries documentation for adapter authors" do
+      {:docs_v1, _, :elixir, _, moduledoc, _, _} = Code.fetch_docs(Dialect)
+
+      assert %{"en" => text} = moduledoc
+      assert text =~ "Dialect"
+    end
+  end
+
+  describe "session hooks are optional" do
+    defmodule MinimalDialect do
+      @moduledoc false
+      @behaviour Dialect
+
+      alias Lotus.Query.Statement
+
+      @impl true
+      def execute_in_transaction(_repo, fun, _opts), do: {:ok, fun.()}
+
+      @impl true
+      def format_error(error), do: inspect(error)
+
+      @impl true
+      def quote_identifier(id), do: ~s("#{id}")
+
+      @impl true
+      def param_placeholder(index, _var, _type), do: "$#{index}"
+
+      @impl true
+      def limit_offset_placeholders(limit_index, offset_index),
+        do: {"$#{limit_index}", "$#{offset_index}"}
+
+      @impl true
+      def apply_filters(statement, _filters), do: statement
+
+      @impl true
+      def apply_sorts(statement, _sorts), do: statement
+
+      @impl true
+      def query_plan(_repo, %Statement{}, _opts), do: {:ok, nil}
+
+      @impl true
+      def builtin_denies(_repo), do: []
+
+      @impl true
+      def builtin_schema_denies(_repo), do: []
+
+      @impl true
+      def default_schemas(_repo), do: []
+
+      @impl true
+      def list_schemas(_repo), do: []
+
+      @impl true
+      def list_tables(_repo, _schemas, _include_views?), do: []
+
+      @impl true
+      def describe_table(_repo, _schema, _table), do: []
+
+      @impl true
+      def resolve_table_namespace(_repo, _table, _schemas), do: nil
+
+      @impl true
+      def source_type, do: :other
+
+      @impl true
+      def ecto_adapter, do: __MODULE__
+
+      @impl true
+      def query_language, do: "minimal"
+
+      @impl true
+      def limit_query(statement, _limit), do: statement
+    end
+
+    test "a dialect compiles without set_statement_timeout/2 or set_search_path/2" do
+      refute function_exported?(MinimalDialect, :set_statement_timeout, 2)
+      refute function_exported?(MinimalDialect, :set_search_path, 2)
+    end
+
+    test "both hooks are declared optional on the behaviour" do
+      optional = Dialect.behaviour_info(:optional_callbacks)
+
+      assert {:set_statement_timeout, 2} in optional
+      assert {:set_search_path, 2} in optional
+    end
+  end
+end

--- a/test/lotus/source/adapters/ecto_test.exs
+++ b/test/lotus/source/adapters/ecto_test.exs
@@ -513,7 +513,7 @@ defmodule Lotus.Source.Adapters.EctoTest do
                )
     end
 
-    test "returns the prepared statement validatable by query_plan/4" do
+    test "returns the prepared statement validatable by query_plan/3" do
       adapter = EctoAdapter.wrap("main", Repo)
 
       {:ok, prepared} =
@@ -522,7 +522,7 @@ defmodule Lotus.Source.Adapters.EctoTest do
           Statement.new("SELECT id FROM test_users WHERE id = {{id}} [[AND name = {{name}}]]")
         )
 
-      assert {:ok, _plan} = Adapter.query_plan(adapter, prepared.body, prepared.params, [])
+      assert {:ok, _plan} = Adapter.query_plan(adapter, prepared, [])
     end
   end
 end

--- a/test/lotus/source/adapters/ecto_test.exs
+++ b/test/lotus/source/adapters/ecto_test.exs
@@ -363,13 +363,6 @@ defmodule Lotus.Source.Adapters.EctoTest do
       error = %RuntimeError{message: "boom"}
       assert is_binary(Adapter.format_error(adapter, error))
     end
-
-    test "handled_errors/0 returns list of exception modules" do
-      adapter = EctoAdapter.wrap("main", Repo)
-      errors = Adapter.handled_errors(adapter)
-      assert is_list(errors)
-      assert Postgrex.Error in errors
-    end
   end
 
   describe "validate_statement/3" do

--- a/test/lotus/source/adapters/pluggable_registry_test.exs
+++ b/test/lotus/source/adapters/pluggable_registry_test.exs
@@ -59,8 +59,6 @@ defmodule Lotus.Source.Adapters.PluggableRegistryTest do
     @impl true
     def format_error(_, e), do: inspect(e)
     @impl true
-    def handled_errors(_), do: []
-    @impl true
     def source_type(_), do: :custom
     @impl true
     def supports_feature?(_, _), do: false
@@ -232,8 +230,6 @@ defmodule Lotus.Source.Adapters.PluggableRegistryTest do
     def disconnect(_), do: :ok
     @impl true
     def format_error(_, e), do: inspect(e)
-    @impl true
-    def handled_errors(_), do: []
     @impl true
     def source_type(_), do: :echo
     @impl true

--- a/test/lotus/source/adapters/pluggable_registry_test.exs
+++ b/test/lotus/source/adapters/pluggable_registry_test.exs
@@ -45,7 +45,7 @@ defmodule Lotus.Source.Adapters.PluggableRegistryTest do
     @impl true
     def apply_sorts(_, statement, _), do: statement
     @impl true
-    def query_plan(_, _, _, _), do: {:ok, "plan"}
+    def query_plan(_, _, _), do: {:ok, "plan"}
     @impl true
     def builtin_denies(_), do: []
     @impl true
@@ -214,7 +214,7 @@ defmodule Lotus.Source.Adapters.PluggableRegistryTest do
     @impl true
     def apply_sorts(_, statement, _), do: statement
     @impl true
-    def query_plan(_, _, _, _), do: {:ok, "echo-plan"}
+    def query_plan(_, _, _), do: {:ok, "echo-plan"}
 
     # Echo adapter has no real relations — return an empty set so preflight
     # passes without needing the :allow_unrestricted_resources opt-in.

--- a/test/lotus/source/editor_config_shape_test.exs
+++ b/test/lotus/source/editor_config_shape_test.exs
@@ -75,9 +75,6 @@ defmodule Lotus.Source.EditorConfigShapeTest do
         def supports_feature?(_state, _feature), do: false
 
         @impl true
-        def limit_query(_state, stmt, limit), do: "#{stmt} LIMIT #{limit}"
-
-        @impl true
         def db_type_to_lotus_type(_state, _type), do: :text
       end
     end

--- a/test/lotus/source/editor_config_shape_test.exs
+++ b/test/lotus/source/editor_config_shape_test.exs
@@ -48,7 +48,7 @@ defmodule Lotus.Source.EditorConfigShapeTest do
         def apply_sorts(_state, %Statement{} = s, _sorts), do: s
 
         @impl true
-        def query_plan(_state, _sql, _params, _opts), do: {:ok, nil}
+        def query_plan(_state, _statement, _opts), do: {:ok, nil}
 
         @impl true
         def builtin_denies(_state), do: []

--- a/test/lotus/source/editor_config_shape_test.exs
+++ b/test/lotus/source/editor_config_shape_test.exs
@@ -69,9 +69,6 @@ defmodule Lotus.Source.EditorConfigShapeTest do
         def format_error(_state, err), do: inspect(err)
 
         @impl true
-        def handled_errors(_state), do: []
-
-        @impl true
         def supports_feature?(_state, _feature), do: false
 
         @impl true

--- a/test/lotus/source/resolvers/static_test.exs
+++ b/test/lotus/source/resolvers/static_test.exs
@@ -90,14 +90,14 @@ defmodule Lotus.Source.Resolvers.StaticTest do
       assert adapter.name == "sqlite"
     end
 
-    test "unloaded atoms in both positions fall through to default" do
-      assert {:ok, adapter} = Static.resolve(:typoed_one, :typoed_two)
-      assert adapter.name == "postgres"
+    test "unloaded atoms in both positions are not found" do
+      # Silently answering with the default source would run the query
+      # against the wrong database.
+      assert {:error, :not_found} = Static.resolve(:typoed_one, :typoed_two)
     end
 
-    test "non-atom, non-string values fall through to default" do
-      assert {:ok, adapter} = Static.resolve(123, :"Elixir.Nonexistent.Module")
-      assert adapter.name == "postgres"
+    test "non-atom, non-string values are not found" do
+      assert {:error, :not_found} = Static.resolve(123, :"Elixir.Nonexistent.Module")
     end
   end
 
@@ -154,6 +154,126 @@ defmodule Lotus.Source.Resolvers.StaticTest do
       # Default is "postgres" per test config
       assert name == "postgres"
       assert adapter.state == Lotus.Test.Repo
+    end
+  end
+
+  describe "unresolvable source names" do
+    test "a typo'd atom source name is an error, not a fall-through to the default" do
+      assert {:error, :not_found} = Static.resolve(:postgress, nil)
+    end
+
+    test "a typo'd atom as the query's stored data_source is an error" do
+      assert {:error, :not_found} = Static.resolve(nil, :postgress)
+    end
+
+    test "an unconfigured string source name is an error" do
+      assert {:error, :not_found} = Static.resolve("warehouse", nil)
+    end
+
+    test "only nil on both sides selects the default source" do
+      assert {:ok, adapter} = Static.resolve(nil, nil)
+      assert adapter.name == "postgres"
+    end
+  end
+
+  describe "canonical %{adapter: Module} entries" do
+    setup do
+      Mimic.copy(Config)
+      :ok
+    end
+
+    defmodule CanonicalAdapter do
+      @moduledoc false
+
+      def wrap(name, opts) do
+        %Lotus.Source.Adapter{
+          name: name,
+          module: __MODULE__,
+          state: opts,
+          source_type: :other
+        }
+      end
+    end
+
+    test "an entry naming its adapter resolves without probing can_handle?/1" do
+      entry = %{adapter: CanonicalAdapter, url: "https://example.test"}
+
+      Config
+      |> stub(:data_sources, fn -> %{"api" => entry} end)
+      |> stub(:source_adapters, fn -> [] end)
+
+      assert [adapter] = Static.list_sources()
+      assert adapter.name == "api"
+      assert adapter.module == CanonicalAdapter
+      assert adapter.state == entry
+    end
+
+    test "a named adapter that is not loaded raises a pointed error" do
+      Config
+      |> stub(:data_sources, fn -> %{"api" => %{adapter: NoSuchAdapterModule}} end)
+      |> stub(:source_adapters, fn -> [] end)
+
+      assert_raise ArgumentError, ~r/NoSuchAdapterModule/, fn ->
+        Static.list_sources()
+      end
+    end
+  end
+
+  describe "ambiguous entries" do
+    setup do
+      Mimic.copy(Config)
+      :ok
+    end
+
+    defmodule GreedyAdapterA do
+      @moduledoc false
+      def can_handle?(%{kind: :shared}), do: true
+      def can_handle?(_), do: false
+
+      def wrap(name, opts),
+        do: %Lotus.Source.Adapter{
+          name: name,
+          module: __MODULE__,
+          state: opts,
+          source_type: :other
+        }
+    end
+
+    defmodule GreedyAdapterB do
+      @moduledoc false
+      def can_handle?(%{kind: :shared}), do: true
+      def can_handle?(_), do: false
+
+      def wrap(name, opts),
+        do: %Lotus.Source.Adapter{
+          name: name,
+          module: __MODULE__,
+          state: opts,
+          source_type: :other
+        }
+    end
+
+    test "two adapters claiming the same entry raise instead of silently picking one" do
+      Config
+      |> stub(:data_sources, fn -> %{"shared" => %{kind: :shared}} end)
+      |> stub(:source_adapters, fn -> [GreedyAdapterA, GreedyAdapterB] end)
+
+      assert_raise ArgumentError, ~r/more than one source adapter/i, fn ->
+        Static.list_sources()
+      end
+    end
+
+    test "the error names every adapter that claimed the entry" do
+      Config
+      |> stub(:data_sources, fn -> %{"shared" => %{kind: :shared}} end)
+      |> stub(:source_adapters, fn -> [GreedyAdapterA, GreedyAdapterB] end)
+
+      error =
+        assert_raise ArgumentError, fn -> Static.list_sources() end
+
+      assert error.message =~ "GreedyAdapterA"
+      assert error.message =~ "GreedyAdapterB"
+      assert error.message =~ "adapter:"
     end
   end
 

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -266,13 +266,20 @@ defmodule Lotus.SourcesTest do
   describe "limit_query/3" do
     test "wraps statement with limit from adapter struct" do
       adapter = Source.resolve!("postgres", nil)
-      result = Source.limit_query(adapter, "SELECT * FROM users", 10)
-      assert result == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
+      statement = Lotus.Query.Statement.new("SELECT * FROM users", [:bound])
+
+      assert %Lotus.Query.Statement{body: body, params: params} =
+               Source.limit_query(adapter, statement, 10)
+
+      assert body == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
+      assert params == [:bound]
     end
 
     test "wraps statement with limit from source name" do
-      result = Source.limit_query("postgres", "SELECT * FROM users", 10)
-      assert result == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
+      statement = Lotus.Query.Statement.new("SELECT * FROM users")
+
+      assert %Lotus.Query.Statement{body: body} = Source.limit_query("postgres", statement, 10)
+      assert body == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
     end
   end
 end

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -1,6 +1,7 @@
 defmodule Lotus.SourcesTest do
   use Lotus.Case, async: true
 
+  alias Lotus.Query.Statement
   alias Lotus.Source
   alias Lotus.Source.Adapter
 
@@ -264,19 +265,18 @@ defmodule Lotus.SourcesTest do
   describe "limit_query/3" do
     test "wraps statement with limit from adapter struct" do
       adapter = Source.resolve!("postgres", nil)
-      statement = Lotus.Query.Statement.new("SELECT * FROM users", [:bound])
+      statement = Statement.new("SELECT * FROM users", [:bound])
 
-      assert %Lotus.Query.Statement{body: body, params: params} =
-               Source.limit_query(adapter, statement, 10)
+      assert %Statement{body: body, params: params} = Source.limit_query(adapter, statement, 10)
 
       assert body == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
       assert params == [:bound]
     end
 
     test "wraps statement with limit from source name" do
-      statement = Lotus.Query.Statement.new("SELECT * FROM users")
+      statement = Statement.new("SELECT * FROM users")
 
-      assert %Lotus.Query.Statement{body: body} = Source.limit_query("postgres", statement, 10)
+      assert %Statement{body: body} = Source.limit_query("postgres", statement, 10)
       assert body == "SELECT * FROM (SELECT * FROM users) AS limited_query LIMIT 10"
     end
   end

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -96,18 +96,16 @@ defmodule Lotus.SourcesTest do
       assert adapter.state == Lotus.Test.SqliteRepo
     end
 
-    test "unloaded atoms in both positions fall through to default" do
-      adapter = Source.resolve!(:typoed_one, :typoed_two)
-      assert %Adapter{} = adapter
-      assert adapter.name == "postgres"
-      assert adapter.state == Lotus.Test.Repo
+    test "unloaded atoms in both positions raise rather than using the default" do
+      assert_raise ArgumentError, ~r/not configured/, fn ->
+        Source.resolve!(:typoed_one, :typoed_two)
+      end
     end
 
-    test "handles invalid types gracefully" do
-      adapter = Source.resolve!(123, :"Elixir.Nonexistent.Module")
-      assert %Adapter{} = adapter
-      assert adapter.name == "postgres"
-      assert adapter.state == Lotus.Test.Repo
+    test "invalid types raise rather than using the default" do
+      assert_raise ArgumentError, ~r/not configured/, fn ->
+        Source.resolve!(123, :"Elixir.Nonexistent.Module")
+      end
     end
   end
 

--- a/test/lotus/storage/schema_cache_test.exs
+++ b/test/lotus/storage/schema_cache_test.exs
@@ -26,7 +26,7 @@ defmodule Lotus.Storage.SchemaCacheTest do
     def quote_identifier(_, id), do: ~s("#{id}")
     def apply_filters(_, statement, _), do: statement
     def apply_sorts(_, statement, _), do: statement
-    def query_plan(_, _, _, _), do: {:ok, "plan"}
+    def query_plan(_, _, _), do: {:ok, "plan"}
     def builtin_denies(_), do: []
     def builtin_schema_denies(_), do: []
     def default_schemas(_), do: ["public"]

--- a/test/lotus/storage/schema_cache_test.exs
+++ b/test/lotus/storage/schema_cache_test.exs
@@ -33,7 +33,6 @@ defmodule Lotus.Storage.SchemaCacheTest do
     def health_check(_), do: :ok
     def disconnect(_), do: :ok
     def format_error(_, e), do: inspect(e)
-    def handled_errors(_), do: []
     def source_type(_), do: :postgres
     def supports_feature?(_, _), do: false
     def limit_query(_, statement, _limit), do: statement

--- a/test/lotus/telemetry_test.exs
+++ b/test/lotus/telemetry_test.exs
@@ -31,11 +31,11 @@ defmodule Lotus.TelemetryTest do
       {:ok, _result} = Runner.run_statement(@pg_adapter, Statement.new("SELECT 1 AS num"))
 
       assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
-                       %{repo: "postgres", statement: %Statement{body: "SELECT 1 AS num"}}}
+                       %{source: "postgres", statement: %Statement{body: "SELECT 1 AS num"}}}
 
       assert_received {:telemetry, [:lotus, :query, :stop], measurements,
                        %{
-                         repo: "postgres",
+                         source: "postgres",
                          statement: %Statement{body: "SELECT 1 AS num"},
                          result: %Lotus.Result{}
                        }}
@@ -65,9 +65,10 @@ defmodule Lotus.TelemetryTest do
         Runner.run_statement(@pg_adapter, Statement.new("SELECT 1 AS num", []), context: ctx)
 
       assert_received {:telemetry, [:lotus, :query, :start], _,
-                       %{repo: "postgres", context: ^ctx}}
+                       %{source: "postgres", context: ^ctx}}
 
-      assert_received {:telemetry, [:lotus, :query, :stop], _, %{repo: "postgres", context: ^ctx}}
+      assert_received {:telemetry, [:lotus, :query, :stop], _,
+                       %{source: "postgres", context: ^ctx}}
 
       :telemetry.detach("#{inspect(ref)}")
     end
@@ -134,12 +135,12 @@ defmodule Lotus.TelemetryTest do
       {:error, _} = Runner.run_statement(@pg_adapter, Statement.new("DROP TABLE test_users"))
 
       assert_received {:telemetry, [:lotus, :query, :start], %{system_time: _},
-                       %{repo: "postgres", statement: %Statement{body: "DROP TABLE test_users"}}}
+                       %{source: "postgres", statement: %Statement{body: "DROP TABLE test_users"}}}
 
       assert_received {:telemetry, [:lotus, :query, :exception], measurements,
                        %{
                          kind: :error,
-                         repo: "postgres",
+                         source: "postgres",
                          statement: %Statement{body: "DROP TABLE test_users"}
                        }}
 

--- a/test/support/in_memory_adapter.ex
+++ b/test/support/in_memory_adapter.ex
@@ -366,9 +366,6 @@ defmodule Lotus.Test.InMemoryAdapter do
   @impl true
   def format_error(_state, error), do: inspect(error)
 
-  @impl true
-  def handled_errors(_state), do: []
-
   # ---------------------------------------------------------------------------
   # Identity & presentation
   # ---------------------------------------------------------------------------

--- a/test/support/in_memory_adapter.ex
+++ b/test/support/in_memory_adapter.ex
@@ -258,7 +258,7 @@ defmodule Lotus.Test.InMemoryAdapter do
   def needs_preflight?(_state, _statement), do: true
 
   @impl true
-  def query_plan(_state, _sql, _params, _opts), do: {:ok, nil}
+  def query_plan(_state, _statement, _opts), do: {:ok, nil}
 
   @impl true
   def substitute_variable(_state, %Statement{} = statement, var_name, value, _type) do

--- a/test/support/test_adapters.ex
+++ b/test/support/test_adapters.ex
@@ -96,8 +96,6 @@ defmodule Lotus.Test.StubAdapter do
   @impl true
   def supports_feature?(_state, _feature), do: false
   @impl true
-  def limit_query(_state, statement, _limit), do: statement
-  @impl true
   def db_type_to_lotus_type(_state, _db_type), do: :text
   @impl true
   def editor_config(_state),

--- a/test/support/test_adapters.ex
+++ b/test/support/test_adapters.ex
@@ -39,8 +39,6 @@ defmodule Lotus.Test.NoOpAdapter do
   @impl true
   def format_error(_state, error), do: inspect(error)
   @impl true
-  def handled_errors(_state), do: []
-  @impl true
   def source_type(_state), do: :other
   @impl true
   def supports_feature?(_state, _feature), do: false
@@ -89,8 +87,6 @@ defmodule Lotus.Test.StubAdapter do
   def disconnect(_state), do: :ok
   @impl true
   def format_error(_state, error), do: inspect(error)
-  @impl true
-  def handled_errors(_state), do: []
   @impl true
   def source_type(_state), do: :other
   @impl true

--- a/test/support/test_adapters.ex
+++ b/test/support/test_adapters.ex
@@ -25,7 +25,7 @@ defmodule Lotus.Test.NoOpAdapter do
   @impl true
   def apply_sorts(_state, statement, _sorts), do: statement
   @impl true
-  def query_plan(_state, _sql, _params, _opts), do: {:ok, ""}
+  def query_plan(_state, _statement, _opts), do: {:ok, ""}
   @impl true
   def builtin_denies(_state), do: []
   @impl true
@@ -76,7 +76,7 @@ defmodule Lotus.Test.StubAdapter do
   @impl true
   def apply_sorts(_state, statement, _sorts), do: statement
   @impl true
-  def query_plan(_state, _sql, _params, _opts), do: {:ok, ""}
+  def query_plan(_state, _statement, _opts), do: {:ok, ""}
   @impl true
   def builtin_denies(_state), do: []
   @impl true


### PR DESCRIPTION
## Summary

Closes the last places where the frozen v1 public surface still assumed SQL, before `1.0.0` is tagged. Each of these becomes a breaking change the day after 1.0 ships, so they go in now.

Three of them are plumbing gaps rather than shape problems: scoped visibility was not applied at execution, `:before_query` plugs could not rewrite a statement, and the AI layer ran everything with no actor.

12 commits, one per task, each with its tests and docs.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Changes made

### Adapter contract

- **`query_plan/4` → `query_plan/3`**, taking a `%Statement{}`. The callback still typed its second argument as `sql :: String.t()` while the pipeline already passed an opaque body; bound values now travel in `statement.params`.
- **`limit_query/3` is `%Statement{}` in, `%Statement{}` out, and optional**, defaulting to the statement unchanged. It was required and String-typed, so non-SQL adapters implemented a passthrough purely to satisfy the behaviour.
- **`handled_errors/1` deleted.** It was documented as feeding the Runner's rescue clause; the Runner always routed every exception through `format_error/2`, which already falls back for unrecognised types.
- **The SQL-shaped callbacks are optional, with defaults** — `list_schemas/1`, `resolve_table_namespace/3`, `default_schemas/1`, `builtin_schema_denies/1`, `quote_identifier/2`, `apply_filters/3`, `apply_sorts/3`, `query_plan/3`, `supports_feature?/2`, `db_type_to_lotus_type/2`, `editor_config/1`. A non-SQL adapter now implements the ten callbacks it needs rather than thirty, most of them stubs.
- **New optional `table_stats/3`.** `get_table_stats/3` hard-coded `SELECT COUNT(*)`, which no non-SQL source can answer. Adapters implementing the callback are asked first; everything else keeps the SQL fallback.
- **`%Statement{}` params accept a map**, for engines with named binds.
- **`t:Lotus.Source.Adapter.feature/0`** documents the atoms `supports_feature?/2` is asked about.

### Sources

- **`%{adapter: Module, ...}` is the canonical data source entry** — used directly, no `can_handle?/1` probing. Two adapters claiming the same non-canonical entry now raise and name themselves instead of the first one silently winning.
- **An unresolvable data source is an error, not the default source.** A typo in a saved query's `data_source`, or a source dropped from config, used to fall through and return rows from the wrong database. Only a caller that names no source at all gets the default.

### Visibility and middleware

- **Scoped visibility is enforced at execution.** `Preflight.authorize/4` takes the caller's `:scope`, and the Runner threads `:scope` into both preflight and column policies. A resolver denying a table for one tenant previously hid it from the explorer while a query against it still returned rows.
- **`:before_query` plugs can rewrite the statement.** The Runner discarded the returned payload, so row-level security and tenant predicates had no way to change what runs. `:before_query` consequently moves *ahead of* sanitization and preflight, so those checks apply to the statement that will actually execute — a plug cannot rewrite its way onto a denied table.

### AI

- **Public `:sql` keys renamed to `:statement`** — `generate_query/1`, `generate_query_with_context/1`, `explain_query/1`, `Conversation` messages, and `ErrorDetector`'s `:failed_statement`.
- **`:context` and `:scope` are threaded through the AI layer.** Eight call sites ran queries and listed tables with no actor, so an access-control plug or a scoped resolver saw `nil` for every AI-initiated action and the AI could see more than the user it acts for. `Tool.from_action/2` gained `:context`; `Action.actor_opts/1` converts it back to the options the `Lotus` functions take.

### Telemetry

- **`[:lotus, :query, :start | :stop | :exception]` carry `:source` and `:statement`.** The Runner emitted `:repo` while every middleware payload already used `:source`, and the docs still described `:sql` / `:params` keys the events had not carried since the statement pipeline landed.

### Docs

- **`Lotus.Source.Adapters.Ecto.Dialect` is public.** The adapter guide told external libraries to implement it while it was `@moduledoc false` and absent from the generated docs. `set_statement_timeout/2` and `set_search_path/2` became optional.
- **The two-level relation rule is stated** in both the behaviour and the guide: relations are `{schema | nil, table}` everywhere, and engines with a deeper hierarchy flatten the upper levels into the schema part.
- Corrected the `%Statement{}` payload field in the behaviour docs (`:text` → `:body`), repointed the ex_doc module grouping at the live `Lotus.Source.Adapters` namespace, and cleared every dangling doc reference outside the upgrade guide.
- Fixed specs that had drifted: `run_statement/3` claimed `binary()` statements, and the shared `opts` type never declared `:scope` or `:sorts` despite reading both.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

Written test-first, one task at a time, with the full suite run after each.

```
mix compile --warnings-as-errors   # clean
mix format --check-formatted       # clean
mix test                           # 13 doctests, 1906 tests, 0 failures
```

Baseline on `main` was 1864 tests; this adds 42. The suite was run three times with random seeds after the final change, since one new test compiles middleware into `:persistent_term` and an early version of it leaked into other modules.

New test files:

- `test/lotus/query/statement_test.exs` — map and list params
- `test/lotus/source/adapters/ecto/dialect_test.exs` — the published Dialect contract, and a minimal dialect that omits both session hooks
- `test/lotus/middleware_statement_rewrite_test.exs` — a rewritten statement is the one executed, and a rewrite onto a blocked table is caught
- `test/lotus/ai/actor_threading_test.exs` — the actor reaches actions, and a scoped deny stops an AI-initiated query

## Environment (if applicable)

**Elixir & OTP versions:** Elixir 1.18.3, OTP 27

**Dependencies:** none changed.

## Breaking changes

All against the pre-1.0 adapter and AI surface. `CHANGELOG.md` and `guides/upgrading-to-v1.md` describe each with its migration.

**Adapter authors**

| Before | After |
|---|---|
| `query_plan(state, sql, params, opts)` | `query_plan(state, %Statement{}, opts)` |
| `limit_query(state, sql, limit) :: String.t()` | `limit_query(state, %Statement{}, limit) :: %Statement{}`, optional |
| `handled_errors/1` | removed — delete your implementation |
| Dialect `query_plan(repo, sql, params, opts)` | `query_plan(repo, %Statement{}, opts)` |
| Dialect `limit_query(sql, limit)` | `limit_query(%Statement{}, limit)` |
| Dialect `set_statement_timeout/2`, `set_search_path/2` required | optional — drop no-op clauses |

**Hosts**

- Telemetry handlers matching `%{repo: _}` on query events must switch to `:source`.
- `Lotus.AI` callers reading `result.sql` must read `result.statement`; `explain_query/1` takes `:statement`, not `:sql`.
- A `data_source` naming an unconfigured source now raises instead of quietly running against the default source. This is the one change that can surface as a new error in existing code — it is a bug being fixed, not a behaviour to preserve.
- `:before_query` plugs now run before sanitization and preflight. Plugs that return their payload untouched are unaffected.

## Documentation

- [ ] This change requires documentation updates
- [x] Documentation has been updated
- [ ] No documentation changes needed

`CHANGELOG.md` (Unreleased), `guides/upgrading-to-v1.md`, `guides/source-adapters.md`, `guides/middleware.md`, `guides/telemetry.md`, `guides/ai_query_generation.md`, `guides/caching.md`, `guides/configuration.md`, `guides/contributing.md`.

`mix docs` warnings drop from 60 to 24. All 24 remaining are `upgrading-to-v1.md` naming 0.16 functions on purpose.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that this change doesn't introduce security vulnerabilities

Two of these changes close gaps that were security-relevant: scoped visibility now blocks execution rather than only hiding tables in the explorer, and a `:before_query` rewrite is sanitized and authorized rather than executed unchecked.

## Related issues

Relates to #232

## Additional context

Deliberately **not** included:

- **No `query_language` column / V5 migration.** It is additive and can land in 1.x without breaking anything, so it does not need to block the tag. The language-aware AI fences and tool names depend on it and are parked alongside it.
- **MSSQL and Oracle** stay out. The pluggable registry they needed shipped in #216, so they can be external libraries after 1.0.

Two ordering decisions are worth a reviewer's attention, since both go slightly beyond a literal "make the signature right" reading:

1. `:before_query` moved ahead of sanitization and preflight. Capturing the rewritten statement without moving it would have left rewrites unchecked.
2. Scoped visibility reaches column policies as well as preflight, so masking and omission are scoped consistently with table access.
