### PR TITLE
feat(middleware): expose bound query variables to before/after_query plugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Bound query variables in middleware payloads.** `:before_query` and
+  `:after_query` plugs receive a `:vars` key with the merged variable map
+  (defaults plus caller-supplied values, keyed by variable name), or `%{}`
+  for a raw `Lotus.run_statement/3`. Plugs can enforce rules on the values a
+  user picked — maximum date ranges, tenant checks — without parsing the
+  statement. See the middleware guide for a date-range limit example (#97).
+- **`Lotus.Config.t()` lists every configuration key**, including
+  `:allow_unrestricted_resources`, `:ai`, `:source_adapters`,
+  `:trusted_source_adapters`, `:source_resolver`, `:visibility_resolver`
+  and `:middleware`.
+
 ## [1.0.0-rc.1] - 2026-09-11
 
 > **v1.0 is a large rewrite and not a drop-in upgrade from the v0.16.x

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -25,13 +25,15 @@ Each middleware receives a payload map whose contents depend on the pipeline eve
 
 | Event | Triggered | Payload keys |
 |-------|-----------|--------------|
-| `:before_query` | Before sanitization, preflight and execution | `:statement`, `:source`, `:context` |
-| `:after_query` | After execution, before result returned to caller | `:result`, `:statement`, `:source`, `:context` |
+| `:before_query` | Before sanitization, preflight and execution | `:statement`, `:source`, `:context`, `:vars` |
+| `:after_query` | After execution, before result returned to caller | `:result`, `:statement`, `:source`, `:context`, `:vars` |
 | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
 | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |
-| `:after_get_table_schema` | After table schema introspection and column visibility | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
+| `:after_describe_table` | After table schema introspection and column visibility | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
 | `:after_list_relations` | After relation discovery and visibility filtering | `:relations`, `:source`, `:scope`, `:context` |
 | `:after_discover` | After any discovery call, following the kind-specific `:after_list_*` event | `:kind`, `:result`, `:source`, `:scope`, `:context` |
+
+`:vars` is the map of bound query variables by name, after defaults and caller-supplied values are merged. It is `%{}` for a raw statement run through `Lotus.run_statement/3`.
 
 ### Discovery event ordering
 
@@ -160,14 +162,14 @@ Block queries that don't include a tenant filter:
 defmodule MyApp.TenantMiddleware do
   def init(opts), do: opts
 
-  def call(%{sql: sql, context: context} = payload, _opts) do
+  def call(%{statement: statement, context: context} = payload, _opts) do
     tenant_id = Map.get(context || %{}, :tenant_id)
 
     cond do
       is_nil(tenant_id) ->
         {:halt, "tenant context required"}
 
-      not String.contains?(String.downcase(sql), "tenant_id") ->
+      not String.contains?(String.downcase(statement.body), "tenant_id") ->
         {:halt, "queries must filter by tenant_id"}
 
       true ->
@@ -178,6 +180,34 @@ end
 ```
 
 > **Note:** The `String.contains?` check above is intentionally simplified for illustration. It can be bypassed (e.g. via SQL comments). For real row-level security, inject a parameterized filter using the `:filters` option on `Lotus.run_query/2` instead of inspecting raw SQL text.
+
+### Limiting Variable Values
+
+Reject a query when the caller picks a date range that is too wide. The plug reads the bound variables from `:vars`, so it works on every path that runs a saved query: the editor, dashboards, exports and the AI assistant.
+
+```elixir
+config :lotus,
+  middleware: %{before_query: [{MyApp.DateRangeLimit, max_days: 5}]}
+
+defmodule MyApp.DateRangeLimit do
+  def init(opts), do: opts
+
+  def call(%{vars: %{"start_date" => from, "end_date" => to}} = payload, opts) do
+    with {:ok, from} <- Date.from_iso8601(to_string(from)),
+         {:ok, to} <- Date.from_iso8601(to_string(to)),
+         true <- Date.diff(to, from) <= opts[:max_days] do
+      {:cont, payload}
+    else
+      _ -> {:halt, "Date range must be #{opts[:max_days]} days or less"}
+    end
+  end
+
+  # Queries without those variables are not affected.
+  def call(payload, _opts), do: {:cont, payload}
+end
+```
+
+Use `payload.context` in the same plug for per-user exceptions, or `payload.source` for per-source limits.
 
 ### Redacting Sensitive Data in Results
 

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -459,7 +459,7 @@ defmodule Lotus do
 
     if language_compatible?(q.query_language, adapter_language) do
       search_path = Keyword.get(opts, :search_path) || q.search_path
-      runner_opts = prepare_final_opts(opts, search_path)
+      runner_opts = opts |> prepare_final_opts(search_path) |> Keyword.put(:vars, vars)
 
       execute_with_options(adapter, body, params, opts, runner_opts, vars, q.id)
     else

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -83,7 +83,14 @@ defmodule Lotus.Config do
           table_visibility: map(),
           column_visibility: map(),
           schema_visibility: map(),
-          cache: cache_config()
+          allow_unrestricted_resources: boolean(),
+          cache: cache_config(),
+          ai: keyword() | map() | nil,
+          source_adapters: [module()],
+          trusted_source_adapters: [module()],
+          source_resolver: module(),
+          visibility_resolver: module(),
+          middleware: %{atom() => [{module(), term()}]}
         }
 
   @type cache_config :: %{

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -19,13 +19,19 @@ defmodule Lotus.Middleware do
 
   | Event | Triggered | Payload keys |
   |-------|-----------|--------------|
-  | `:before_query` | After preflight visibility check, before execution | `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context` |
-  | `:after_query` | After execution, before result returned to caller | `:result`, `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context` |
+  | `:before_query` | After preflight visibility check, before execution | `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
+  | `:after_query` | After execution, before result returned to caller | `:result`, `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
   | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
   | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |
   | `:after_describe_table` | After table schema introspection and column visibility | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
   | `:after_list_relations` | After relation discovery and visibility filtering | `:relations`, `:source`, `:scope`, `:context` |
   | `:after_discover` | After any discovery call, following the kind-specific `:after_list_*` event | `:kind`, `:result`, `:source`, `:scope`, `:context` |
+
+  `:vars` is the map of bound query variables, by name, after defaults and
+  caller-supplied values are merged (`%{"start_date" => "2026-01-01"}`).
+  It is `%{}` for a raw statement run through `Lotus.run_statement/3`. A plug
+  can enforce rules on the values a caller picked (date-range limits, tenant
+  checks) without parsing the statement.
 
   ### Discovery event ordering
 

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -23,13 +23,16 @@ defmodule Lotus.Runner do
           statement_timeout_ms: non_neg_integer(),
           read_only: boolean(),
           search_path: String.t() | nil,
-          scope: term()
+          scope: term(),
+          context: term(),
+          vars: map()
         ]
 
   @spec run_statement(Adapter.t(), Statement.t(), opts()) ::
           {:ok, query_result()} | {:error, term()}
   def run_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
     context = Keyword.get(opts, :context)
+    vars = Keyword.get(opts, :vars) || %{}
     telemetry_meta = %{source: adapter.name, statement: statement, context: context}
     start_time = Telemetry.query_start(telemetry_meta)
 
@@ -38,11 +41,12 @@ defmodule Lotus.Runner do
     # predicates. Sanitization and preflight then apply to what will actually
     # execute, rather than to the text the caller originally supplied.
     result =
-      with {:ok, %Statement{} = statement} <- run_before_query(adapter, statement, context),
+      with {:ok, %Statement{} = statement} <-
+             run_before_query(adapter, statement, context, vars),
            :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
            :ok <- preflight_visibility(adapter, statement, opts),
            {:ok, %Result{} = res} <- exec_read_only(adapter, statement, opts),
-           {:ok, %Result{} = res} <- run_after_query(adapter, statement, res, context) do
+           {:ok, %Result{} = res} <- run_after_query(adapter, statement, res, context, vars) do
         {:ok, res}
       end
 
@@ -246,8 +250,8 @@ defmodule Lotus.Runner do
   # payload has its version carried forward; one that returns the payload
   # untouched leaves the original in place. Anything that is not a statement
   # is ignored rather than trusted.
-  defp run_before_query(%Adapter{} = adapter, %Statement{} = statement, context) do
-    payload = %{source: adapter.name, statement: statement, context: context}
+  defp run_before_query(%Adapter{} = adapter, %Statement{} = statement, context, vars) do
+    payload = %{source: adapter.name, statement: statement, context: context, vars: vars}
 
     case Middleware.run(:before_query, payload) do
       {:cont, %{statement: %Statement{} = rewritten}} -> {:ok, rewritten}
@@ -260,9 +264,16 @@ defmodule Lotus.Runner do
          %Adapter{} = adapter,
          %Statement{} = statement,
          %Result{} = result,
-         context
+         context,
+         vars
        ) do
-    payload = %{source: adapter.name, statement: statement, result: result, context: context}
+    payload = %{
+      source: adapter.name,
+      statement: statement,
+      result: result,
+      context: context,
+      vars: vars
+    }
 
     case Middleware.run(:after_query, payload) do
       {:cont, %{result: res}} -> {:ok, res}

--- a/test/lotus/middleware_vars_payload_test.exs
+++ b/test/lotus/middleware_vars_payload_test.exs
@@ -1,0 +1,87 @@
+defmodule Lotus.MiddlewareVarsPayloadTest do
+  @moduledoc """
+  `:before_query` and `:after_query` plugs receive the bound query variables
+  under `:vars`, so a plug can enforce rules on the values a caller picked
+  (date-range limits, tenant checks) without parsing the statement.
+  """
+
+  use Lotus.Case
+
+  alias Lotus.Middleware
+  alias Lotus.Test.Schemas.User
+
+  defmodule CaptureVarsPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{vars: vars} = payload, event: event) do
+      send(self(), {event, vars})
+      {:cont, payload}
+    end
+  end
+
+  defmodule MaxRangePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{vars: %{"min_age" => min, "max_age" => max}} = payload, max_span: span) do
+      if max - min <= span do
+        {:cont, payload}
+      else
+        {:halt, "age range must be #{span} or less"}
+      end
+    end
+
+    def call(payload, _opts), do: {:cont, payload}
+  end
+
+  setup do
+    on_exit(fn -> :persistent_term.erase({Lotus.Middleware, :compiled}) end)
+
+    Repo.insert!(%User{id: 1, name: "Ada", email: "ada@example.test", age: 36})
+    Repo.insert!(%User{id: 2, name: "Grace", email: "grace@example.test", age: 85})
+
+    {:ok, query} =
+      Lotus.create_query(%{
+        name: "Users by age",
+        statement: "SELECT name FROM test_users WHERE age >= {{min_age}} AND age <= {{max_age}}",
+        data_source: "postgres",
+        variables: [
+          %{name: "min_age", type: :number, default: "18"},
+          %{name: "max_age", type: :number}
+        ]
+      })
+
+    %{query: query}
+  end
+
+  test "both hooks see the merged variables: defaults plus supplied values", %{query: query} do
+    Middleware.compile(%{
+      before_query: [{CaptureVarsPlug, [event: :before]}],
+      after_query: [{CaptureVarsPlug, [event: :after]}]
+    })
+
+    assert {:ok, _} = Lotus.run_query(query, vars: %{"max_age" => 40})
+
+    assert_receive {:before, %{"min_age" => "18", "max_age" => 40}}
+    assert_receive {:after, %{"min_age" => "18", "max_age" => 40}}
+  end
+
+  test "a raw statement carries an empty vars map" do
+    Middleware.compile(%{before_query: [{CaptureVarsPlug, [event: :before]}]})
+
+    assert {:ok, _} = Lotus.run_statement("SELECT 1", [], repo: "postgres")
+    assert_receive {:before, vars}
+    assert vars == %{}
+  end
+
+  test "a plug can halt on the variable values", %{query: query} do
+    Middleware.compile(%{before_query: [{MaxRangePlug, [max_span: 10]}]})
+
+    assert {:error, "age range must be 10 or less"} =
+             Lotus.run_query(query, vars: %{"min_age" => 20, "max_age" => 90})
+
+    assert {:ok, result} = Lotus.run_query(query, vars: %{"min_age" => 30, "max_age" => 40})
+    assert result.rows == [["Ada"]]
+  end
+end


### PR DESCRIPTION
## Summary

Closes #97.

`:before_query` and `:after_query` plugs now receive a `:vars` key: the merged variable map (defaults plus caller-supplied values, keyed by variable name), or `%{}` for a raw `Lotus.run_statement/3`. A plug can enforce rules on the values a user picked, such as a maximum date range or a tenant check, without parsing the statement.

Additive. The key is part of the 1.0 middleware contract, so it lands before the tag.

## Changes

- `Lotus.Runner`: reads `:vars` from the runner opts and adds it to both payloads; `opts()` type lists `:context` and `:vars`.
- `Lotus.run_query/2`: passes the merged variables (not only the caller-supplied ones) into the runner opts.
- `Lotus.Middleware` docs and `guides/middleware.md`: payload table gains `:vars`; the guide's event table now names `:after_describe_table`; the row-level security example reads `statement.body` instead of the removed `:sql` key; new "Limiting Variable Values" example with a date-range plug.
- `Lotus.Config.t()` lists every configuration key.
- CHANGELOG: new `[Unreleased]` section.

## Tests

`test/lotus/middleware_vars_payload_test.exs`: both hooks see the merged map, a raw statement sees `%{}`, and a plug can halt on the values.

## Verification

- `mix compile --warnings-as-errors` clean
- `mix format --check-formatted` clean
- `mix credo --strict` no issues
- `mix test`: 13 doctests, 1930 tests, 0 failures
- `mix docs`: 0 warnings