### PR TITLE
Feat/dynamic options feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,6 +550,15 @@
 
 ### Added
 
+- **`:dynamic_options` feature atom** — `supports_feature?/2` now answers
+  a documented `:dynamic_options` question: whether a query against this
+  source can return a flat list of values suitable for populating a
+  variable's dropdown. Every built-in SQL dialect (Postgres, MySQL,
+  SQLite, and the generic Ecto fallback) answers `true`; adapters whose
+  query language returns shaped documents rather than rows answer
+  `false`, and the dashboard then offers manual option entry only
+  (elixir-lotus/lotus_web#127).
+
 - **`editor_config/1` exposes two optional extension points** —
   `:dialect_spec` (SQL tokenizer options: identifier quotes, operator
   chars, hash / slash / dollar-quoted string rules, PL/SQL quoting,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,6 +550,12 @@
 
 ### Added
 
+- **An empty middleware config clears the compiled pipeline** —
+  `Lotus.Middleware.compile/1` used to ignore an empty or missing config,
+  so a config reload could add middleware but never take it away. It now
+  erases the compiled pipeline, which also lets a host app (or a test)
+  turn middleware off at runtime.
+
 - **`:dynamic_options` feature atom** — `supports_feature?/2` now answers
   a documented `:dynamic_options` question: whether a query against this
   source can return a flat list of values suitable for populating a

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -87,6 +87,9 @@ defmodule Lotus.Middleware do
   @doc """
   Compiles all middleware by calling `init/1` on each module and stores
   the result in `:persistent_term` for fast runtime access.
+
+  An empty config clears the compiled pipeline, so reloading a config that
+  no longer declares middleware actually turns it off.
   """
   @spec compile(map()) :: :ok
   def compile(middleware_config) when is_map(middleware_config) and middleware_config != %{} do
@@ -103,7 +106,10 @@ defmodule Lotus.Middleware do
     :persistent_term.put(@persistent_term_key, compiled)
   end
 
-  def compile(_), do: :ok
+  def compile(_) do
+    :persistent_term.erase(@persistent_term_key)
+    :ok
+  end
 
   @doc """
   Runs the middleware pipeline for the given event.

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -575,11 +575,24 @@ defmodule Lotus.Source.Adapter do
       function, so the transformer can rewrite `INTERVAL '{{n}} days'`
       into a parameterized call instead of inlining the value.
 
+    * `:dynamic_options` — a query against this source can return a flat
+      list of values suitable for populating a variable's dropdown, so the
+      UI offers query-based option population alongside manual entry. True
+      for every SQL source. False for sources whose query language returns
+      shaped documents rather than rows (Elasticsearch), where the user
+      enters dropdown options by hand.
+
   Answer `false` for anything you do not recognise; the built-in dialects
   all end with a catch-all clause that does exactly that.
   """
   @type feature ::
-          :schema_hierarchy | :search_path | :arrays | :json | :make_interval | atom()
+          :schema_hierarchy
+          | :search_path
+          | :arrays
+          | :json
+          | :make_interval
+          | :dynamic_options
+          | atom()
 
   @doc """
   Whether this adapter supports a given feature.

--- a/lib/lotus/source/adapters/ecto/dialects/default.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/default.ex
@@ -131,6 +131,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Default do
   end
 
   @impl true
+  def supports_feature?(:dynamic_options), do: true
   def supports_feature?(_), do: false
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/mysql.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/mysql.ex
@@ -274,6 +274,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.MySQL do
   def supports_feature?(:make_interval), do: false
   def supports_feature?(:arrays), do: false
   def supports_feature?(:json), do: true
+  def supports_feature?(:dynamic_options), do: true
   def supports_feature?(_), do: false
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/postgres.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/postgres.ex
@@ -177,6 +177,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Postgres do
   def supports_feature?(:make_interval), do: true
   def supports_feature?(:arrays), do: true
   def supports_feature?(:json), do: true
+  def supports_feature?(:dynamic_options), do: true
   def supports_feature?(_), do: false
 
   @impl true

--- a/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
@@ -171,6 +171,7 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
   def supports_feature?(:make_interval), do: false
   def supports_feature?(:arrays), do: false
   def supports_feature?(:json), do: true
+  def supports_feature?(:dynamic_options), do: true
   def supports_feature?(_), do: false
 
   @impl true

--- a/test/lotus/sources_test.exs
+++ b/test/lotus/sources_test.exs
@@ -247,6 +247,12 @@ defmodule Lotus.SourcesTest do
       assert Source.supports_feature?("mysql", :schema_hierarchy) == false
       assert Source.supports_feature?("sqlite", :schema_hierarchy) == false
     end
+
+    test "every SQL source populates dropdown options from a query" do
+      assert Source.supports_feature?("postgres", :dynamic_options) == true
+      assert Source.supports_feature?("mysql", :dynamic_options) == true
+      assert Source.supports_feature?("sqlite", :dynamic_options) == true
+    end
   end
 
   describe "query_language/1" do


### PR DESCRIPTION
## Summary

Two small additive changes the dashboard needs before the 1.0.0 tag.

`supports_feature?/2` learns a documented `:dynamic_options` question — whether a query against this source can return a flat list of values suitable for populating a variable's dropdown. lotus_web gates its "From query" dropdown mode on it (elixir-lotus/lotus_web#127); without the atom in core, every adapter answers `false` through the existing catch-all and the feature switches off for Postgres too.

`Lotus.Middleware.compile/1` also stops ignoring an empty config. It used to return `:ok` without touching `:persistent_term`, so a config reload could add middleware but never take it away.

Both land before 1.0.0 because the feature atom is part of the frozen adapter contract.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Changes made

**`:dynamic_options` feature atom**

- `lib/lotus/source/adapter.ex` — documents the atom in `t:feature/0` alongside `:schema_hierarchy`, `:search_path`, `:arrays`, `:json` and `:make_interval`, and adds it to the union.
- `lib/lotus/source/adapters/ecto/dialects/{postgres,mysql,sqlite,default}.ex` — every built-in SQL dialect answers `true`, including the generic Ecto fallback, since any SQL source can `SELECT` a flat list.
- Adapters that return shaped documents rather than rows (Elasticsearch) answer `false` through the catch-all clause they already have. No adapter has to change to keep working.

**Middleware reset**

- `lib/lotus/middleware.ex` — the catch-all `compile/1` clause erases the compiled pipeline instead of returning `:ok`, so "no middleware configured" actually means no pipeline. Also lets a test turn middleware off between cases.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

`test/lotus/sources_test.exs` gains a case asserting all three built-in SQL sources answer `true` for `:dynamic_options`, next to the existing per-feature cases.

`mix test` — 1940 passing (13 doctests, 1927 tests), 0 failures.

Exercised end to end from lotus_web on the v1 release branch: the dropdown modal offers "From query" for the Postgres sources and manual entry only for a source that declines the feature. The middleware reset is what lets lotus_web's new actor-plumbing test install a recorder plug per case and clear it afterwards.

## Environment (if applicable)

**Elixir & OTP versions:** Elixir 1.20.1, OTP 29

**Dependencies:** none

## Breaking changes

None. `t:feature/0` is an open type and `supports_feature?/2` already returns `false` for unrecognised atoms, so external adapters compile and behave exactly as before — they simply answer `false` for `:dynamic_options` until they choose otherwise.

The middleware change alters behaviour only for a caller that reloads config to remove middleware, which previously did nothing.

## Documentation

- [ ] This change requires documentation updates
- [x] Documentation has been updated
- [ ] No documentation changes needed

`t:feature/0` and `compile/1` moduledocs updated in place; both entries added to the Unreleased CHANGELOG under `### Added`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that this change doesn't introduce security vulnerabilities

`mix format` clean.

## Related issues

Relates to elixir-lotus/lotus_web#127
Relates to #232

## Additional context

Part of the 1.0.0 release train — Phase 1 (core API-freeze fixes) before the tag, consumed by Phase 3 (lotus_web). The `:dynamic_options` gating and the actor plumbing that depends on the middleware reset are already implemented on lotus_web's `release/v1.0-prep`.
