### PR TITLE
chore(release): prepare 1.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.0-rc.1] - 2026-09-11
 
 > **v1.0 is a large rewrite and not a drop-in upgrade from the v0.16.x
 > line.** The motivating goal was to stop assuming every data source is

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Get a fully working BI dashboard in your Phoenix app in under 5 minutes.
 # mix.exs
 def deps do
   [
-    {:lotus, "~> 0.16.1"},
-    {:lotus_web, "~> 0.14.0"}
+    {:lotus, "~> 1.0.0-rc.1"},
+    {:lotus_web, "~> 1.0.0-rc.1"}
   ]
 end
 ```

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -16,7 +16,7 @@ Add `lotus` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:lotus, "~> 0.16.1"}
+    {:lotus, "~> 1.0.0-rc.1"}
   ]
 end
 ```
@@ -240,8 +240,8 @@ Add `lotus_web` to your dependencies:
 ```elixir
 def deps do
   [
-    {:lotus, "~> 0.16.1"},
-    {:lotus_web, "~> 0.14.0"}
+    {:lotus, "~> 1.0.0-rc.1"},
+    {:lotus_web, "~> 1.0.0-rc.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-lotus/lotus"
-  @version "0.16.4"
+  @version "1.0.0-rc.1"
 
   def project do
     [


### PR DESCRIPTION
Bump the version, close the Unreleased changelog section as 1.0.0-rc.1, and point the installation snippets at the release candidate.