### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,6 @@
 # Changelog
 
-## [Unreleased]
-
-### Added
-
-- **Bound query variables in middleware payloads.** `:before_query` and
-  `:after_query` plugs receive a `:vars` key with the merged variable map
-  (defaults plus caller-supplied values, keyed by variable name), or `%{}`
-  for a raw `Lotus.run_statement/3`. Plugs can enforce rules on the values a
-  user picked — maximum date ranges, tenant checks — without parsing the
-  statement. See the middleware guide for a date-range limit example (#97).
-- **`Lotus.Config.t()` lists every configuration key**, including
-  `:allow_unrestricted_resources`, `:ai`, `:source_adapters`,
-  `:trusted_source_adapters`, `:source_resolver`, `:visibility_resolver`
-  and `:middleware`.
-
-## [1.0.0-rc.1] - 2026-09-11
+## [1.0.0] - 2026-09-12
 
 > **v1.0 is a large rewrite and not a drop-in upgrade from the v0.16.x
 > line.** The motivating goal was to stop assuming every data source is
@@ -565,6 +550,16 @@
 
 ### Added
 
+- **Bound query variables in middleware payloads.** `:before_query` and
+  `:after_query` plugs receive a `:vars` key with the merged variable map
+  (defaults plus caller-supplied values, keyed by variable name), or `%{}`
+  for a raw `Lotus.run_statement/3`. Plugs can enforce rules on the values a
+  user picked — maximum date ranges, tenant checks — without parsing the
+  statement. See the middleware guide for a date-range limit example (#97).
+- **`Lotus.Config.t()` lists every configuration key**, including
+  `:allow_unrestricted_resources`, `:ai`, `:source_adapters`,
+  `:trusted_source_adapters`, `:source_resolver`, `:visibility_resolver`
+  and `:middleware`.
 - **An empty middleware config clears the compiled pipeline** —
   `Lotus.Middleware.compile/1` used to ignore an empty or missing config,
   so a config reload could add middleware but never take it away. It now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,9 @@
   payloads (JSON maps, DSL ASTs) in `:body` without serializing to
   strings. Constructor: `Lotus.Query.Statement.new(body, params \\ [])`.
   `Lotus.Runner.run_statement/3` takes
-  `(%Adapter{}, %Statement{}, opts)`. `Lotus.Preflight.authorize/3`
-  takes `(%Adapter{}, %Statement{}, search_path)`. The `:sql`/`:params`
-  tuple shape is gone from the pipeline.
+  `(%Adapter{}, %Statement{}, opts)`. `Lotus.Preflight.authorize/4`
+  takes `(%Adapter{}, %Statement{}, search_path, scope)`. The
+  `:sql`/`:params` tuple shape is gone from the pipeline.
 
 - **Pagination count queries moved into `statement.meta[:count_spec]`.**
   `apply_pagination/3` returns a single `%Statement{}` whose `:meta`
@@ -550,6 +550,15 @@
 
 ### Added
 
+- **Renamed config keys now fail loudly.** `:ecto_repo`, `:data_repos` and
+  `:default_repo` were dropped silently by the config loader, so an app
+  upgrading from 0.16 was told `:storage_repo` was missing rather than that
+  the key had moved. Lotus now raises and names every renamed key it finds.
+- **A stale `data_repo` attribute is rejected.** `Lotus.create_query/1` and
+  `update_query/2` used to drop the unpermitted key and save the query with
+  no source, which then resolved to the default source at run time — a
+  multi-source host silently queried the wrong database. The changeset now
+  returns an error on `:data_source` instead.
 - **Bound query variables in middleware payloads.** `:before_query` and
   `:after_query` plugs receive a `:vars` key with the merged variable map
   (defaults plus caller-supplied values, keyed by variable name), or `%{}`
@@ -664,6 +673,17 @@
   against the cache facade (#161).
 
 ### Changed
+
+- **Schema-introspection telemetry emits `:source`, not `:repo`.** The
+  `[:lotus, :schema, :introspection, :*]` events carried the source name
+  under `:repo` while the query events used `:source` for the same value.
+  Handlers matching on `:repo` must be updated.
+- **The guides were rewritten against the v1 code.** Every guide was audited
+  callback by callback and key by key: the configuration, caching and
+  introspection guides still taught pre-v1 config keys and removed
+  functions, the adapter guide's callback table did not match the
+  behaviour, and several examples could not have run. `guides/schema-introspection.md`
+  now ships with the docs; it was never listed in the extras before.
 
 - `:sha256` column masks hash a rendered form of values that are neither text
   nor binary, so digests change for those columns: a `NaiveDateTime` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,6 +550,15 @@
 
 ### Added
 
+- **Cache entry options are read from config.** `:max_bytes`, `:compress`
+  and `:lock_timeout` were declared in `Lotus.Config.cache_config/0` but
+  nothing read them from the application environment: the first two worked
+  only as a per-call `:cache` option and `:lock_timeout` was unreachable
+  from every caller, so it was always 10 seconds. They are deployment
+  policy, so they now come from `config :lotus, cache: %{...}`, and a
+  per-call `:cache` option still overrides them. New:
+  `Lotus.Config.cache_entry_options/0` and `Lotus.Cache.build_options/2`,
+  which replaces the two private copies that had drifted apart.
 - **Renamed config keys now fail loudly.** `:ecto_repo`, `:data_repos` and
   `:default_repo` were dropped silently by the config loader, so an app
   upgrading from 0.16 was told `:storage_repo` was missing rather than that

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Get a fully working BI dashboard in your Phoenix app in under 5 minutes.
 # mix.exs
 def deps do
   [
-    {:lotus, "~> 1.0.0-rc.1"},
-    {:lotus_web, "~> 1.0.0-rc.1"}
+    {:lotus, "~> 1.0"},
+    {:lotus_web, "~> 1.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   </a>
 </p>
 
-**The embeddable BI engine for Elixir apps — SQL editor, dashboards, visualizations, and AI-powered query generation that mount directly in your Phoenix app. No Metabase. No Redash. No extra infrastructure.**
+**The embeddable BI engine for Elixir apps — query editor, dashboards, visualizations, and AI-powered query generation that mount directly in your Phoenix app. SQL and non-SQL data sources behind one pluggable adapter contract. No Metabase. No Redash. No extra infrastructure.**
 
 [Try the live demo](https://lotus.typhoon.works/)
 
@@ -24,7 +24,9 @@
 
 Every app eventually needs analytics, reporting, or an internal SQL tool. The usual options — Metabase, Redash, Grafana — mean another service to deploy, another auth system to sync, another thing to keep running.
 
-Lotus takes a different approach: it mounts inside your Phoenix app. Add the dependency, run a migration, add one line to your router, and you have a full BI interface — SQL editor, charts, dashboards — running on your existing infrastructure. Read-only by design, production-safe from day one.
+Lotus takes a different approach: it mounts inside your Phoenix app. Add the dependency, run a migration, add one line to your router, and you have a full BI interface — query editor, charts, dashboards — running on your existing infrastructure. Read-only by design, production-safe from day one.
+
+And it is not limited to SQL. Every data source is wrapped behind a uniform `Lotus.Source.Adapter` contract, so a Postgres repo, a ClickHouse HTTP endpoint, and an Elasticsearch cluster all run through the same pipeline, the same visibility rules, the same cache, and the same AI assistant.
 
 ## See It in Action
 
@@ -32,7 +34,7 @@ Lotus takes a different approach: it mounts inside your Phoenix app. Add the dep
 
 **What you get out of the box:**
 - Ask your database questions in plain English — AI-powered query generation with multi-turn conversations, query explanations, and optimization suggestions (bring your own OpenAI, Anthropic, or Gemini key)
-- Web-based SQL editor with syntax highlighting and autocomplete
+- Web-based query editor with syntax highlighting and autocomplete
 - Interactive schema explorer for browsing tables and columns
 - 5 chart types (bar, line, area, scatter, pie) saved per query
 - Dashboards with grid layouts, auto-refresh, and public sharing
@@ -107,22 +109,26 @@ For the complete setup guide (caching, multiple databases, visibility controls),
 
 ## Features
 
-- **SQL editor** with syntax highlighting, autocomplete, and real-time execution
+- **Query editor** with syntax highlighting, autocomplete, and real-time execution
 - **Query management** — save, organize, and reuse queries with descriptive names
-- **Smart variables** — parameterize queries with `{{variable}}` syntax, configurable input widgets, and SQL-backed dropdown options
+- **Smart variables** — parameterize queries with `{{variable}}` syntax, configurable input widgets, and query-backed dropdown options. Each adapter owns its own substitution, so prepared-statement engines bind parameters while JSON/DSL engines inline properly escaped literals
 - **Visualizations** — 5 chart types (bar, line, area, scatter, pie) with renderer-agnostic config DSL
-- **Dashboards** — combine queries into interactive views with 12-column grid layouts, auto-refresh, and public sharing via secure tokens
-- **Multi-database support** — PostgreSQL, MySQL, and SQLite with per-query repo selection
-- **Result caching** — TTL-based caching with ETS backend, cache profiles, and tag-based invalidation
-- **CSV export** — download query results with streaming support for large datasets
-- **Result filters** — apply column-level filters on query results via `Lotus.Query.Filter`; multiple filters stack with AND and wrap the original query in a CTE for safe application
-- **Result sorting** — apply column-level sorting on query results via `Lotus.Query.Sort`; sorts wrap the original query in a CTE so they work safely with any SQL complexity
-- **Schema explorer** — browse tables, columns, and statistics interactively
-- **AI query generation** — ask your database questions in plain English; schema-aware, multi-turn conversations using OpenAI, Anthropic, or Gemini (BYOK)
+- **Dashboards** — combine queries into interactive views with 12-column grid layouts, filters mapped onto query variables, auto-refresh, and public sharing via secure tokens
+- **Pluggable data sources** — every source is wrapped in a uniform `Lotus.Source.Adapter` behaviour, so the execution pipeline is decoupled from Ecto and SQL. First-party adapters cover PostgreSQL, MySQL, and SQLite; external packages add [ClickHouse](https://github.com/elixir-lotus/lotus_clickhouse) and [Elasticsearch](https://github.com/elixir-lotus/lotus_elasticsearch). Custom adapters target anything else, and custom resolvers can load sources dynamically from a database or external service. See the [source adapters guide](guides/source-adapters.md)
+- **Result caching** — TTL-based caching with ETS or Cachex backends, cache profiles, a pluggable `Lotus.Cache.KeyBuilder`, and tag- and scope-based invalidation
+- **Exports** — CSV, JSON, and JSONL, with streaming CSV for large result sets and a ZIP export of a whole dashboard
+- **Result filters** — apply column-level filters on query results via `Lotus.Query.Filter`; multiple filters stack with AND, and each adapter declares which operators it supports
+- **Result sorting** — apply column-level sorting on query results via `Lotus.Query.Sort`, injected by the adapter rather than concatenated
+- **Windowed pagination** — `window: [limit: _, offset: _, count: :exact | :none]` on any query, with the exact total supplied either inline by the engine or by a separate count query
+- **Schema explorer** — browse namespaces, tables, columns, and statistics interactively
+- **AI query generation** — ask your database questions in plain English; schema-aware, multi-turn conversations using OpenAI, Anthropic, Gemini, or any other ReqLLM provider (BYOK)
 - **AI query explanation** — get plain-language explanations of what a query does, including selected fragments; understands Lotus `{{variable}}` and `[[optional]]` syntax
-- **AI query optimization** — get actionable optimization suggestions (indexes, rewrites, schema changes) powered by EXPLAIN plan analysis
+- **AI query optimization** — get actionable optimization suggestions (indexes, rewrites, schema changes) powered by query-plan analysis
+- **Adapter-driven AI** — each adapter describes its own query language, example query, syntax notes, and error patterns through `ai_context/1`, so the assistant speaks the engine's dialect instead of assuming SQL. Free-form adapter text only reaches the prompt for adapters you list in `:trusted_source_adapters`
+- **Three-level visibility** — schema, table, and column rules, with schema taking precedence over table and per-column `:omit` / `{:mask, _}` / `:error` policies applied to result rows
+- **Middleware** — a plug-style pipeline with `:before_query`, `:after_query`, and `:after_list_*` hooks for auditing, access control, and per-tenant statement rewriting
+- **Telemetry** — `[:lotus, ...]` events for query execution, schema introspection, and cache hits and misses
 - **Read-only by default** — all queries run in read-only transactions with automatic timeout controls and session state management (opt out per-query with `read_only: false`)
-- **Pluggable adapters** — data sources are wrapped in a uniform `Lotus.Source.Adapter` behaviour, decoupling the execution pipeline from Ecto. The default `Ecto` adapter works out of the box with your existing `data_sources` config. Custom adapters can target non-Ecto sources, and custom resolvers can load sources dynamically from a database or external service. See the [source adapters guide](guides/source-adapters.md).
 
 ## Production Ready
 
@@ -133,6 +139,8 @@ Lotus is built for production use from the ground up:
 - **Automatic type casting** — query variables are cast to match column types (UUIDs, dates, numbers, booleans, enums) using schema metadata, with graceful fallbacks.
 - **Timeout controls** — configurable per-query timeouts with sensible defaults.
 - **Defense-in-depth** — preflight authorization, schema/table/column visibility controls, and built-in system table protection.
+- **No silent degradation** — an adapter declares which filter operators it handles and whether it can enforce visibility. A filter it cannot express raises `Lotus.UnsupportedOperatorError`, and a source that cannot report which resources a statement touches is blocked until you opt in with `:allow_unrestricted_resources`.
+- **Language-aware saved queries** — a saved query records the `family:dialect` it was written for (`sql:postgres`, `json:elasticsearch`). Repointing it at a source that speaks a different language returns an error instead of handing the statement to an engine that cannot parse it.
 
 ## Using Lotus as a Library
 
@@ -157,6 +165,20 @@ config :lotus,
   }
 ```
 
+A data source value is either an Ecto repo module (handled by the built-in Ecto
+adapter) or a config map naming a custom adapter:
+
+```elixir
+config :lotus,
+  storage_repo: MyApp.Repo,
+  default_source: "main",
+  data_sources: %{
+    "main" => MyApp.Repo,
+    "events" => %{adapter: MyApp.ElasticsearchAdapter, url: "http://localhost:9200"}
+  },
+  source_adapters: [MyApp.ElasticsearchAdapter]
+```
+
 ### Creating and Running Queries
 
 ```elixir
@@ -169,33 +191,53 @@ config :lotus,
 # Execute a saved query
 {:ok, results} = Lotus.run_query(query)
 
-# Execute SQL directly (read-only)
+# Execute a statement directly (read-only)
 {:ok, results} = Lotus.run_statement("SELECT * FROM products WHERE price > $1", [100])
 
 # Execute against a specific data source
 {:ok, results} = Lotus.run_statement("SELECT COUNT(*) FROM events", [], repo: "analytics")
+
+# Page through results with an exact total
+{:ok, results} = Lotus.run_statement("SELECT * FROM orders", [],
+  window: [limit: 50, offset: 100, count: :exact]
+)
+results.meta.total_count
+```
+
+### Exploring the Schema
+
+```elixir
+Lotus.list_data_source_names()
+# => ["main", "analytics"]
+
+{:ok, tables}  = Lotus.list_tables("main")
+{:ok, columns} = Lotus.describe_table("main", "users")
+{:ok, stats}   = Lotus.get_table_stats("main", "users")
 ```
 
 ### AI Query Generation
 
-Ask your database questions in plain English. The AI assistant discovers your schema, respects visibility rules, and generates accurate, schema-qualified SQL. Supports multi-turn conversations for iterative refinement — no other embeddable BI tool does this.
+Ask your database questions in plain English. The AI assistant discovers your schema, respects visibility rules, and generates an accurate, schema-qualified statement in the language the source actually speaks — the adapter supplies its own example query, syntax notes, and error patterns. Supports multi-turn conversations for iterative refinement — no other embeddable BI tool does this.
 
 ```elixir
 {:ok, result} = Lotus.AI.generate_query(
   prompt: "Show all customers with unpaid invoices",
-  data_source: "my_repo"
+  data_source: "main"
 )
 
-result.sql
+result.statement
 #=> "SELECT c.id, c.name FROM reporting.customers c ..."
+
+result.model
+#=> "openai:gpt-4o"
 ```
 
 Get a plain-language explanation of any query (or a selected fragment):
 
 ```elixir
 {:ok, result} = Lotus.AI.explain_query(
-  sql: "SELECT d.name, COUNT(o.id) FROM departments d LEFT JOIN orders o ...",
-  data_source: "my_repo"
+  statement: "SELECT d.name, COUNT(o.id) FROM departments d LEFT JOIN orders o ...",
+  data_source: "main"
 )
 
 result.explanation
@@ -203,18 +245,21 @@ result.explanation
 
 # Explain just a highlighted fragment
 {:ok, result} = Lotus.AI.explain_query(
-  sql: "SELECT d.name FROM departments d LEFT JOIN employees e ON e.department_id = d.id",
+  statement: "SELECT d.name FROM departments d LEFT JOIN employees e ON e.department_id = d.id",
   fragment: "LEFT JOIN employees e ON e.department_id = d.id",
-  data_source: "my_repo"
+  data_source: "main"
 )
 ```
 
-Get optimization suggestions for existing queries:
+Get optimization suggestions for existing queries. `suggest_optimizations/1`
+takes a `%Lotus.Query.Statement{}` so it works for non-SQL engines too:
 
 ```elixir
+statement = Lotus.Query.Statement.new("SELECT * FROM orders WHERE created_at > $1", ["2024-01-01"])
+
 {:ok, result} = Lotus.AI.suggest_optimizations(
-  sql: "SELECT * FROM orders WHERE created_at > '2024-01-01'",
-  data_source: "my_repo"
+  statement: statement,
+  data_source: "main"
 )
 
 result.suggestions
@@ -222,17 +267,24 @@ result.suggestions
 #=>    "title" => "Add index on orders.created_at", ...}]
 ```
 
-Bring your own OpenAI, Anthropic, or Gemini API key. See the [AI query generation guide](guides/ai_query_generation.md) for setup, multi-turn conversation support, and query optimization.
+Bring your own API key for OpenAI, Anthropic, Gemini, or any other provider
+ReqLLM supports. A source whose adapter opts out of AI returns
+`{:error, :ai_not_supported_for_source}`. See the
+[AI query generation guide](guides/ai_query_generation.md) for setup,
+multi-turn conversation support, and query optimization.
 
 ## Configuration
 
 See the [configuration guide](guides/configuration.md) for all options including:
 
-- Data repository setup (single and multi-database)
+- Data source setup (single source, multi-database, and non-Ecto adapters)
+- Registering custom adapters (`:source_adapters`) and trusting their AI context (`:trusted_source_adapters`)
+- Custom source and visibility resolvers (`:source_resolver`, `:visibility_resolver`)
 - Schema, table, and column visibility controls
-- Cache backends and TTL profiles
+- Cache backends, TTL profiles, and key builders
+- Middleware pipelines
 - AI configuration
-- Query execution options (timeouts, search paths)
+- Query execution options (timeouts, search paths, read-only)
 
 ## Upgrading
 
@@ -240,6 +292,24 @@ Upgrading from Lotus v0.x? See the [upgrading to v1.0 guide](guides/upgrading-to
 for the full list of config renames, DB column renames, middleware/telemetry
 payload changes, and adapter-contract updates — plus a step-by-step
 upgrade checklist.
+
+## Data Sources
+
+| Source | Package | Query language |
+|---|---|---|
+| **PostgreSQL** | built in (`Lotus.Source.Adapters.Postgres`) | `sql:postgres` |
+| **MySQL** | built in (`Lotus.Source.Adapters.MySQL`) | `sql:mysql` |
+| **SQLite** | built in (`Lotus.Source.Adapters.SQLite3`) | `sql:sqlite` |
+| **Any other Ecto repo** | built in (`Lotus.Source.Adapters.Ecto` fallback) | `sql` |
+| **ClickHouse** | [lotus_clickhouse](https://github.com/elixir-lotus/lotus_clickhouse) | `sql:clickhouse` |
+| **Elasticsearch** | [lotus_elasticsearch](https://github.com/elixir-lotus/lotus_elasticsearch) | `json:elasticsearch` |
+| **Anything else** | your own `Lotus.Source.Adapter` | whatever you declare |
+
+Ecto-backed engines only need a dialect module
+(`use Lotus.Source.Adapters.Ecto, dialect: MyDialect`). Non-SQL engines
+implement `Lotus.Source.Adapter` directly and carry a native payload — a JSON
+map, a DSL AST — through the pipeline without ever serializing it to a string.
+See the [source adapters guide](guides/source-adapters.md).
 
 ## How Lotus Compares
 
@@ -249,7 +319,8 @@ upgrade checklist.
 | **Extra infra** | None | Java + DB | Python + Redis + DB | None | None |
 | **Auth** | Uses your app's auth | Separate auth system | Separate auth system | Uses your app's auth | Token-based |
 | **Language** | Elixir | Java/Clojure | Python | Ruby | Elixir |
-| **SQL editor** | Yes | Yes | Yes | Yes | Yes (in code cells) |
+| **Query editor** | Yes | Yes | Yes | Yes | Yes (in code cells) |
+| **Non-SQL sources** | Yes (pluggable adapters) | Yes | Yes | No | Yes (any Elixir client) |
 | **Dashboards** | Yes | Yes | Yes | No | No |
 | **Charts** | 5 types | Many | Many | 3 types | Via libraries |
 | **AI query gen** | Yes (BYOK) | No | No | No | No |
@@ -260,7 +331,8 @@ upgrade checklist.
 
 ### Prerequisites
 - Elixir 1.18+ / OTP 27+
-- PostgreSQL 14+, MySQL 8.0+, SQLite 3
+- Docker (the repo ships a `docker-compose.yml` with PostgreSQL 15 on port `2345` and MySQL 8.0 on port `3307`)
+- SQLite 3
 
 ### Setup
 
@@ -269,17 +341,20 @@ git clone https://github.com/elixir-lotus/lotus.git
 cd lotus
 mix deps.get
 
-# Optional: Start MySQL with Docker Compose
-docker compose up -d mysql
+# Start PostgreSQL and MySQL
+docker compose up -d
 
-mix ecto.create && mix ecto.migrate
+mix ecto.setup
 ```
 
 ### Running tests
 
 ```bash
+mix test.setup   # drop, create, and migrate the test databases
 mix test
 ```
+
+See the [contribution guide](guides/contributing.md) for the full workflow.
 
 ## Contributing
 

--- a/guides/advanced-variables.md
+++ b/guides/advanced-variables.md
@@ -1,6 +1,79 @@
 # Advanced Variables
 
-This guide covers advanced variable usage patterns in Lotus queries, including automatic type casting, SQL transformation, and advanced patterns for cross-database applications.
+This guide covers advanced variable usage patterns in Lotus queries: the `{{var}}` and `[[...]]` template syntax, variable definitions, automatic type casting, and — for Ecto-backed sources — the SQL transformer.
+
+## How a Query Is Compiled
+
+`Lotus.Storage.Query.compile/2` turns a stored query and a map of supplied
+values into an executable `%Lotus.Query.Statement{}`:
+
+```elixir
+{:ok, statement} = Lotus.Storage.Query.compile(query, %{"status" => "active"})
+
+statement.body    #=> the adapter-native payload (SQL text for Ecto sources)
+statement.params  #=> the bound values
+```
+
+`compile!/2` is the raising variant. `Lotus.run_query/2` calls `compile/2`
+for you, so you rarely call it directly.
+
+The steps, in order:
+
+1. `[[...]]` optional blocks are resolved against the supplied values
+2. The adapter rewrites the raw statement (`transform_statement/2`)
+3. Variable names are extracted in the order they appear
+4. Each value is cast, then folded through the adapter's
+   `substitute_variable/5` (or `substitute_list_variable/5`)
+
+Step 4 is where v1 differs most from earlier versions: **substitution is
+adapter-owned.** A prepared-statement adapter appends a placeholder to the
+body and pushes the value onto `params`; a JSON or DSL adapter inlines the
+value as a properly escaped literal in its own encoder. An adapter with no
+`{{var}}` model at all returns `{:error, :unsupported}`. You write
+`{{name}}` either way.
+
+> Before v1.0 this function was `Lotus.Storage.Query.to_sql_params` and
+> returned an `{sql, params}` tuple. See the
+> [upgrade guide](upgrading-to-v1.md).
+
+## Variable Definitions
+
+Each entry in a query's `:variables` list is a `Lotus.Storage.QueryVariable`:
+
+| Field | Values | Notes |
+|---|---|---|
+| `:name` | string | Required. Matches `{{name}}` in the statement |
+| `:type` | `:text`, `:number`, `:date` | Required. How the value is interpreted |
+| `:widget` | `:input`, `:select` | Defaults to `:input` |
+| `:label` | string | Human-friendly label for the UI |
+| `:default` | string | Used when no value is supplied. For `list: true`, a comma-separated string |
+| `:list` | boolean | Defaults to `false`. `true` accepts multiple values |
+| `:static_options` | list | Allowed values for a `:select` widget |
+| `:options_query` | string | Query returning `value` and `label` columns, for a dynamic `:select` |
+
+Those three types and two widgets are the complete set. A `:select` widget
+must define either `:static_options` or `:options_query`, or the changeset
+fails with `"select must define either static_options or options_query"`.
+
+`:static_options` accepts a list of strings or a list of `{value, label}`
+tuples (or maps), but the formats cannot be mixed within one variable.
+
+```elixir
+{:ok, query} = Lotus.create_query(%{
+  name: "Orders by Status",
+  statement: "SELECT * FROM orders WHERE status = {{status}}",
+  variables: [
+    %{
+      name: "status",
+      type: :text,
+      widget: :select,
+      label: "Order Status",
+      default: "pending",
+      static_options: [{"pending", "Pending"}, {"shipped", "Shipped"}]
+    }
+  ]
+})
+```
 
 ## Optional Variables (`[[...]]` Syntax)
 
@@ -95,27 +168,70 @@ Optional clauses work with list variables too:
 
 ### How It Works
 
-1. Before SQL transformation, Lotus scans for `[[...]]` blocks
+1. Before the adapter transforms the statement, Lotus scans for `[[...]]` blocks
 2. For each block, it checks whether all `{{variable}}` references inside have values
 3. If all variables have values, the `[[` and `]]` brackets are removed and the content is kept
 4. If any variable is missing/nil/empty, the entire block (including brackets) is removed
-5. The remaining SQL is then processed normally (variable substitution, type casting, etc.)
+5. The remainder is then processed normally (variable substitution, type casting, etc.)
+
+`Lotus.Query.OptionalClause` works on text, not on SQL specifically, so the
+same syntax applies to any textual query language. An adapter that builds an
+AST applies it before serializing.
+
+## Enforcing Limits on Supplied Values
+
+The bound variables reach `:before_query` and `:after_query` middleware under
+the `:vars` key — a map keyed by variable name, after defaults and
+caller-supplied values are merged. A plug can enforce rules on what the user
+picked (a maximum date range, a tenant check) without parsing the statement:
+
+```elixir
+%{statement: statement, source: source, context: context, vars: vars} = payload
+```
+
+For a raw statement run through `Lotus.run_statement/3`, `:vars` is `%{}`.
+See the [middleware guide](middleware.md) for a worked plug.
+
+## Saved Queries Record Their Language
+
+A stored query carries a `:query_language` (for example `"sql:postgres"`),
+recorded from the source it was written against. `Lotus.run_query/2`
+compares it with the resolved source's language and returns an error rather
+than sending the statement to an engine that cannot parse it:
+
+```elixir
+{:error, "Query was written for \"sql:postgres\" but data source \"warehouse\" speaks \"sql:clickhouse\""} =
+  Lotus.run_query(query, repo: "warehouse")
+```
+
+A query with no recorded language runs anywhere, which is how every query
+predating the column behaves.
 
 ## Automatic Type Casting
 
 Lotus includes an intelligent automatic type casting system that detects column types from your database schema and converts string values (typically from web inputs) to the correct database-native formats.
 
+> **Ecto-backed sources.** The rest of this guide — type casting, the SQL
+> transformer, and the interval rewrites — describes the built-in Ecto
+> adapter and its Postgres, MySQL and SQLite dialects. A non-SQL adapter
+> owns its own substitution and does its own escaping.
+
 ### How It Works
 
 When you use a variable in your query, Lotus:
 
-1. **Analyzes the SQL** to determine which table column the variable is bound to
+1. **Analyzes the SQL** (`Lotus.Storage.VariableResolver`) to determine which table column the variable is bound to
 2. **Queries the schema cache** to get the column's database type
 3. **Maps the database type** to a Lotus internal type (`:uuid`, `:integer`, `:date`, etc.)
 4. **Casts the value** if needed, or passes it through for text types
-5. **Generates the appropriate SQL placeholder** with type annotations where needed
+5. **Asks the dialect for a placeholder**, with a type annotation where the dialect wants one
 
 This all happens automatically - you don't need to manually specify types in most cases.
+
+Binding resolution is regex-based heuristics, not a full SQL parser: it
+handles explicit (`users.id = {{id}}`), implicit (`id = {{id}}`) and aliased
+(`u.id = {{id}}`) bindings, and falls back to the variable's declared
+`:type` when it cannot resolve one.
 
 ### Supported Types
 
@@ -312,6 +428,11 @@ When type casting fails, Lotus provides clear, user-friendly error messages:
 # Error: Invalid boolean format: 'maybe' is not a valid boolean (expected: true/false, yes/no, 1/0, on/off)
 ```
 
+Those messages come from `Lotus.Storage.TypeCaster`, which runs when the
+column type was detected. When Lotus falls back to the variable's declared
+`:type`, the wording is shorter and carries no format hint — for example
+`Invalid number format: 'abc' is not a valid number`.
+
 ### Performance Considerations
 
 Type casting adds minimal overhead:
@@ -320,9 +441,14 @@ Type casting adds minimal overhead:
 - **Smart casting**: Text and enum types skip casting entirely
 - **Graceful degradation**: If schema cache fails, falls back to manual types with logging
 
-## SQL Transformer Overview
+## SQL Transformer Overview (Ecto Adapters)
 
-Lotus includes an automatic SQL transformer that ensures your queries work correctly across different database systems. When you execute a query, Lotus automatically transforms the SQL to match the target database's syntax requirements, particularly around variable placeholders and database-specific functions.
+The Ecto adapter's dialects rewrite a statement before variables are bound,
+through the `transform_statement/1` dialect callback backed by
+`Lotus.Source.Adapters.Ecto.SQL.Transformer`. This is what lets one query
+text work across Postgres, MySQL and SQLite. It is a dialect concern, not a
+core one — an adapter for a non-SQL engine implements whatever
+preprocessing its own language needs, or none.
 
 The transformer handles three main areas:
 - **Quoted Variable Stripping**: Removes unnecessary quotes around variable placeholders
@@ -608,6 +734,21 @@ WHERE last_activity >= NOW() - INTERVAL '7 {{unit}}'
 # Transforms to:
 # "SELECT COUNT(*) FROM sessions WHERE last_activity >= NOW() - (( '7 ' || {{unit}} )::interval)"
 ```
+
+#### Pattern 5: `INTERVAL '{{var}}'` (Quoted, Whole Interval in the Variable)
+
+```elixir
+# Original query
+statement: """
+SELECT * FROM logs
+WHERE logged_at >= NOW() - INTERVAL '{{window}}'
+"""
+
+# Transforms to:
+# "SELECT * FROM logs WHERE logged_at >= NOW() - CAST({{window}} AS interval)"
+```
+
+The variable then holds a complete interval string such as `"3 months"`.
 
 ### Practical PostgreSQL Interval Examples
 

--- a/guides/ai_query_generation.md
+++ b/guides/ai_query_generation.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Experimental Feature**: This feature is experimental and disabled by default. The API may change in future versions.
 
-Lotus includes experimental support for generating SQL queries from natural language descriptions using Large Language Models (LLMs). This guide covers setup, usage, and best practices.
+Lotus includes experimental support for generating queries from natural language descriptions using Large Language Models (LLMs). The pipeline is adapter-driven: it generates whatever query language the resolved source speaks, not SQL only. This guide covers setup, usage, and best practices.
 
 ## Overview
 
@@ -10,14 +10,16 @@ The AI query generation feature:
 
 - **Disabled by default** - Requires explicit configuration
 - **BYOK (Bring Your Own Key)** - You provide API keys and pay for usage directly
-- **Schema-aware** - Introspects your database structure automatically
+- **Adapter-driven** - The source adapter supplies the query language, an example query, and its own syntax notes through `ai_context/1`
+- **Schema-aware** - Introspects your data source structure automatically
 - **Respects visibility** - Only sees tables/columns allowed by your Lotus visibility rules
-- **Read-only** - Inherits Lotus's read-only execution guarantees
+- **Read-only by default** - Pass `read_only: false` to let the AI generate write queries
 - **Multi-provider** - Works with any provider supported by [ReqLLM](https://github.com/agentjido/req_llm) (OpenAI, Anthropic, Google, Groq, Mistral, and more)
 - **Conversational** - Multi-turn conversations for iterative query refinement and error fixing
 - **Variable-aware** - Generates query variable configurations with UI metadata (widget types, labels, dropdown options)
 - **Query explanation** - Get plain-language explanations of full queries or selected fragments
-- **Query optimization** - Analyzes execution plans and suggests indexes, rewrites, and schema improvements
+- **Query optimization** - Analyzes execution plans and suggests indexes, rewrites, and structural changes
+- **Per-source capability gates** - Each adapter declares which of the three AI features it supports, so a UI can disable a button per source
 
 > **Web-first design:** The AI module is designed to work hand-in-hand with the [Lotus Web](https://github.com/elixir-lotus/lotus_web) interface. Generated variable configurations — widget types, labels, static options, and options queries — map directly to the web editor's `WidgetComponent`, which renders them as text inputs, dropdowns, multi-selects, date pickers, and tag inputs. While the API is usable standalone, the variable metadata is most valuable when paired with the web UI.
 
@@ -51,6 +53,68 @@ Core asks for the generated statement inside a fence labelled with the
 adapter's language **family** — `sql` for `sql:postgres`, `json` for
 `json:elasticsearch`. See the [source adapters
 guide](source-adapters.md#ai-adapter-support) for how to supply these.
+
+### The Trust Boundary
+
+An adapter's free-form `ai_context/1` text goes into an LLM prompt, so it is
+a prompt-injection surface. `:trusted_source_adapters` is the allowlist:
+
+```elixir
+config :lotus,
+  trusted_source_adapters: [MyApp.ClickHouseAdapter]
+```
+
+The built-in `Lotus.Source.Adapters.Ecto` and its per-dialect wrappers
+(`Postgres`, `MySQL`, `SQLite3`) are always trusted; you do not list them.
+
+For an adapter that is **not** on the list, Lotus keeps only `:language`
+and strips `:example_query`, `:syntax_notes`, `:error_patterns`,
+`:generation_notes` and `:read_only_notes`. The two notes keys are
+*dropped*, not blanked, so the prompt layer falls back to core's own text.
+That distinction matters: a blank `:read_only_notes` would leave the prompt
+with no read-only instruction at all, which is exactly how an untrusted
+adapter would weaken the guard. Capability `{false, reason}` strings from an
+untrusted adapter are likewise replaced with a generic fallback sentence.
+
+Lotus logs the strip once per adapter, at `:info`, and only when the adapter
+actually supplied something to strip.
+
+## Per-Source Capability Gates
+
+An adapter's `ai_context/1` may declare `:capabilities` — one entry per AI
+feature, each either `true` or `{false, reason}`:
+
+```elixir
+%{generation: true, optimization: {false, "This engine exposes no query plan."}, explanation: true}
+```
+
+An adapter that omits `:capabilities` gets all three as `true`. An adapter
+that returns `{:error, _}` from `ai_context/1` is out of AI entirely.
+
+Query the gates before you render a button:
+
+```elixir
+Lotus.AI.supports?("warehouse", :optimization)
+#=> false
+
+Lotus.AI.unsupported_reason("warehouse", :optimization)
+#=> "This engine exposes no query plan."
+
+Lotus.AI.unsupported_reason("warehouse", :generation)
+#=> nil
+```
+
+The features are `:generation`, `:optimization` and `:explanation`. The
+reason string is safe to show verbatim — untrusted adapters never reach a
+user with their own wording.
+
+Every public AI function also enforces the gate itself, so a caller that
+skips the check gets a structured error rather than a hallucinated query:
+
+```elixir
+{:error, {:ai_feature_unsupported, :optimization, "This engine exposes no query plan."}} =
+  Lotus.AI.suggest_optimizations(statement: statement, data_source: "warehouse")
+```
 
 ## Saved Queries Record Their Language
 
@@ -176,10 +240,37 @@ case Lotus.AI.generate_query(prompt: prompt, data_source: repo) do
   {:error, {:unable_to_generate, reason}} ->
     # LLM couldn't generate query (e.g., "This is a weather question")
 
+  {:error, {:ai_feature_unsupported, feature, reason}} ->
+    # The adapter declared this feature unsupported for this source
+
+  {:error, :ai_not_supported_for_source} ->
+    # The adapter returned {:error, _} from ai_context/1 — no AI at all
+
+  {:error, :missing_data_source} ->
+    # :data_source was not passed
+
   {:error, reason} ->
     # Other error (network, timeout, etc.)
 end
 ```
+
+### Allowing Write Queries
+
+Generation is read-only by default. Pass `read_only: false` to lift the
+restriction — the prompt then carries core's write-permitted text instead of
+the adapter's read-only notes:
+
+```elixir
+{:ok, result} = Lotus.AI.generate_query(
+  prompt: "Mark order 42 as shipped",
+  data_source: "my_repo",
+  read_only: false
+)
+```
+
+This only changes what the LLM is *asked* to produce. Execution is gated
+separately: `Lotus.run_statement/3` and `Lotus.run_query/2` still refuse
+writes unless you also pass `read_only: false` there.
 
 ### Complex Queries
 
@@ -195,7 +286,7 @@ Lotus.AI.generate_query(
 # Behind the scenes, the AI will:
 # 1. Call list_schemas() to find "reporting" schema
 # 2. Call list_tables() to find "customers" and "invoices" tables
-# 3. Call get_table_schema() for both tables
+# 3. Call describe_table() for both tables
 # 4. Call get_column_values("invoices", "status") to check valid statuses
 # 5. Generate: SELECT c.name, SUM(i.amount) FROM reporting.customers c ...
 ```
@@ -204,14 +295,23 @@ Lotus.AI.generate_query(
 
 ### Schema Introspection Tools
 
-The AI has access to these tools:
+During generation the AI has access to these tools:
 
-1. **`list_schemas()`** - Get all database schemas
+1. **`list_schemas()`** - Get all schemas (namespaces) in the source
 2. **`list_tables()`** - Get tables with schema-qualified names
 3. **`describe_table(table_name)`** - Get columns, types, constraints
 4. **`get_column_values(table_name, column_name)`** - Get distinct values (enums, statuses)
 5. **`validate_statement(statement)`** - Check syntax against the source without executing
-6. **`execute_statement(statement)`** - Run a read-only statement (investigation flows)
+
+Explanation and optimization are given only `describe_table`, since they
+already have the statement in hand.
+
+Two further actions ship but are not wired into any built-in flow — they
+are building blocks for host-written agents, reachable through
+`Lotus.AI.Actions.investigation_actions/0`:
+
+- **`list_data_sources()`** - List the configured data sources
+- **`execute_statement(statement)`** - Run a read-only statement and return a row preview
 
 All tools respect your Lotus visibility rules - the AI sees exactly what your users see.
 
@@ -308,12 +408,12 @@ Be clear about dates:
 
 ### 4. Review Generated Queries
 
-Always review the generated SQL before using it in production:
+Always review the generated statement before using it in production:
 
 ```elixir
 {:ok, result} = Lotus.AI.generate_query(prompt: prompt, data_source: repo)
 
-IO.puts("Generated SQL:")
+IO.puts("Generated statement:")
 IO.puts(result.statement)
 
 # Review before executing:
@@ -347,11 +447,16 @@ UNABLE_TO_GENERATE: api_keys table not available
 
 ### Read-Only Execution
 
-All AI-generated queries inherit Lotus's read-only guarantees:
+AI-generated queries are executed through the same pipeline as any other
+query, so they inherit Lotus's read-only guarantees:
 
-- Queries run in read-only transactions
-- `INSERT`, `UPDATE`, `DELETE` statements are blocked
-- DDL commands (`CREATE`, `DROP`, `ALTER`) are blocked
+- Queries run read-only unless the caller passes `read_only: false`
+- What counts as a write is the adapter's call — `sanitize_query/3` is an
+  adapter callback, so an SQL adapter blocks `INSERT` / `UPDATE` / `DELETE`
+  and DDL, while a non-SQL adapter blocks whatever its own engine's write
+  operations are
+- The prompt tells the LLM the same thing, in the adapter's own words, via
+  `ai_context.read_only_notes`
 
 ## Cost Management
 
@@ -365,7 +470,7 @@ Each query generation consumes tokens from your API provider. Check your usage:
 result.usage
 #=> %{
 #=>   prompt_tokens: 450,      # Input (schema info + prompt)
-#=>   completion_tokens: 42,   # Output (generated SQL)
+#=>   completion_tokens: 42,   # Output (generated statement)
 #=>   total_tokens: 492
 #=> }
 ```
@@ -404,7 +509,7 @@ Application.get_env(:lotus, :ai)
 
 ### "Unable to generate query: ..."
 
-The LLM refused to generate SQL. Common reasons:
+The LLM refused to generate a statement. Common reasons:
 
 - Question not related to database ("What's the weather?")
 - Required tables not visible
@@ -517,7 +622,7 @@ conversation = Conversation.prune_messages(conversation, 10)
 
 ## Query Explanation
 
-Lotus can explain what a SQL query does in plain language, powered by AI. This helps users understand complex queries written by others (or generated by AI) without mentally parsing the SQL.
+Lotus can explain what a query does in plain language, powered by AI. This helps users understand complex queries written by others (or generated by AI) without mentally parsing them. The examples below are SQL because the source is Postgres; the explainer works for whatever language the source adapter declares.
 
 ### Explaining a Full Query
 
@@ -545,7 +650,7 @@ result.explanation
 
 ### Explaining a Selected Fragment
 
-Users can highlight a portion of SQL to explain just that part. The full query is sent as context so the AI can accurately explain even isolated terms like a single JOIN, a HAVING clause, or a function call.
+Users can highlight a portion of the query to explain just that part. The full query is sent as context so the AI can accurately explain even isolated terms like a single JOIN, a HAVING clause, or a function call.
 
 ```elixir
 {:ok, result} = Lotus.AI.explain_query(
@@ -599,13 +704,21 @@ end
 
 ## Query Optimization
 
-Lotus can analyze your SQL queries and suggest performance improvements using AI-powered EXPLAIN plan analysis.
+Lotus can analyze a query and suggest performance improvements, using the
+engine's own execution plan where one is available.
+
+`:statement` here is a `%Lotus.Query.Statement{}`, not a string — the
+optimizer hands it to the adapter, which owns the body's shape. Build one
+with `Lotus.Query.Statement.new/2`, or take the one
+`Lotus.Storage.Query.compile/2` returns for a stored query.
 
 ### Basic Usage
 
 ```elixir
+statement = Lotus.Query.Statement.new("SELECT * FROM orders WHERE created_at > '2024-01-01'")
+
 {:ok, result} = Lotus.AI.suggest_optimizations(
-  statement: "SELECT * FROM orders WHERE created_at > '2024-01-01'",
+  statement: statement,
   data_source: "my_repo"
 )
 
@@ -637,8 +750,11 @@ Each suggestion includes a `type` and `impact` level:
 |------|-------------|
 | `index` | Missing or suboptimal indexes |
 | `rewrite` | Query structure improvements |
-| `schema` | Table or column design changes |
-| `configuration` | Database configuration tuning |
+| `structure` | Table, collection, or mapping design changes |
+| `configuration` | Engine configuration tuning |
+
+A suggestion whose `type` is not one of these four is normalized to
+`rewrite` rather than discarded.
 
 | Impact | Description |
 |--------|-------------|
@@ -648,39 +764,53 @@ Each suggestion includes a `type` and `impact` level:
 
 ### How It Works
 
-1. Runs `EXPLAIN` on the query to get the database execution plan
-2. Sends both the SQL and execution plan to the AI for analysis
-3. The AI can inspect table schemas via tools for deeper analysis
-4. Returns structured suggestions with actionable recommendations
+1. Calls the adapter's `prepare_for_analysis/2` to make the statement
+   parseable by the engine's diagnostic endpoint
+2. Calls the adapter's `query_plan/3` for an execution plan — `EXPLAIN`
+   output for SQL dialects, a native profile response elsewhere
+3. Sends the statement and the plan to the AI for analysis
+4. The AI can call `describe_table()` for deeper analysis
+5. Returns structured suggestions with actionable recommendations
+
+An adapter that cannot produce a plan is not an error. `query_plan/3` may
+return `{:ok, nil}`, and `prepare_for_analysis/2` may return
+`{:error, :unsupported}`; in either case the optimizer sends the statement
+with no plan and the AI reviews it structurally.
 
 ### Lotus Variable Syntax
 
-Queries using Lotus-specific syntax (`{{variables}}` and `[[optional clauses]]`) are handled automatically:
+Statements using Lotus-specific syntax (`{{variables}}` and `[[optional
+clauses]]`) are handled by `prepare_for_analysis/2`. For the built-in Ecto
+adapter that means:
 
-- `[[...]]` brackets are removed (content kept) so EXPLAIN sees all clauses
-- `{{variable}}` placeholders are replaced with `NULL` for EXPLAIN
-- The original SQL (with Lotus syntax) is sent to the AI for analysis
+- `[[...]]` brackets are removed (content kept) so `EXPLAIN` sees all clauses
+- `{{variable}}` placeholders are replaced with `NULL`
+
+Other adapters substitute whatever null-ish literal their language wants.
+The statement sent to the AI is the original one, Lotus syntax intact.
 
 ```elixir
-# Works with Lotus variable syntax
-{:ok, result} = Lotus.AI.suggest_optimizations(
-  statement: """
+statement =
+  Lotus.Query.Statement.new("""
   SELECT id, name FROM users
   WHERE 1=1
   [[AND status = {{status}}]]
   [[AND created_at > {{start_date}}]]
   ORDER BY id
-  """,
+  """)
+
+{:ok, result} = Lotus.AI.suggest_optimizations(
+  statement: statement,
   data_source: "my_repo"
 )
 ```
 
 ### Options
 
-- `:statement` (required) - The statement to optimize
+- `:statement` (required) - A `%Lotus.Query.Statement{}` to review
 - `:data_source` (required) - Name of the data source
-- `:params` (optional) - Query parameters (default: `[]`)
 - `:search_path` (optional) - PostgreSQL search path
+- `:context` / `:scope` (optional) - See [Acting on Behalf of a User](#acting-on-behalf-of-a-user)
 
 ### Error Handling
 
@@ -707,32 +837,41 @@ end
 
 ## API Reference
 
+Every AI entry point returns the shared error tuples
+`{:error, :not_configured}`, `{:error, :api_key_not_configured}`,
+`{:error, :missing_data_source}`,
+`{:error, {:ai_feature_unsupported, feature, reason}}`,
+`{:error, :ai_not_supported_for_source}` and `{:error, term()}`. Only the
+extra ones are listed below.
+
 ### `Lotus.AI.generate_query/1`
 
-Generates SQL from natural language (single-turn).
+Generates a statement from natural language (single-turn).
 
 **Options:**
 
 - `:prompt` (required) - Natural language description
-- `:data_source` (required) - Repository name or module
+- `:data_source` (required) - Data source name
+- `:read_only` (optional) - Restrict generation to read-only queries (default: `true`)
+- `:context` / `:scope` (optional) - Actor threaded into every query and discovery call
 
 **Returns:**
 
 - `{:ok, %{statement: String.t(), variables: [map()], model: String.t(), usage: map()}}` - Success
-- `{:error, :not_configured}` - AI not enabled
-- `{:error, :api_key_not_configured}` - Missing API key
 - `{:error, {:unable_to_generate, reason}}` - LLM refused
-- `{:error, term()}` - Other error
 
 ### `Lotus.AI.generate_query_with_context/1`
 
-Generates SQL with conversation context for multi-turn refinement.
+Generates a statement with conversation context for multi-turn refinement.
 
 **Options:**
 
 - `:prompt` (required) - Natural language description
-- `:data_source` (required) - Repository name or module
-- `:conversation` (optional) - `Conversation` struct with message history
+- `:data_source` (required) - Data source name
+- `:conversation` (optional) - Conversation state with message history
+- `:query_context` (optional) - `%{statement: ..., variables: [...]}` describing the query already in the user's editor
+- `:read_only` (optional) - Restrict generation to read-only queries (default: `true`)
+- `:context` / `:scope` (optional) - Actor threaded into every query and discovery call
 
 **Returns:**
 
@@ -740,52 +879,49 @@ Same as `generate_query/1`.
 
 ### `Lotus.AI.Conversation`
 
-Manages conversational state for multi-turn interactions.
+Manages conversational state for multi-turn interactions. The state is a
+plain map, not a struct, and every message carries `:statement` — never
+`:sql`.
 
 **Key Functions:**
 
 - `Conversation.new()` - Initialize a new conversation
 - `Conversation.add_user_message(conversation, content)` - Add user message
-- `Conversation.add_assistant_response(conversation, content, sql, variables \\ [])` - Add AI response
+- `Conversation.add_assistant_response(conversation, content, statement, variables \\ [])` - Add AI response
 - `Conversation.add_query_result(conversation, result)` - Add query execution result (success or error)
 - `Conversation.should_auto_retry?(conversation)` - Check if last message was an error
-- `Conversation.prune_messages(conversation, keep_last)` - Remove old messages to manage token usage
-- `Conversation.update_schema_context(conversation, tables)` - Track analyzed tables
+- `Conversation.prune_messages(conversation, keep_last \\ 10)` - Remove old messages to manage token usage
+- `Conversation.update_source_context(conversation, tables)` - Track analyzed tables under `:source_context`
 
 ### `Lotus.AI.explain_query/1`
 
-Explains a SQL query (or a selected fragment) in plain language.
+Explains a query (or a selected fragment) in plain language.
 
 **Options:**
 
-- `:statement` (required) - The full statement to explain
+- `:statement` (required) - The full statement to explain, as text
 - `:fragment` (optional) - A selected portion of the query to explain
-- `:data_source` (required) - Repository name
+- `:data_source` (required) - Data source name
+- `:context` / `:scope` (optional) - Actor threaded into the `describe_table` tool
 
 **Returns:**
 
 - `{:ok, %{explanation: String.t(), model: String.t(), usage: map()}}` - Success
-- `{:error, :not_configured}` - AI not enabled
-- `{:error, :api_key_not_configured}` - Missing API key
-- `{:error, term()}` - Other error
 
 ### `Lotus.AI.suggest_optimizations/1`
 
-Analyzes a SQL query and returns optimization suggestions.
+Analyzes a statement and returns optimization suggestions.
 
 **Options:**
 
-- `:statement` (required) - The statement to optimize
-- `:data_source` (required) - Repository name
-- `:params` (optional) - Query parameters (default: `[]`)
+- `:statement` (required) - A `%Lotus.Query.Statement{}` to review
+- `:data_source` (required) - Data source name
 - `:search_path` (optional) - PostgreSQL search path
+- `:context` / `:scope` (optional) - Actor threaded into the `describe_table` tool
 
 **Returns:**
 
 - `{:ok, %{suggestions: [map()], model: String.t(), usage: map()}}` - Success
-- `{:error, :not_configured}` - AI not enabled
-- `{:error, :api_key_not_configured}` - Missing API key
-- `{:error, term()}` - Other error
 
 ### `Lotus.AI.enabled?/0`
 
@@ -796,3 +932,57 @@ if Lotus.AI.enabled?() do
   # Show AI button in UI
 end
 ```
+
+### `Lotus.AI.supports?/2` and `Lotus.AI.unsupported_reason/2`
+
+Per-source, per-feature gates. `feature` is `:generation`,
+`:optimization` or `:explanation`.
+
+```elixir
+Lotus.AI.supports?("my_repo", :explanation)
+#=> true
+
+Lotus.AI.unsupported_reason("my_repo", :explanation)
+#=> nil
+```
+
+`unsupported_reason/2` returns `nil` when the feature is supported, and a
+displayable string otherwise. Both raise if the source name does not
+resolve.
+
+### `Lotus.AI.model/0`
+
+Returns the configured model string.
+
+```elixir
+Lotus.AI.model()
+#=> {:ok, "openai:gpt-4o"}
+```
+
+Returns `{:error, :not_configured}` or `{:error, :api_key_not_configured}`
+when AI is not usable.
+
+### `Lotus.AI.ErrorDetector`
+
+Classifies a failed query's error message and suggests fixes, for feeding
+back into a conversation.
+
+```elixir
+Lotus.AI.ErrorDetector.analyze_error(
+  "column \"status\" does not exist",
+  "SELECT status FROM users",
+  %{tables_analyzed: ["users"]}
+)
+#=> %{
+#=>   error_type: :column_not_found,
+#=>   error_message: "column \"status\" does not exist",
+#=>   failed_statement: "SELECT status FROM users",
+#=>   suggestions: ["Use describe_table('users') to see the actual column names ...", ...]
+#=> }
+```
+
+The key is `:failed_statement` (it was `:failed_sql` before v1.0). An
+optional fourth argument takes the sanitized `ai_context` map; its
+`:error_patterns` are matched against the message and the matching hints
+are prepended to `:suggestions`. Untrusted adapters have that list stripped
+to `[]` upstream, so only the generic suggestions remain.

--- a/guides/caching.md
+++ b/guides/caching.md
@@ -1,6 +1,6 @@
 # Caching Guide
 
-This guide covers Lotus's comprehensive caching system, which improves query performance by storing and reusing results from expensive database operations.
+This guide covers Lotus's caching system, which improves query performance by storing and reusing results from expensive database operations.
 
 Lotus does not enable caching by default. To turn it on, configure a cache adapter under `config :lotus` — Lotus's supervisor starts automatically with your app and will boot the configured cache backend for you.
 
@@ -8,23 +8,25 @@ Lotus does not enable caching by default. To turn it on, configure a cache adapt
 
 Lotus provides a flexible caching system with the following features:
 
-- **Pluggable adapters** - Support for different cache backends
-- **TTL-based expiration** - Automatic cache invalidation based on time-to-live
-- **Cache profiles** - Different caching strategies for different use cases
-- **Tag-based invalidation** - Selective cache clearing using tags
-- **Multiple cache modes** - Fine-grained control over cache behavior
-- **Namespace support** - Cache isolation and organization
+- **Pluggable adapters** — support for different cache backends
+- **TTL-based expiration** — automatic cache invalidation based on time-to-live
+- **Cache profiles** — different caching strategies for different use cases
+- **Tag-based invalidation** — selective cache clearing using tags
+- **Scope-aware keys** — per-actor or per-tenant result isolation
+- **Pluggable key builders** — replace the key scheme through a behaviour
+- **Multiple cache modes** — fine-grained control over cache behavior
+- **Namespace support** — cache isolation and organization
 
 ## Quick Start
 
 ### Basic Configuration
 
-Lotus ships with built-in cache profiles (`:results`, `:schema`, `:options`) that work without any configuration. To enable caching, just add the cache adapter to your Lotus configuration:
+Lotus ships with built-in cache profiles (`:results`, `:schema`, `:options`) that work without any configuration. To enable caching, add a cache adapter to your Lotus configuration:
 
 ```elixir
 # config/config.exs
 config :lotus,
-  ecto_repo: MyApp.Repo,
+  storage_repo: MyApp.Repo,
   data_sources: %{
     "main" => MyApp.Repo
   },
@@ -33,6 +35,9 @@ config :lotus,
     namespace: "myapp_lotus"
   }
 ```
+
+> **The `:cache` value must be a map.** Configuration validation accepts a map
+> or `nil`; a keyword list raises an `ArgumentError` at boot.
 
 **Note**: Even with minimal configuration, you get sensible caching defaults:
 
@@ -44,7 +49,7 @@ config :lotus,
 
 Lotus is an OTP application: as long as `:lotus` is in your `mix.exs` dependencies, its supervisor starts automatically with your app and boots the cache backend declared under `config :lotus, :cache`. No supervision-tree wiring is required on your end.
 
-The `Lotus.Cache.ETS` GenServer is always started by the supervisor to ensure cache tables are available. If you configure a different cache adapter (e.g., `Lotus.Cache.Cachex`), it is started in addition to the ETS tables.
+The `Lotus.Cache.ETS` GenServer is always started by the supervisor to ensure cache tables are available. If you configure a different cache adapter (e.g. `Lotus.Cache.Cachex`), it is started in addition to the ETS tables.
 
 > **Note:** If you accidentally include `Lotus` as a child in your own supervision tree, the double-start is handled gracefully — `Lotus.Supervisor` returns `{:ok, pid}` for an already-running instance.
 
@@ -56,7 +61,7 @@ Once configured and started, caching works automatically:
 # First call - executes query and caches result
 {:ok, result1} = Lotus.run_statement("SELECT COUNT(*) FROM users")
 
-# Second call - returns cached result (much faster!)
+# Second call - returns cached result
 {:ok, result2} = Lotus.run_statement("SELECT COUNT(*) FROM users")
 ```
 
@@ -64,10 +69,10 @@ Once configured and started, caching works automatically:
 
 ### Cache Adapter
 
-Currently, Lotus supports two cache adapters:
+Lotus ships with two cache adapters:
 
-1. `Lotus.Cache.ETS` - Local-only in-memory caching using ETS, implemented as a GenServer with automatic expiration cleanup
-2. `Lotus.Cache.Cachex` - Distributed caching using [Cachex](https://hexdocs.pm/cachex)
+1. `Lotus.Cache.ETS` — local-only in-memory caching using ETS, implemented as a GenServer with automatic expiration cleanup
+2. `Lotus.Cache.Cachex` — distributed caching using [Cachex](https://hexdocs.pm/cachex)
 
 #### ETS Adapter
 
@@ -77,9 +82,7 @@ The `Lotus.Cache.ETS` adapter provides in-memory caching using Erlang Term Stora
 config :lotus,
   cache: %{
     adapter: Lotus.Cache.ETS,
-    namespace: "myapp_lotus",    # Optional namespace
-    max_bytes: 5_000_000,       # Max entry size: 5MB (default)
-    compress: true              # Compress cache entries (default: true)
+    namespace: "myapp_lotus"
   }
 ```
 
@@ -93,21 +96,20 @@ First, add Cachex to your dependencies in `mix.exs`:
 {:cachex, "~> 4.0"}
 ```
 
-Then, configure Lotus to use Cachex in `config/runtime.exs` (or wherever your runtime config is located):
+Then configure Lotus to use Cachex in `config/runtime.exs` (or wherever your runtime config lives):
 
 ```elixir
 config :lotus,
   cache: %{
     adapter: Lotus.Cache.Cachex,
-    namespace: "myapp_lotus",    # Optional namespace
+    namespace: "myapp_lotus",
     cachex_opts: [] # Optional Cachex options (see Cachex docs)
-    # You can set other Lotus cache config options here as well
   }
 ```
 
 **Note: You MUST configure Cachex at runtime. This is because Cachex uses Records, which are not available in compile-time configuration.**
 
-`cachex_opts` [accepts all options supported by Cachex](https://hexdocs.pm/cachex/cache-routers.html#default-routers). If not specified, the default Cachex configuration is used is:
+`cachex_opts` [accepts all options supported by Cachex](https://hexdocs.pm/cachex/cache-routers.html#default-routers). If not specified, the default Cachex configuration used is:
 
 ```elixir
 [router: router(module: Cachex.Router.Ring, options: [monitor: true])]
@@ -115,21 +117,19 @@ config :lotus,
 
 ### Cache Profiles
 
-Profiles allow you to configure different TTL strategies for different types of queries. Lotus comes with three predefined profiles that are always available:
+Profiles let you configure different TTL strategies for different kinds of data. Lotus comes with three predefined profiles that are always available.
 
 #### Predefined Profiles
 
-Lotus ships with these built-in cache profiles:
-
-- **`:results`** - 60 seconds TTL - For query results and fast-changing data
-- **`:schema`** - 1 hour TTL - For database schema information that changes rarely
-- **`:options`** - 5 minutes TTL - For dropdown options and reference data
+- **`:results`** — 60 seconds TTL — for query results and fast-changing data
+- **`:schema`** — 1 hour TTL — for database schema information that changes rarely
+- **`:options`** — 5 minutes TTL — for dropdown options and reference data
 
 These profiles are always available, even without any cache configuration. You can override their settings or add custom profiles:
 
 ```elixir
 config :lotus,
-  cache: [
+  cache: %{
     adapter: Lotus.Cache.ETS,
     profiles: %{
       # Override built-in profiles
@@ -141,8 +141,8 @@ config :lotus,
       reports: [ttl_ms: 1_800_000]    # 30 minutes - business reports
     },
     default_profile: :results,        # Used when no profile specified
-    default_ttl_ms: 60_000           # 1 minute - fallback TTL
-  ]
+    default_ttl_ms: 60_000            # Fallback TTL
+  }
 ```
 
 #### Profile Fallback Behavior
@@ -153,42 +153,44 @@ When you don't configure cache profiles:
 - `:schema` uses 1 hour TTL
 - `:options` uses 5 minutes TTL
 
-When you configure `default_ttl_ms` but don't specify `:results` profile:
+When you configure `default_ttl_ms` but don't define a `:results` profile:
 
 - `:results` uses your `default_ttl_ms` value
 - `:schema` and `:options` keep their built-in defaults
 
+A profile name that is not configured and is not one of the three built-ins falls back to `default_ttl_ms`, and then to 60 seconds.
+
 ### Namespace Support
 
-Namespaces provide cache isolation and organization:
+The namespace is prefixed to every cache key, which isolates one app's entries from another sharing the same backend:
 
 ```elixir
 config :lotus,
-  cache: [
+  cache: %{
     adapter: Lotus.Cache.ETS,
-    namespace: "myapp_lotus"  # Optional namespace for cache isolation
-  ]
+    namespace: "myapp_lotus"  # Default: "lotus:v1"
+  }
 ```
 
 ## Cache Modes
 
-Lotus provides three cache modes for different scenarios:
+Lotus provides three cache modes for different scenarios.
 
 ### Default Mode (Automatic Caching)
 
 When no cache mode is specified, Lotus automatically caches results:
 
 ```elixir
-# Uses cache if available, otherwise queries database and caches result
+# Uses cache if available, otherwise queries the source and caches the result
 {:ok, result} = Lotus.run_statement("SELECT * FROM products")
 ```
 
 ### Bypass Mode
 
-Skip cache entirely - always query the database:
+Skip the cache entirely — always query the source:
 
 ```elixir
-# Always hits database, never reads from or writes to cache
+# Always hits the database, never reads from or writes to cache
 {:ok, result} = Lotus.run_statement("SELECT * FROM products", [], cache: :bypass)
 ```
 
@@ -200,10 +202,9 @@ Skip cache entirely - always query the database:
 
 ### Refresh Mode
 
-Execute query and update cache with fresh results:
+Execute the query and overwrite the cache entry with the fresh result:
 
 ```elixir
-# Executes query AND updates cache with new result
 {:ok, result} = Lotus.run_statement("SELECT * FROM products", [], cache: :refresh)
 ```
 
@@ -213,6 +214,13 @@ Execute query and update cache with fresh results:
 - Scheduled cache warming
 - Manual cache updates
 
+The mode atoms also work inside the option list, so you can combine a mode with other cache options:
+
+```elixir
+{:ok, result} = Lotus.run_statement("SELECT * FROM products", [],
+  cache: [:refresh, profile: :options])
+```
+
 ## Cache Options
 
 ### Profile Selection
@@ -220,13 +228,12 @@ Execute query and update cache with fresh results:
 Choose a specific cache profile for a query:
 
 ```elixir
-# Use the 'schema' profile (longer TTL)
-{:ok, tables} = Lotus.run_statement("SELECT name FROM sqlite_master", [], cache: [profile: :schema])
+{:ok, result} = Lotus.run_statement("SELECT * FROM countries", [], cache: [profile: :options])
 ```
 
 ### TTL Override
 
-Override the default TTL for specific queries:
+Override the profile TTL for specific queries:
 
 ```elixir
 # Cache for exactly 2 minutes regardless of profile
@@ -246,9 +253,21 @@ Tag cache entries for selective invalidation:
 Lotus.Cache.invalidate_tags(["user:123"])
 ```
 
-### Combined Options
+### Entry Size and Compression
 
-You can combine multiple cache options:
+Cache entries are serialized and, by default, compressed. Entries larger than `max_bytes` are silently not cached — the query still returns its result.
+
+```elixir
+# Don't cache this result if it serializes to more than 1 MB
+{:ok, result} = Lotus.run_statement("SELECT * FROM events", [], cache: [max_bytes: 1_000_000])
+
+# Skip compression for a result that doesn't compress well
+{:ok, result} = Lotus.run_statement("SELECT * FROM blobs", [], cache: [compress: false])
+```
+
+**Defaults**: `max_bytes: 5_000_000`, `compress: true`. Both are per-call options, honored by the ETS and Cachex adapters.
+
+### Combined Options
 
 ```elixir
 {:ok, result} = Lotus.run_statement("SELECT * FROM products", [],
@@ -261,20 +280,52 @@ You can combine multiple cache options:
 
 ## Cache Key Generation
 
-Lotus generates cache keys based on:
+Lotus builds two kinds of cache key.
 
-- **SQL statement** - The actual query text
-- **Parameters** - Query parameters and variable values
-- **Repository** - Which database the query targets
-- **Search path** - PostgreSQL schema search path
-- **Scope** - When non-nil, hashed into discovery cache keys
-- **Lotus version** - Ensures cache invalidation across version upgrades
+**Result keys** (`run_query/2`, `run_statement/3`) hash:
 
-This ensures that different queries, even with slight variations, get separate cache entries.
+- **Statement body** — the adapter-native payload (SQL text for Ecto sources, a JSON/DSL term for others)
+- **Bound values** — variable bindings or positional parameters, including the pagination window
+- **Data source name** — which source the statement targets
+- **Search path** — the schema search path, when set
+- **Lotus version** — so entries do not survive an upgrade
+- **Scope** — when non-nil, its digest is appended to the key
+
+**Discovery keys** (schema introspection) hash the operation kind, the source name, the kind-specific components (such as schema and table name), the Lotus version, and the scope digest when set.
+
+### Scope and cache correctness
+
+The result cache key includes `:scope`. It does **not** include `:context`.
+
+That distinction matters. `:context` is an opaque value for middleware and telemetry — an audit trail. `:scope` is the identity that Lotus treats as part of the cache identity and hands to the visibility resolver.
+
+> ### Warning {: .warning}
+>
+> If middleware rewrites statements per actor, or your column policies mask
+> values per actor, and the actor is carried only in `:context`, then two
+> different actors running the same statement share one cache entry — and
+> the second actor is served the first actor's rows. Pass a `:scope` that
+> identifies the actor (or the security boundary: tenant, role) whenever
+> what a query returns depends on who is asking.
+
+```elixir
+# Wrong when masking or a before_query rewrite depends on the actor:
+Lotus.run_query(query, context: %{actor: current_user})
+
+# Right — the actor is part of the cache identity and reaches the resolver:
+Lotus.run_query(query,
+  context: %{request_id: request_id},
+  scope: %{tenant_id: current_user.tenant_id, role: current_user.role}
+)
+```
+
+Use the narrowest scope that captures the security boundary. A scope of `%{user_id: id}` gives every user their own cache entry, which is correct but has a low hit rate; `%{tenant_id: id, role: role}` is usually the right granularity when masking is decided by tenant and role.
+
+The same rule applies to discovery: `Lotus.list_tables/2`, `describe_table/3` and friends pass `:scope` to the visibility resolver *and* hash it into the discovery key, so a resolver that hides tables per tenant does not leak one tenant's table list into another's.
 
 ### Custom Key Builder
 
-The default key generation can be replaced by implementing the `Lotus.Cache.KeyBuilder` behaviour. This is useful when you need to incorporate additional context into cache keys or use a different hashing strategy.
+The key scheme can be replaced by implementing the `Lotus.Cache.KeyBuilder` behaviour. This is useful when you need extra components in the key or a different hashing strategy.
 
 ```elixir
 defmodule MyApp.CustomKeyBuilder do
@@ -282,7 +333,7 @@ defmodule MyApp.CustomKeyBuilder do
 
   @impl true
   def discovery_key(params, scope) do
-    # Add environment to discovery keys
+    # Add the deployment environment to discovery keys
     env = Application.get_env(:my_app, :env, :prod)
 
     Lotus.Cache.KeyBuilder.Default.discovery_key(
@@ -293,7 +344,6 @@ defmodule MyApp.CustomKeyBuilder do
 
   @impl true
   def result_key(body, bound, opts, scope) do
-    # Delegate to default for result keys
     Lotus.Cache.KeyBuilder.Default.result_key(body, bound, opts, scope)
   end
 end
@@ -311,38 +361,54 @@ config :lotus,
 
 The behaviour defines two callbacks:
 
-- `discovery_key/2` — builds keys for schema introspection cache entries (list_tables, get_table_schema, etc.)
-- `result_key/4` — builds keys for query result cache entries (accepts `scope` as the 4th argument)
+- `discovery_key/2` — keys for schema introspection entries. Takes a map with `:kind` (e.g. `:list_schemas`, `:list_tables`), `:source_name`, `:components` (a tuple of kind-specific parts) and `:version`, plus the scope (or `nil`)
+- `result_key/4` — keys for query result entries. Takes the statement body (`term()` — a SQL string for Ecto adapters, a JSON or AST payload for others), the bound values (map or list), an options keyword list carrying `:data_source`, `:search_path` and `:lotus_version`, and the scope (or `nil`)
 
-When no `key_builder` is configured, `Lotus.Cache.KeyBuilder.Default` is used, which preserves the built-in key generation logic.
+`Lotus.Cache.KeyBuilder.scope_digest/1` is a public helper: it returns a 16-character hex digest of any term, and `""` for `nil`. Use it if your implementation builds its own scope-specific keys or tags.
+
+```elixir
+Lotus.Cache.KeyBuilder.scope_digest(nil)
+# ""
+
+Lotus.Cache.KeyBuilder.scope_digest(%{tenant_id: 42})
+# a 16-character lowercase hex digest of the term
+```
+
+When no `key_builder` is configured, `Lotus.Cache.KeyBuilder.Default` is used.
+
+> ### Warning {: .warning}
+>
+> A custom key builder that ignores its `scope` argument removes the
+> per-scope isolation described above. If you delegate, delegate the scope
+> too.
 
 ## Schema Function Caching
 
-All Lotus schema introspection functions are automatically cached:
+All Lotus schema introspection functions are cached automatically:
 
-- `Lotus.list_tables/2` - Lists tables and views in database
-- `Lotus.describe_table/3` - Gets column information for tables
-- `Lotus.get_table_stats/3` - Gets row counts and table statistics
-- `Lotus.list_relations/2` - Lists tables with schema information
+- `Lotus.list_schemas/2` — lists schemas (namespaces) in the source
+- `Lotus.list_tables/2` — lists tables and views
+- `Lotus.describe_table/3` — column information for a table
+- `Lotus.get_table_stats/3` — row counts and table statistics
+- `Lotus.list_relations/2` — tables with schema information
 
 ### Default Cache Behavior
 
-Schema functions use different cache profiles by default:
-
 ```elixir
-# Schema metadata - uses :schema profile (1 hour TTL)
+# Schema metadata - uses the :schema profile (1 hour TTL)
+{:ok, schemas} = Lotus.list_schemas("postgres")
 {:ok, tables} = Lotus.list_tables("postgres")
-{:ok, schema} = Lotus.get_table_schema("postgres", "users")
+{:ok, columns} = Lotus.describe_table("postgres", "users")
 {:ok, relations} = Lotus.list_relations("postgres")
 
-# Table statistics - uses :results profile (30 seconds TTL)
+# Table statistics - uses the :results profile (60 second TTL)
 {:ok, stats} = Lotus.get_table_stats("postgres", "users")
 ```
 
 **Why different profiles?**
 
-- **Schema metadata** (tables, columns) changes rarely, so longer caching (1 hour) is safe
-- **Table statistics** (row counts) change frequently, so shorter caching (30 seconds) keeps data fresh
+- **Schema metadata** (tables, columns) changes rarely, so longer caching is safe
+- **Table statistics** (row counts) change constantly, so a short TTL keeps them useful
 
 ### Schema Cache Options
 
@@ -353,43 +419,49 @@ Schema functions support all cache modes and options:
 {:ok, tables} = Lotus.list_tables("postgres", cache: :bypass)
 
 # Refresh cache with latest data
-{:ok, schema} = Lotus.get_table_schema("postgres", "users", cache: :refresh)
+{:ok, columns} = Lotus.describe_table("postgres", "users", cache: :refresh)
 
-# Use custom profile
-{:ok, stats} = Lotus.get_table_stats("postgres", "users",
-  cache: [profile: :options])  # 5 minute TTL
+# Use a different profile
+{:ok, stats} = Lotus.get_table_stats("postgres", "users", cache: [profile: :options])
 
 # Override TTL
-{:ok, relations} = Lotus.list_relations("postgres",
-  cache: [ttl_ms: 600_000])  # 10 minutes
+{:ok, relations} = Lotus.list_relations("postgres", cache: [ttl_ms: 600_000])
 
 # Add tags for invalidation
-{:ok, schema} = Lotus.get_table_schema("postgres", "products",
-  cache: [tags: ["schema:products", "metadata"]])
+{:ok, columns} = Lotus.describe_table("postgres", "products",
+  cache: [tags: ["metadata"]])
 ```
 
 ### Schema Cache Invalidation
 
-Schema information is automatically tagged for selective invalidation:
+Discovery entries are tagged automatically, so you can clear exactly what changed:
 
 ```elixir
 # After schema changes (migrations, table creation, etc.)
-Lotus.Cache.invalidate_tags(["repo:postgres", "schema:list_tables"])
+Lotus.Cache.invalidate_tags(["source:postgres", "schema:list_tables"])
 
 # After specific table changes
 Lotus.Cache.invalidate_tags(["table:public.users"])
 ```
 
-**Automatic tags added:**
+**Automatic tags on discovery entries:**
 
-- `"repo:#{repo_name}"` - Repository-specific data
-- `"schema:#{function_name}"` - Function-specific data
-- `"table:#{schema}.#{table}"` - Table-specific data (when applicable)
-- `"scope:<digest>"` - Scope-specific data (when a non-nil `:scope` option is passed)
+- `"source:#{source_name}"` — every entry for one data source
+- `"schema:#{kind}"` — one discovery operation: `schema:list_schemas`, `schema:list_tables`, `schema:describe_table`, `schema:get_table_stats`, `schema:list_relations`, `schema:resolve_table_namespace`
+- `"table:#{schema}.#{table}"` — table-specific entries (`describe_table`, `get_table_stats`, `resolve_table_namespace`); the schema part is omitted for schema-less sources
+- `"scope:<digest>"` — added when a non-nil `:scope` option is passed
+
+> ### Renamed in v1.0 {: .warning}
+>
+> The source tag prefix was `"repo:"` before v1.0 and is now `"source:"`.
+> Host code that invalidates by tag must be updated. Entries written by a
+> pre-v1 install are never found again after the upgrade; they expire on
+> their own and re-seed on the next read, so this is a cold cache, not a
+> correctness problem.
 
 ### Per-Scope Cache Invalidation
 
-When using the `:scope` option on discovery or query execution functions, each cached entry is automatically tagged with a scope digest. This lets you invalidate all cached entries for a specific scope without flushing the entire cache:
+When you pass `:scope` to a discovery or execution function, the entry is tagged with a scope digest. That lets you clear everything for one scope without flushing the cache:
 
 ```elixir
 # Populate cache for different scopes
@@ -403,15 +475,15 @@ When using the `:scope` option on discovery or query execution functions, each c
 {:ok, _} = Lotus.list_tables("postgres", scope: %{tenant_id: 2})
 ```
 
-This is useful when visibility rules change for a specific scope (e.g. a tenant's permissions are updated) and you need to clear stale cache entries without affecting other scopes. `invalidate_scope/1` clears both discovery and result cache entries tagged with the given scope.
+This is what you want when visibility rules change for one scope — a tenant's permissions are updated, a role gains a table — and stale entries for that scope must go. `Lotus.invalidate_scope/1` (delegating to `Lotus.Cache.invalidate_scope/1`) clears both discovery and result entries carrying the scope tag.
 
-`invalidate_scope/1` accepts any non-nil term and returns `:ok`. Passing `nil` is a no-op (there is no scope tag to invalidate).
+`invalidate_scope/1` accepts any term and returns `:ok`. Passing `nil` is a no-op, because there is no scope tag to invalidate.
 
-When passing `:scope` to query execution (`run_query/2`, `run_statement/3`), the scope is hashed into the result cache key so different scopes produce independent cached results. This is important when the database uses row-level security (RLS) policies, middleware rewrites queries per-scope, or a `SET ROLE` / session variable changes what data the query sees.
+The scope must match the one used when the entry was written: the digest is taken over the term itself, so `%{tenant_id: 1}` and `%{tenant_id: "1"}` are different scopes.
 
 ## Working with run_query
 
-Saved queries (`run_query`) support all the same cache options:
+Saved queries support all the same cache options:
 
 ```elixir
 # Automatic caching based on configuration
@@ -420,19 +492,21 @@ Saved queries (`run_query`) support all the same cache options:
 # Bypass cache
 {:ok, result} = Lotus.run_query(query_id, cache: :bypass)
 
-# Use specific profile
+# Use a specific profile
 {:ok, result} = Lotus.run_query(query_id, cache: [profile: :reports])
 
 # Tag for invalidation
-{:ok, result} = Lotus.run_query(query_id,
-  cache: [tags: ["query:#{query_id}", "dashboard"]])
+{:ok, result} = Lotus.run_query(query_id, cache: [tags: ["dashboard"]])
+
+# Per-tenant results
+{:ok, result} = Lotus.run_query(query_id, scope: %{tenant_id: 42})
 ```
+
+Query variables are part of the bound values, so the same saved query with different `vars` produces independent cache entries. So does each page of a windowed query.
 
 ## Cache Management
 
 ### Manual Cache Invalidation
-
-Invalidate cache entries by tags:
 
 ```elixir
 # Invalidate specific entries
@@ -441,42 +515,44 @@ Lotus.Cache.invalidate_tags(["user:123"])
 # Invalidate multiple tags
 Lotus.Cache.invalidate_tags(["user_data", "reports", "dashboard"])
 
-# Invalidate all cached discovery entries for a specific scope
+# Invalidate every cached entry for a scope
 Lotus.invalidate_scope(%{tenant_id: 42})
 ```
 
+`invalidate_tags/1` is a no-op when no cache adapter is configured, or when the configured adapter does not support tag invalidation.
+
 ### Automatic Tagging
 
-Lotus automatically adds these tags to cached entries:
+Lotus adds these tags to result entries:
 
-- `"query:#{query_id}"` - For run_query calls
-- `"repo:#{repo_name}"` - For the database repository used
-- `"schema:#{function_name}"` - For Schema function calls (list_tables, get_table_schema, etc.)
-- `"table:#{schema}.#{table}"` - For table-specific Schema operations
+- `"query:#{query_id}"` — for `run_query/2` calls on a saved query
+- `"source:#{source_name}"` — the data source the statement ran against
+- `"scope:#{digest}"` — when a non-nil `:scope` is passed
 
-You can add your own tags in addition to these automatic ones.
+Discovery entries carry the tags listed under [Schema Cache Invalidation](#schema-cache-invalidation). Your own `cache: [tags: [...]]` are added on top of the automatic ones.
 
 ## Performance Considerations
 
 ### Cache Effectiveness
 
-Monitor cache effectiveness by observing query performance improvements and application response times. Future versions may include cache statistics and telemetry integration.
+Cache activity is emitted as telemetry — `[:lotus, :cache, :hit]`, `[:lotus, :cache, :miss]` and `[:lotus, :cache, :put]` — so you can measure hit ratio without instrumenting call sites. See the [Telemetry Guide](telemetry.md).
 
 ### Memory Usage
 
 ETS cache memory grows with cached data. Consider:
 
-- **Appropriate TTLs** - Don't cache data longer than needed
-- **Selective caching** - Use `:bypass` for large result sets that aren't reused
-- **Size limits** - Large cache entries are automatically rejected (default: 5MB, configurable)
-- **Regular cleanup** - TTL-based expiration handles this automatically
+- **Appropriate TTLs** — don't cache data longer than it is useful
+- **Selective caching** — use `:bypass` for large result sets that are not reused
+- **Size limits** — oversized entries are skipped rather than stored (`max_bytes`, default 5 MB)
+- **Scope granularity** — a per-user scope multiplies entries by your user count; prefer the narrowest boundary that is still correct
+- **Regular cleanup** — expired ETS entries are swept by a janitor every 30 seconds
 
 ### Cache Warming
 
-Pre-populate cache with commonly used queries:
+Pre-populate the cache with commonly used queries:
 
 ```elixir
-# During application startup or scheduled jobs
+# During application startup or from a scheduled job
 {:ok, _} = Lotus.run_statement("SELECT * FROM lookup_tables", [], cache: :refresh)
 {:ok, _} = Lotus.run_query(dashboard_query_id, cache: :refresh)
 ```
@@ -485,28 +561,27 @@ Pre-populate cache with commonly used queries:
 
 ### Profile Strategy
 
-Lotus provides sensible defaults for the built-in profiles, but you can customize them based on your needs:
-
 ```elixir
 config :lotus,
-  cache: [
+  cache: %{
+    adapter: Lotus.Cache.ETS,
     profiles: %{
       # Built-in profiles (customize as needed)
-      results: [ttl_ms: 30_000],      # Default: 60s - Fast-changing data
-      options: [ttl_ms: 300_000],     # Default: 5m - Reference data
-      schema: [ttl_ms: 3_600_000],    # Default: 1h - Schema information
+      results: [ttl_ms: 30_000],      # Default: 60s - fast-changing data
+      options: [ttl_ms: 300_000],     # Default: 5m - reference data
+      schema: [ttl_ms: 3_600_000],    # Default: 1h - schema information
 
       # Add custom profiles for specific use cases
-      reports: [ttl_ms: 1_800_000]    # 30 minutes - Business reports
+      reports: [ttl_ms: 1_800_000]    # 30 minutes - business reports
     }
-  ]
+  }
 ```
 
 **Default TTL Guidelines:**
 
-- **`:results` (60s)** - Query results, user data, transactional information
-- **`:options` (5m)** - Dropdown options, lookup tables, reference data
-- **`:schema` (1h)** - Database schema, table structure, metadata
+- **`:results` (60s)** — query results, table statistics, transactional information
+- **`:options` (5m)** — dropdown options, lookup tables, reference data
+- **`:schema` (1h)** — database schema, table structure, metadata
 
 ### Tagging Strategy
 
@@ -523,32 +598,26 @@ cache: [tags: ["product:#{product_id}", "inventory"]]
 
 ### When to Use Each Mode
 
-- **Default mode**: Most queries - let cache system optimize automatically
-- **`:bypass` mode**: Real-time data, large one-off queries, testing
-- **`:refresh` mode**: After data updates, scheduled cache warming, manual refresh
+- **Default mode**: most queries — let the cache do its job
+- **`:bypass` mode**: real-time data, large one-off queries, testing
+- **`:refresh` mode**: after data updates, scheduled cache warming, manual refresh
 
 ### Cache Invalidation
 
 ```elixir
 # After updating user data
-User.update(user, %{name: "New Name"})
 Lotus.Cache.invalidate_tags(["user:#{user.id}"])
 
 # After bulk data updates
-Products.bulk_update()
 Lotus.Cache.invalidate_tags(["products", "inventory"])
 
 # After schema changes (migrations, DDL operations)
-Ecto.Migrator.run(MyApp.Repo, :up, all: true)
-Lotus.Cache.invalidate_tags(["repo:postgres", "schema:list_tables"])
+Lotus.Cache.invalidate_tags(["source:postgres", "schema:list_tables"])
 
 # After table-specific changes
-alter table(:users) do
-  add :new_column, :string
-end
 Lotus.Cache.invalidate_tags(["table:public.users"])
 
-# After tenant permissions change — clear only that tenant's cached entries
+# After a tenant's permissions change — clear only that tenant's entries
 Lotus.invalidate_scope(%{tenant_id: tenant.id})
 ```
 
@@ -556,21 +625,28 @@ Lotus.invalidate_scope(%{tenant_id: tenant.id})
 
 ### Cache Not Working
 
-1. **Check configuration**: Ensure a cache adapter is configured under `config :lotus, :cache`
-2. **Check the `:lotus` app is running**: Lotus's supervisor starts automatically with the `:lotus` OTP app, so make sure it isn't excluded from `included_applications` or otherwise prevented from starting
-3. **Verify identical queries**: Cache keys are generated from exact SQL + params
-4. **Check TTL**: Ensure cache hasn't expired between calls
+1. **Check configuration**: a cache adapter must be set under `config :lotus, :cache`, and the value must be a map
+2. **Check the `:lotus` app is running**: Lotus's supervisor starts with the `:lotus` OTP app, so make sure it isn't excluded from `included_applications` or otherwise prevented from starting
+3. **Verify identical calls**: keys come from the exact statement body, bound values, source, search path and scope — a different scope is a different entry by design
+4. **Check TTL**: make sure the entry has not expired between calls
+5. **Check entry size**: a result larger than `max_bytes` (5 MB default) is never stored, so it misses every time
 
-**Common Error**: `** (ArgumentError) argument error` or `:noproc` errors usually mean the `:lotus` application failed to boot. Since the ETS cache GenServer is always started by the supervisor, cache tables should be available as long as `:lotus` is running.
+**Common Error**: `** (ArgumentError) argument error` or `:noproc` errors usually mean the `:lotus` application failed to boot. The ETS cache GenServer is always started by the supervisor, so cache tables should be available as long as `:lotus` is running.
+
+### Stale or Leaking Results
+
+1. **Check `:scope` vs `:context`**: results that differ per actor must carry that actor in `:scope`. See [Scope and cache correctness](#scope-and-cache-correctness)
+2. **Check a custom key builder**: an implementation that drops the `scope` argument removes per-scope isolation
+3. **Check tag prefixes after upgrading**: invalidation code written for v0.x used `"repo:"`, which now matches nothing
 
 ### Memory Issues
 
-1. **Review TTL settings**: Shorter TTLs = less memory usage
-2. **Use selective caching**: Don't cache large result sets unnecessarily
-3. **Monitor cache size**: Check ETS table memory usage
+1. **Review TTL settings**: shorter TTLs mean less memory
+2. **Review scope granularity**: a per-user scope multiplies entry count
+3. **Use selective caching**: don't cache large result sets unnecessarily
 
 ### Performance Issues
 
-1. **Cache hit ratio**: Low hit ratio may indicate poor cache strategy
-2. **TTL tuning**: Balance between data freshness and cache effectiveness
-3. **Query optimization**: Cache works best with optimized queries
+1. **Cache hit ratio**: a low ratio may mean the scope is too narrow or the TTL too short
+2. **TTL tuning**: balance data freshness against cache effectiveness
+3. **Query optimization**: caching works best on top of already-reasonable queries

--- a/guides/caching.md
+++ b/guides/caching.md
@@ -253,9 +253,30 @@ Tag cache entries for selective invalidation:
 Lotus.Cache.invalidate_tags(["user:123"])
 ```
 
-### Entry Size and Compression
+### Entry Size, Compression and Lock Timeout
 
-Cache entries are serialized and, by default, compressed. Entries larger than `max_bytes` are silently not cached — the query still returns its result.
+Three settings apply to every cached entry. They are deployment policy, so they belong in config, and any call can override them for one query.
+
+| Option | Default | What it does |
+|---|---|---|
+| `max_bytes` | `5_000_000` | Skip writing an entry whose serialized size exceeds this. The query still returns its result; it is simply not cached, so one enormous result set cannot evict everything else. |
+| `compress` | `true` | Store the entry compressed. Trades CPU for memory. |
+| `lock_timeout` | `10_000` | On a miss, one caller computes the value while the others wait for it. This bounds that wait, after which a waiter computes the value itself. |
+
+Set them for the whole application:
+
+```elixir
+config :lotus,
+  cache: %{
+    adapter: Lotus.Cache.Cachex,
+    namespace: "lotus",
+    max_bytes: 2_000_000,
+    compress: true,
+    lock_timeout: 5_000
+  }
+```
+
+Override for a single call:
 
 ```elixir
 # Don't cache this result if it serializes to more than 1 MB
@@ -265,7 +286,9 @@ Cache entries are serialized and, by default, compressed. Entries larger than `m
 {:ok, result} = Lotus.run_statement("SELECT * FROM blobs", [], cache: [compress: false])
 ```
 
-**Defaults**: `max_bytes: 5_000_000`, `compress: true`. Both are per-call options, honored by the ETS and Cachex adapters.
+A key you leave unset in both places falls back to the adapter default in the table above. `Lotus.Config.cache_entry_options/0` returns what the operator configured; `Lotus.Cache.build_options/2` is what layers a per-call option over it.
+
+> Before v1.0.0 these three were declared in the cache config but never read from it. `max_bytes` and `compress` worked only as a per-call option and `lock_timeout` could not be set at all.
 
 ### Combined Options
 
@@ -543,7 +566,7 @@ ETS cache memory grows with cached data. Consider:
 
 - **Appropriate TTLs** — don't cache data longer than it is useful
 - **Selective caching** — use `:bypass` for large result sets that are not reused
-- **Size limits** — oversized entries are skipped rather than stored (`max_bytes`, default 5 MB)
+- **Size limits** — oversized entries are skipped rather than stored (`max_bytes`, default 5 MB, set in config or per call)
 - **Scope granularity** — a per-user scope multiplies entries by your user count; prefer the narrowest boundary that is still correct
 - **Regular cleanup** — expired ETS entries are swept by a janitor every 30 seconds
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -156,9 +156,16 @@ config :lotus,
       schema: [ttl_ms: 3_600_000]    # Long-term schema info (1 hour)
     },
     default_profile: :results,       # Default profile when none specified
-    default_ttl_ms: 60_000           # Fallback TTL for the :results profile
+    default_ttl_ms: 60_000,          # Fallback TTL for the :results profile
+    max_bytes: 5_000_000,            # Skip entries larger than this
+    compress: true,                  # Store entries compressed
+    lock_timeout: 10_000             # How long a caller waits on a concurrent miss
   }
 ```
+
+`max_bytes`, `compress` and `lock_timeout` apply to every entry and can be
+overridden for one call through the `:cache` execution option. The values
+above are the defaults the adapters use when you leave them unset.
 
 **Type**: `map()` or `nil` — a keyword list is rejected by validation
 **Default**: `nil` (no caching)

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -8,68 +8,77 @@ Lotus configuration is typically placed in your `config/config.exs` file:
 
 ```elixir
 config :lotus,
-  ecto_repo: MyApp.Repo,        # Repository for Lotus query storage
+  storage_repo: MyApp.Repo,     # Repository for Lotus query storage
   default_source: "main",       # Default data source for query execution
   data_sources: %{              # Data sources for executing queries
     "main" => MyApp.Repo,
     "analytics" => MyApp.AnalyticsRepo
   },
-  cache: [                      # Optional caching configuration
+  cache: %{                     # Optional caching configuration
     adapter: Lotus.Cache.ETS,   # Cache adapter (ETS for local, Cachex for distributed)
     namespace: "myapp_cache"    # Cache namespace (optional)
-  ]
+  }
 ```
+
+> ### Renamed in v1.0 {: .warning}
+>
+> `:ecto_repo`, `:data_repos` and `:default_repo` were renamed to
+> `:storage_repo`, `:data_sources` and `:default_source`. There is no
+> compatibility shim: the old keys are rejected by configuration validation
+> at boot. See the [Upgrading to v1.0 guide](upgrading-to-v1.md).
+
+The full option list is validated with `NimbleOptions` in `Lotus.Config`. Unknown keys are ignored, invalid values raise an `ArgumentError` at boot.
 
 ## Configuration Options
 
 ### Required Options
 
-#### `ecto_repo` (required)
+#### `storage_repo` (required)
 
 Specifies the Ecto repository where Lotus stores saved queries. This is where the `lotus_queries` table lives.
 
 ```elixir
 config :lotus,
-  ecto_repo: MyApp.Repo
+  storage_repo: MyApp.Repo
 ```
 
 **Type**: `module()`
 
-#### `data_sources` (required)
+The accessor is `Lotus.repo/0` — that name did not change.
 
-A map of data sources where queries can be executed against actual data. This powerful feature allows Lotus to work with multiple databases simultaneously, supporting PostgreSQL, MySQL, and SQLite.
+#### `data_sources`
 
-Keys are friendly names that you use when executing queries. Values are **either** Ecto repository modules (for SQL databases handled by the built-in Ecto adapter) **or** config maps (for non-Ecto adapters like Elasticsearch, ClickHouse-HTTP, or any custom `Lotus.Source.Adapter` implementation).
+A map of data sources where queries can be executed against actual data. This lets Lotus work with multiple databases at the same time.
 
-> **Deprecation note**: The old `:data_repos` config key is deprecated but still works. Please migrate to `:data_sources`.
+Keys are friendly names that you use when executing queries. Values are **either** Ecto repository modules (for SQL databases handled by the built-in Ecto adapter) **or** config maps (for non-Ecto adapters like Elasticsearch, ClickHouse-over-HTTP, or any custom `Lotus.Source.Adapter` implementation).
 
 ```elixir
 config :lotus,
   data_sources: %{
     # Ecto-backed sources (module values) — handled by the built-in Ecto adapter
-    "main" => MyApp.Repo,           # Can be the same as ecto_repo
+    "main" => MyApp.Repo,               # Can be the same as storage_repo
     "analytics" => MyApp.AnalyticsRepo,
     "reporting" => MyApp.ReportingRepo,
     "mysql_data" => MyApp.MySQLRepo,    # MySQL repository
     "sqlite_data" => MyApp.SqliteRepo,  # Mix database types
 
-    # Non-Ecto sources (map values) — dispatched to a matching
-    # source_adapters entry via its can_handle?/1 callback
-    "search" => %{adapter: :elasticsearch, url: "http://localhost:9200"},
+    # Non-Ecto sources (map values) — resolved through a source_adapters entry
+    "search" => %{adapter: MyApp.ElasticsearchAdapter, url: "http://localhost:9200"},
     "warehouse" => %{adapter: MyApp.ClickHouseAdapter, url: "http://ch:8123"}
   },
-  source_adapters: [MyApp.ClickHouseAdapter]
+  source_adapters: [MyApp.ElasticsearchAdapter, MyApp.ClickHouseAdapter]
 ```
 
 **Type**: `%{String.t() => module() | map()}`
+**Default**: `%{}`
 
-Map values are opaque to Lotus — the matching adapter's `wrap/2` callback interprets them. See the [source adapters guide](source-adapters.md) for details on registering custom adapters.
+A map entry with an `:adapter` key naming a module is the canonical form — that module is used directly, with no probing. Entries without `:adapter` are offered to each `source_adapters` module's `can_handle?/1` callback; if two adapters claim the same entry, resolution raises and names both. The rest of the map is opaque to Lotus — the matching adapter's `wrap/2` callback interprets it. See the [source adapters guide](source-adapters.md).
 
-#### `default_source` (required when multiple data_sources)
+A name that is not in `data_sources` is an error, not a fallback: `Lotus.Source.resolve!/2` raises rather than running the statement against the default source.
 
-When you have multiple data sources configured, you must specify which one to use by default when no explicit source is provided in query execution.
+#### `default_source`
 
-> **Deprecation note**: The old `:default_repo` config key is deprecated but still works. Please migrate to `:default_source`.
+The data source used when a caller names no source. Required in practice as soon as you configure more than one source.
 
 ```elixir
 config :lotus,
@@ -81,101 +90,111 @@ config :lotus,
 ```
 
 **Type**: `String.t()`
-**Default**: Not required if only one data source is configured
+**Default**: none
 
 **Behavior**:
-- **Single source**: When only one data source is configured, it's automatically used as the default
-- **Multiple sources**: You must configure `default_source` to specify which one to use when no source is explicitly provided
-- **No sources**: Raises an error if no data sources are configured
+
+- **Single source**: when only one data source is configured, it is used as the default even if `default_source` is unset
+- **Multiple sources**: set `default_source`, otherwise the first entry of the map wins — which is not a stable order
+- **No sources**: `Lotus.default_data_source/0` raises with instructions to configure one
+- **Typo protection**: if `default_source` is not a key in `data_sources`, configuration validation raises at boot and lists the configured source names
 
 **Usage Examples:**
 
 ```elixir
-# Execute against a specific repository by name
+# Execute against a specific source by name
 Lotus.run_statement("SELECT COUNT(*) FROM users", [], repo: "analytics")
 
 # Execute against a repository module directly
 Lotus.run_statement("SELECT COUNT(*) FROM users", [], repo: MyApp.AnalyticsRepo)
 
-# When no repo is specified, uses the configured default_source
-Lotus.run_statement("SELECT COUNT(*) FROM users")  # Uses "main" from default_source config
+# When no source is given, uses the configured default_source
+Lotus.run_statement("SELECT COUNT(*) FROM users")  # Uses "main"
 ```
+
+> **Note**: The execution option is still named `:repo`. It accepts a source name or a repo module.
 
 **Data Source Management:**
 
 ```elixir
 # List all configured data source names
-source_names = Lotus.list_data_source_names()
+Lotus.list_data_source_names()
 # ["analytics", "main", "reporting", "sqlite_data"]
 
 # Get all configured data sources
-all_sources = Lotus.data_sources()
+Lotus.data_sources()
 # %{"analytics" => MyApp.AnalyticsRepo, "main" => MyApp.Repo, ...}
 
 # Get a specific data source by name (raises if not found)
-source = Lotus.get_data_source!("analytics")
+Lotus.get_data_source!("analytics")
 # MyApp.AnalyticsRepo
+
+# Get the default source as a {name, value} tuple
+Lotus.default_data_source()
+# {"main", MyApp.Repo}
 ```
 
-> **Note**: The `ecto_repo` can also be included in `data_sources` if you want to run queries against the same database where Lotus stores its data. This is common in single-database applications.
+`get_data_source!/1` and `data_sources/0` return what you configured, so a non-Ecto entry comes back as a map, not a module. To get a resolved `%Lotus.Source.Adapter{}` instead, use `Lotus.Source.get_source!/1`, `Lotus.Source.list_sources/0` and `Lotus.Source.default_source/0`.
+
+> **Note**: The `storage_repo` can also be included in `data_sources` if you want to run queries against the same database where Lotus stores its data. This is common in single-database applications.
 
 ### Optional Features
 
 #### `cache`
 
-Configures result caching to improve query performance. When enabled, Lotus automatically caches query results and reuses them for identical queries.
+Configures result and discovery caching. When a cache adapter is configured, Lotus caches query results and schema introspection automatically.
 
 ```elixir
 config :lotus,
-  cache: [
-    adapter: Lotus.Cache.ETS,         # Cache adapter (required)
-    namespace: "myapp_cache",         # Cache namespace (optional)
-    max_bytes: 5_000_000,            # Max cache entry size: 5MB (default)
-    compress: true,                   # Compress cache entries (default)
-    key_builder: MyApp.KeyBuilder,   # Custom key builder (optional)
-    profiles: %{                      # Cache profiles with different TTL strategies
+  cache: %{
+    adapter: Lotus.Cache.ETS,        # Cache adapter (required to enable caching)
+    namespace: "myapp_cache",        # Cache key namespace (default: "lotus:v1")
+    key_builder: MyApp.KeyBuilder,   # Lotus.Cache.KeyBuilder implementation (optional)
+    profiles: %{                     # Cache profiles with different TTL strategies
       results: [ttl_ms: 30_000],     # Short-term results (30 seconds)
-      options: [ttl_ms: 300_000],    # Medium-term data (5 minutes)  
+      options: [ttl_ms: 300_000],    # Medium-term data (5 minutes)
       schema: [ttl_ms: 3_600_000]    # Long-term schema info (1 hour)
     },
-    default_profile: :results,        # Default profile when none specified
-    default_ttl_ms: 60_000           # Fallback TTL (1 minute)
-  ]
+    default_profile: :results,       # Default profile when none specified
+    default_ttl_ms: 60_000           # Fallback TTL for the :results profile
+  }
 ```
 
-**Type**: `keyword()`  
+**Type**: `map()` or `nil` — a keyword list is rejected by validation
 **Default**: `nil` (no caching)
 
 **Available Adapters:**
-- `Lotus.Cache.ETS` - In-memory caching using ETS tables
 
-**Cache Modes:**
-- **Default**: Automatic caching when cache is configured
-- **`:bypass`**: Skip cache entirely, always query database
-- **`:refresh`**: Execute query and update cache with fresh results
+- `Lotus.Cache.ETS` — local in-memory caching using ETS
+- `Lotus.Cache.Cachex` — distributed caching through [Cachex](https://hexdocs.pm/cachex) (configure at runtime, see the caching guide)
+
+**Cache Modes** (per call, through the `:cache` execution option):
+
+- **Default**: automatic caching when a cache adapter is configured
+- **`:bypass`**: skip the cache entirely, always query the source
+- **`:refresh`**: execute the query and overwrite the cache entry
 
 For detailed caching configuration and usage, see the [Caching Guide](caching.md).
 
 #### `default_page_size`
 
-Configures the global default page size for windowed pagination. This setting helps prevent performance issues when users query large tables by automatically limiting the number of rows returned when using windowed pagination without an explicit limit.
+Configures the global default page size for windowed pagination. This keeps a user from pulling a whole large table when they page through results without an explicit limit.
 
 ```elixir
 config :lotus,
-  default_page_size: 1000  # Default: 1000 rows
+  default_page_size: 1000
 ```
 
-**Type**: `pos_integer() | nil`  
-**Default**: `nil` (falls back to built-in default of 1000)
+**Type**: `pos_integer() | nil`
+**Default**: `nil` (falls back to the built-in default of 1000)
 
 **How it Works:**
 
-This configuration only applies when using windowed pagination (`window` option) without specifying an explicit `limit`:
+This configuration only applies when you use windowed pagination (the `:window` option):
 
 ```elixir
 # Without window option - returns ALL rows (no pagination applied)
 {:ok, result} = Lotus.run_statement("SELECT * FROM large_table")
-# Could return millions of rows
 
 # With window option but no limit - uses default_page_size
 {:ok, result} = Lotus.run_statement("SELECT * FROM large_table", [], window: [])
@@ -185,43 +204,34 @@ This configuration only applies when using windowed pagination (`window` option)
 {:ok, result} = Lotus.run_statement("SELECT * FROM large_table", [], window: [limit: 500])
 # Returns max 500 rows
 
-# Limit exceeding default is capped for safety
-{:ok, result} = Lotus.run_statement("SELECT * FROM large_table", [], window: [limit: 5000])  
-# Returns max 1000 rows (capped at default_page_size)
+# Limit exceeding the default is capped for safety
+{:ok, result} = Lotus.run_statement("SELECT * FROM large_table", [], window: [limit: 5000])
+# Returns max 1000 rows
 ```
 
 **Precedence Rules:**
 
-1. **Explicit limit in window options**: Takes priority but is capped at `default_page_size`
-2. **Configured `default_page_size`**: Used when no explicit limit provided
-3. **Built-in default (1000)**: Fallback when `default_page_size` is `nil`
+1. **Explicit limit in window options**: takes priority but is capped at `default_page_size`
+2. **Configured `default_page_size`**: used when no explicit limit is given
+3. **Built-in default (1000)**: fallback when `default_page_size` is `nil`
 
-**Performance Benefits:**
+`Lotus.Export` uses the same value as its default page size when it streams results.
 
-- **Prevents accidental large queries**: Users can't accidentally return millions of rows
-- **Predictable memory usage**: Limits memory consumption per query
-- **Better responsiveness**: Faster query execution with smaller result sets
-- **Configurable safety**: Adjust the limit based on your application's needs
-
-**Example Configurations:**
-
-```elixir
-# Conservative limit for high-traffic applications
-config :lotus, default_page_size: 100
-
-# Moderate limit for typical applications  
-config :lotus, default_page_size: 1000
-
-# Higher limit for data analysis environments
-config :lotus, default_page_size: 5000
-
-# Disable default limiting (use built-in 1000)
-config :lotus, default_page_size: nil
-```
-
-> **⚠️ Important**: This setting only affects queries that explicitly use windowed pagination. Queries without the `window` option will return all matching rows regardless of this setting.
+> **⚠️ Important**: This setting only affects queries that use windowed pagination. Queries without the `window` option return all matching rows.
 
 ### Behavior Options
+
+#### `read_only`
+
+```elixir
+config :lotus,
+  read_only: true  # Default
+```
+
+**Type**: `boolean()`
+**Default**: `true`
+
+When `true`, Lotus blocks write operations (INSERT, UPDATE, DELETE, DDL) at the application level and runs statements in a read-only transaction where the adapter supports it. See [Enabling Write Queries](#enabling-write-queries) below.
 
 #### `unique_names`
 
@@ -262,14 +272,49 @@ end
 
 3. Run the migration: `mix ecto.migrate`
 
+#### `allow_unrestricted_resources`
+
+Some adapters cannot tell Lotus which tables or indexes a statement touches — Elasticsearch, for example, gates access at the index level inside the engine. Their `extract_accessed_resources/2` returns `{:unrestricted, reason}`, and preflight blocks the statement unless the operator opts in.
+
+```elixir
+config :lotus,
+  allow_unrestricted_resources: false  # Default
+```
+
+**Type**: `boolean()`
+**Default**: `false`
+
+You can opt in globally, or per source through the source's config map:
+
+```elixir
+config :lotus,
+  allow_unrestricted_resources: false,   # Locked down by default
+  data_sources: %{
+    "main" => MyApp.Repo,
+    "search" => %{
+      adapter: MyApp.ElasticsearchAdapter,
+      url: "http://localhost:9200",
+      allow_unrestricted_resources: true  # This source only
+    }
+  }
+```
+
+The per-source value wins in both directions: `true` opts a single source in under a restrictive global default, and `false` keeps a single source locked down under a permissive one. When a statement is blocked, the error names the source and tells the operator exactly which flag to set.
+
+> ### Warning {: .warning}
+>
+> Opting in means Lotus trusts the engine's own access control for that
+> source. Lotus table and column visibility rules cannot be enforced on
+> statements it cannot introspect.
+
 #### `table_visibility`
 
-Controls which database tables and schemas can be accessed through Lotus queries. This provides an additional security layer beyond read-only execution.
+Controls which database tables can be reached through Lotus queries and discovery. This is a security layer beyond read-only execution.
 
 ```elixir
 config :lotus,
   table_visibility: %{
-    # Default rules apply to all repositories unless overridden
+    # Default rules apply to all sources unless overridden
     default: [
       allow: [
         # Allow specific tables in all schemas
@@ -283,19 +328,19 @@ config :lotus,
       deny: [
         # Block sensitive tables across ALL schemas
         "credit_cards",               # Blocks credit_cards in any schema
-        "api_keys",                   # Blocks api_keys in any schema  
+        "api_keys",                   # Blocks api_keys in any schema
         # Block tables in specific schema only
         {"public", "internal_logs"},  # Only blocks public.internal_logs
         # Block pattern in specific schema
         {"public", ~r/_internal$/}    # Tables ending with '_internal' in public
       ]
     ],
-    # Repository-specific rules override defaults
+    # Source-specific rules override defaults
     analytics: [
       allow: [
-        {"analytics", ~r/.*/},        # All tables in analytics schema
-        "users",                      # users table in any schema
-        "sessions"                    # sessions table in any schema
+        {"analytics", ~r/.*/},
+        "users",
+        "sessions"
       ]
     ]
   }
@@ -303,6 +348,8 @@ config :lotus,
 
 **Type**: `map()`
 **Default**: `%{}`
+
+Map keys are matched against the data source name with `to_string/1`, so `analytics:` and `"analytics" =>` both key the `"analytics"` source. The `:default` entry is the fallback.
 
 **Built-in Protection:**
 
@@ -325,25 +372,21 @@ Lotus automatically blocks access to sensitive system tables:
 
 # Pattern matching with regex
 {"analytics", ~r/^daily_/}     # Tables starting with 'daily_' in analytics schema
-~r/^temp_/                     # Tables starting with 'temp_' in any schema (as bare regex)
+~r/^temp_/                     # Tables starting with 'temp_' in any schema
 
 # Schema-wide rules
 {"reporting", ~r/.*/}          # All tables in reporting schema
-{~r/test_/, ~r/.*/}           # All tables in schemas starting with 'test_'
+{~r/test_/, ~r/.*/}            # All tables in schemas starting with 'test_'
 ```
-
-> **Note**: Bare strings like `"api_keys"` are the simplest way to block sensitive tables across all schemas. Use tuples like `{"public", "api_keys"}` when you need schema-specific control.
 
 **Rule Evaluation:**
 
-1. **Built-in denials** - System tables are always blocked
-2. **Allow rules** - If present, only explicitly allowed tables are accessible
-3. **Deny rules** - Explicitly denied tables are blocked
-4. **Default behavior** - If no allow rules exist, all non-denied tables are accessible
+1. **Built-in denials** — system tables are always blocked
+2. **Allow rules** — if present, only explicitly allowed tables are accessible
+3. **Deny rules** — explicitly denied tables are blocked
+4. **Default behavior** — if no allow rules exist, all non-denied tables are accessible
 
-**Per-Repository Rules:**
-
-You can configure different visibility rules for each data source:
+**Per-Source Rules:**
 
 ```elixir
 config :lotus,
@@ -366,11 +409,109 @@ config :lotus,
   }
 ```
 
+#### `schema_visibility`
+
+Schema-level (namespace-level) rules. Schema rules gate table rules: if a schema is denied, every table in it is blocked no matter what `table_visibility` says.
+
+```elixir
+config :lotus,
+  schema_visibility: %{
+    postgres: [
+      allow: ["public", ~r/^tenant_/],
+      deny: ["legacy"]
+    ],
+    mysql: [
+      # In MySQL, schemas = databases
+      allow: ["app_db", "analytics_db"],
+      deny: ["staging_db"]
+    ]
+  }
+```
+
+**Type**: `map()`
+**Default**: `%{}`
+
+**Database-specific schema behavior:**
+
+- **PostgreSQL**: true namespaced schemas within a database (`public`, `reporting`, …)
+- **MySQL**: schemas are databases
+- **SQLite**: schema-less, so schema rules do not apply
+
+#### `column_visibility`
+
+Column-level rules. Lets you hide or mask individual columns per table, rather than blocking the whole table.
+
+```elixir
+config :lotus,
+  column_visibility: %{
+    default: [
+      # {table, column, policy} — any schema
+      {"users", "password_hash", :omit},
+      {"users", "email", [action: :mask, mask: :sha256]},
+      # {schema, table, column, policy}
+      {"public", "cards", ~r/^pan/, [action: :mask, mask: {:partial, [keep_last: 4]}]},
+      # {column, policy} — any schema and table
+      {~r/_ssn$/, :error}
+    ]
+  }
+```
+
+**Type**: `map()`
+**Default**: `%{}`
+
+Actions are `:allow`, `:omit` (drop the column from results), `:mask` (transform values) and `:error` (fail the query). Mask strategies are `:null`, `:sha256`, `{:fixed, value}` and `{:partial, [keep_last: 4, replacement: "*"]}`. The `show_in_schema?` option (default `true`) controls whether the column still appears in introspection. `Lotus.Visibility.Policy` has builder functions (`Policy.column_mask/1`, `Policy.column_omit/0`) for the same rules.
+
+See the [Visibility Guide](visibility.md) for the full rule grammar and worked examples.
+
+#### `middleware`
+
+Hooks that run around query execution and schema discovery.
+
+```elixir
+config :lotus,
+  middleware: %{
+    before_query: [{MyApp.TenantPredicatePlug, []}],
+    after_query: [{MyApp.AuditPlug, []}],
+    after_list_tables: [{MyApp.TableFilterPlug, []}]
+  }
+```
+
+**Type**: `map()` or `nil` — `%{event => [{Module, opts}]}`
+**Default**: `nil`
+
+**Events**: `:before_query`, `:after_query`, `:after_list_schemas`, `:after_list_tables`, `:after_describe_table`, `:after_list_relations`, `:after_discover`.
+
+In v1.0 the payload key for the data source is `:source` (it was `:repo`), and `:before_query` / `:after_query` carry a `%Lotus.Query.Statement{}` under `:statement` instead of separate `:sql` and `:params` keys. A `:before_query` plug that returns `{:cont, %{payload | statement: rewritten}}` changes what actually executes, and the rewritten statement is the one that sanitization and preflight then check. See the [Middleware Guide](middleware.md).
+
+#### `ai`
+
+AI-powered query generation, explanation and optimization.
+
+```elixir
+config :lotus,
+  ai: [
+    enabled: true,
+    model: "openai:gpt-4o",
+    api_key: {:system, "OPENAI_API_KEY"}
+  ]
+```
+
+**Type**: `keyword()`
+**Default**: `[]` (AI features disabled)
+
+**Options:**
+
+- `:enabled` (`boolean()`) — enable AI features. Default `false`
+- `:model` (`String.t()`) — a ReqLLM model string, e.g. `"openai:gpt-4o"`, `"anthropic:claude-opus-4"`. Default `"openai:gpt-4o"`
+- `:api_key` (`String.t()` or `{:system, "ENV_VAR"}`) — provider API key
+
+Without a resolvable API key, AI calls return `{:error, :api_key_not_configured}`. See the [AI Query Generation Guide](ai_query_generation.md).
+
 ### Extension Points
 
 #### `source_adapters`
 
-A list of modules implementing the `Lotus.Source.Adapter` behaviour. Custom adapters let you execute queries against non-Ecto data sources (REST APIs, Elasticsearch, ClickHouse-over-HTTP, gRPC, etc.) through the same public API.
+A list of modules implementing the `Lotus.Source.Adapter` behaviour. Custom adapters let you execute queries against non-Ecto data sources (REST APIs, Elasticsearch, ClickHouse-over-HTTP, gRPC, …) through the same public API.
 
 ```elixir
 config :lotus,
@@ -379,19 +520,33 @@ config :lotus,
     MyApp.ClickHouseAdapter
   ],
   data_sources: %{
-    "search" => %{adapter: :elasticsearch, url: "http://localhost:9200"},
+    "search" => %{adapter: MyApp.ElasticsearchAdapter, url: "http://localhost:9200"},
     "warehouse" => %{adapter: MyApp.ClickHouseAdapter, url: "http://ch:8123"}
   }
 ```
 
-**Type**: `[module()]` — each module must implement `Lotus.Source.Adapter` with `can_handle?/1` and `wrap/2`. Validated at boot: unloaded modules or modules missing the behaviour raise at `Lotus.Config.reload!/0` rather than at first query.
+**Type**: `[module()]` — each module must be loaded and declare `@behaviour Lotus.Source.Adapter`. Validated at boot: an unloaded module or one missing the behaviour raises with a message naming the module, instead of failing at first query.
 **Default**: `[]`
 
-When resolving a data source, Lotus checks each `source_adapters` module's `can_handle?/1` against the entry (repo module or map) and dispatches to the first match. If none match, atom entries fall through to the built-in Ecto adapter; map entries raise a clear error. See the [source adapters guide](source-adapters.md) for the full contract and a walkthrough.
+A map entry naming its adapter with `:adapter` goes straight to that module. Otherwise Lotus asks each `source_adapters` module's `can_handle?/1`; two claimants raise and name both. Module entries with no claimant fall through to the built-in Ecto adapter. See the [source adapters guide](source-adapters.md) for the full contract.
+
+#### `trusted_source_adapters`
+
+Adapter modules whose `ai_context/1` free-form text (`:syntax_notes`, `:error_patterns`, capability reasons) is allowed into the LLM prompt unchanged.
+
+```elixir
+config :lotus,
+  trusted_source_adapters: [MyApp.ClickHouseAdapter]
+```
+
+**Type**: `[module()]`
+**Default**: `[]`
+
+The built-in `Lotus.Source.Adapters.Ecto` and its per-dialect wrappers (Postgres, MySQL, SQLite3) are always trusted. For an untrusted adapter, only the `:language` identifier reaches the prompt — the free-form fields are stripped and capability reasons are replaced with a generic fallback, to bound the blast radius of prompt injection through third-party adapter text.
 
 #### `source_resolver`
 
-Configures the module responsible for turning repo names or modules into `%Lotus.Source.Adapter{}` structs at query time. The default static resolver reads from `data_sources` and is suitable for most applications.
+The module that turns a source name or repo module into a `%Lotus.Source.Adapter{}` struct at query time. The default static resolver reads from `data_sources`.
 
 ```elixir
 config :lotus,
@@ -401,11 +556,11 @@ config :lotus,
 **Type**: `module()` implementing `Lotus.Source.Resolver`
 **Default**: `Lotus.Source.Resolvers.Static`
 
-Use a custom resolver when you need runtime source registration, database-backed source lookup, or per-tenant sources. See the [Custom Resolvers guide](custom-resolvers.md) for contracts, minimal examples, and testing tips.
+Use a custom resolver when you need runtime source registration, database-backed source lookup, or per-tenant sources. See the [Custom Resolvers guide](custom-resolvers.md).
 
 #### `visibility_resolver`
 
-Configures the module responsible for loading schema, table, and column visibility rules. The default static resolver reads from `schema_visibility`, `table_visibility`, and `column_visibility` application config.
+The module that loads schema, table and column visibility rules. The default static resolver reads from `schema_visibility`, `table_visibility` and `column_visibility`.
 
 ```elixir
 config :lotus,
@@ -415,7 +570,7 @@ config :lotus,
 **Type**: `module()` implementing `Lotus.Visibility.Resolver`
 **Default**: `Lotus.Visibility.Resolvers.Static`
 
-Use a custom resolver when visibility rules must change without application restarts, are stored in a database, or vary per tenant or role. See the [Custom Resolvers guide](custom-resolvers.md) for contracts, minimal examples, and testing tips.
+Resolver callbacks (`schema_rules_for/2`, `table_rules_for/2`, `column_rules_for/2`) take the caller's `:scope` as a second argument, so rules can vary per tenant or role. The shipped static resolver ignores it. In v1.0 these rules are enforced at execution as well as in the schema browser: a table hidden from a scope cannot be queried by that scope either. See the [Custom Resolvers guide](custom-resolvers.md) and the [Visibility Guide](visibility.md).
 
 ## Enabling Write Queries
 
@@ -470,10 +625,10 @@ so even `read_only: false` in Lotus cannot bypass it.
 
 ### Why Use Read-Only Repositories?
 
-- **Connection-level enforcement**: The repository rejects all writes before they reach the database
+- **Connection-level enforcement**: the repository rejects all writes before they reach the database
 - **Immune to option overrides**: Lotus's `read_only: false` has no effect — Ecto blocks writes first
-- **Clear intent**: Explicitly declares that a repository is intended only for reading data
-- **Defense-in-depth**: Works alongside Lotus's application-level safety checks
+- **Clear intent**: explicitly declares that a repository is intended only for reading data
+- **Defense-in-depth**: works alongside Lotus's application-level safety checks
 
 ### Configuring Read-Only Repositories
 
@@ -494,7 +649,7 @@ Configure Lotus to use your read-only repository for data queries:
 ```elixir
 # config/config.exs
 config :lotus,
-  ecto_repo: MyApp.Repo,           # Use regular repo for storing Lotus queries
+  storage_repo: MyApp.Repo,        # Use regular repo for storing Lotus queries
   data_sources: %{
     "main" => MyApp.ReadOnlyRepo,  # Use read-only repo for data queries
     "analytics" => MyApp.AnalyticsReadOnlyRepo
@@ -514,7 +669,7 @@ When a data source is configured with Ecto's `read_only: true`:
 
 1. **Ecto blocks writes first** — the repo rejects INSERT/UPDATE/DELETE before Lotus is involved
 2. **Lotus's `read_only: false` has no effect** — even if you pass it, the repo won't execute writes
-3. **Lotus safety checks still apply** — SQL validation, table visibility, and preflight authorization run as usual
+3. **Lotus safety checks still apply** — statement validation, table visibility, and preflight authorization run as usual
 
 ```elixir
 # Reads work normally
@@ -533,12 +688,14 @@ For comprehensive details on repository configuration options, see the official 
 
 ## Execution Options
 
-While not part of application configuration, Lotus supports runtime options for query execution:
+While not part of application configuration, Lotus supports runtime options for query execution. `Lotus.run_query/2` and `Lotus.run_statement/3` accept:
+
+`:timeout`, `:statement_timeout_ms`, `:read_only`, `:search_path`, `:repo`, `:vars`, `:cache`, `:window`, `:filters`, `:sorts`, `:context`, `:scope`.
 
 ### Timeout Options
 
 ```elixir
-# Default timeout (5 seconds)
+# Default timeout (15 seconds)
 Lotus.run_query(query)
 
 # Custom timeout
@@ -555,37 +712,85 @@ Lotus.run_query(query, statement_timeout_ms: 15_000)  # 15 seconds
 Lotus.run_query(query, search_path: "analytics, public")
 ```
 
-## Validation
+### Caller Identity Options
 
-Lotus validates your configuration at startup. Common validation errors:
-
-### Missing Repository
+Two options carry caller identity through the pipeline, and they are not interchangeable:
 
 ```elixir
-# This will raise ArgumentError during compilation
-config :lotus
-  # repo: MyApp.Repo  # Missing!
+# :context — opaque value handed to middleware and telemetry. NOT part of the cache key.
+Lotus.run_query(query, context: %{request_id: "abc", actor: current_user})
+
+# :scope — handed to the visibility resolver AND hashed into the cache key.
+Lotus.run_query(query, scope: %{tenant_id: 42})
 ```
 
-**Error**: `Invalid :lotus config: required :ecto_repo option not found, received options: []`
+If your middleware or visibility rules change what a query returns per actor, that identity must go in `:scope`, not only in `:context` — otherwise two different actors share one cache entry. See [Scope and cache correctness](caching.md#scope-and-cache-correctness).
+
+## Validation
+
+Lotus validates your configuration on first access and caches the result in `:persistent_term`. Common validation errors:
+
+### Missing Storage Repository
+
+```elixir
+config :lotus,
+  data_sources: %{"main" => MyApp.Repo}
+  # storage_repo missing!
+```
+
+**Error**: `Invalid :lotus config: required :storage_repo option not found`
+
+### Default Source Not In Data Sources
+
+```elixir
+config :lotus,
+  storage_repo: MyApp.Repo,
+  default_source: "primary",         # typo
+  data_sources: %{"main" => MyApp.Repo}
+```
+
+**Error**: `Invalid :lotus config: :default_source "primary" is not a key in :data_sources. Configured sources: ["main"]`
+
+### Pre-v1 Keys
+
+Old key names are not normalized. `ecto_repo`, `data_repos` and `default_repo` are simply not part of the schema, so `storage_repo` reads as missing and every source lookup comes up empty. See the [Upgrading to v1.0 guide](upgrading-to-v1.md).
+
+### Reloading Configuration
+
+Because the validated configuration is cached, changing `:lotus` application environment after boot (in tests, for example) has no effect until you refresh it:
+
+```elixir
+Application.put_env(:lotus, :default_page_size, 50)
+Lotus.Config.reload!()
+```
 
 ## Configuration Helpers
 
-Lotus provides helper functions to access configuration at runtime:
+Lotus provides helper functions to read configuration at runtime:
 
 ```elixir
-# Get the configured repository
+# Get the storage repository
 Lotus.repo()
 # MyApp.Repo
 
 # Check if unique names are enforced
 Lotus.unique_names?()
 # true
+
+# Read-only mode
+Lotus.Config.read_only?()
+# true
+
+# The whole validated configuration
+Lotus.Config.all()
+
+# Any single key
+Lotus.Config.get(:default_page_size)
 ```
 
 ## Multi-Database Support
 
-Lotus supports PostgreSQL, MySQL, and SQLite databases. The migration system automatically detects the adapter and runs the appropriate migrations.
+Lotus supports PostgreSQL, MySQL, and SQLite databases out of the box. The migration system automatically detects the adapter and runs the appropriate migrations.
 
 ### PostgreSQL Configuration
 
@@ -622,11 +827,11 @@ config :my_app, MyApp.SqliteRepo,
 
 ### Mixed Database Environments
 
-You can mix PostgreSQL, MySQL, and SQLite repositories:
+You can mix PostgreSQL, MySQL, and SQLite repositories, and add non-Ecto sources alongside them:
 
 ```elixir
 config :lotus,
-  ecto_repo: MyApp.Repo,          # PostgreSQL for storage
+  storage_repo: MyApp.Repo,       # PostgreSQL for storage
   default_source: "postgres",     # Default data source for queries
   data_sources: %{
     "postgres" => MyApp.Repo,     # PostgreSQL data

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -6,11 +6,30 @@ Thank you for your interest in contributing to Lotus! This guide will help you g
 
 ### Prerequisites
 
-- Elixir 1.18 or later
-- OTP 27 or later
-- PostgreSQL 13 or later (for main development database)
-- SQLite 3 (for multi-database testing)
+- **Elixir 1.18 or later** (`mix.exs` requires `~> 1.18`; CI runs 1.18, 1.19 and 1.20)
+- **OTP 27 or later** (CI runs OTP 27.3.2 for Elixir 1.18/1.19 and OTP 29.0.2 for Elixir 1.20)
+- **Docker** — the repo ships a `docker-compose.yml` with the PostgreSQL and MySQL services the test suite expects
+- **SQLite 3** — provided by the `ecto_sqlite3` dependency; the database is a file under `priv/`
 - Git
+
+If you use [mise](https://mise.jdx.dev/), `mise.toml` pins the versions the
+maintainers develop against (Elixir 1.20.1-otp-29, Erlang 29.0.2) — run
+`mise install` and you are done.
+
+### Database Services
+
+`docker compose up -d` starts everything:
+
+| Service | Image | Host port | Credentials |
+|---------|-------|-----------|-------------|
+| `db` (PostgreSQL) | `postgres:15.8` | `2345` | `postgres` / `postgres` |
+| `mysql` | `mysql:8.0` | `3307` | `lotus` / `lotus` (root: `mysql`), database `lotus_test` |
+| `adminer` | `adminer` | `8086` | web DB browser, optional |
+
+The ports are deliberately non-standard so they do not collide with a local
+PostgreSQL or MySQL install. `config/dev.exs` and `config/test.exs` point at
+them. The MySQL test repo reads a `MYSQL_URL` environment variable and falls
+back to `mysql://root:mysql@localhost:3307/lotus_test`.
 
 ### Development Setup
 
@@ -25,47 +44,56 @@ Thank you for your interest in contributing to Lotus! This guide will help you g
    mix deps.get
    ```
 
-3. **Set up the development databases**
+3. **Start the database services**
    ```bash
-   # Start PostgreSQL (if not running)
-   # Then create and migrate the databases
+   docker compose up -d
+   ```
+
+4. **Set up the development databases**
+   ```bash
    mix ecto.setup
    ```
-   
-   This creates:
-   - PostgreSQL database (`lotus_dev`) with both Lotus tables and test data tables
-   - SQLite database (`lotus_dev.db`) with e-commerce sample data
 
-4. **Run the tests**
+   This runs `ecto.create` + `ecto.migrate` for all three dev repos
+   (`Lotus.Test.Repo` on PostgreSQL, `Lotus.Test.MysqlRepo`, and
+   `Lotus.Test.SqliteRepo`), creating:
+
+   - PostgreSQL database `lotus_dev` with both the Lotus tables and sample data
+   - MySQL database `lotus_test` with sample data
+   - SQLite database `priv/lotus_dev.db` with e-commerce sample data
+
+   `mix ecto.reset` drops and recreates them.
+
+5. **Set up the test databases and run the tests**
    ```bash
-   # Run all tests
+   mix test.setup   # ecto.drop --quiet + ecto.create + ecto.migrate, in MIX_ENV=test
    mix test
-   
-   # Run PostgreSQL-specific tests
-   mix test --exclude sqlite
-   
-   # Run SQLite-specific tests  
-   mix test --only sqlite
    ```
 
-5. **Start exploring with interactive development**
+   `mix test.setup` and `mix test` are both pinned to `MIX_ENV=test` by the
+   `cli/0` callback in `mix.exs`, so no `MIX_ENV=` prefix is needed.
+
+6. **Start exploring with interactive development**
    ```bash
    iex -S mix
    ```
-   
-   The development environment automatically starts both PostgreSQL and SQLite repos for testing. You can immediately start experimenting:
-   
+
+   The development environment starts the PostgreSQL, MySQL and SQLite repos.
+   You can immediately start experimenting:
+
    ```elixir
-   # Test PostgreSQL functionality
+   # Run a statement against a named data source
    Lotus.run_statement("SELECT COUNT(*) FROM users", [], repo: "postgres")
-   
-   # Test SQLite functionality
    Lotus.run_statement("SELECT COUNT(*) FROM products", [], repo: "sqlite")
-   
-   # Create and run queries
+
+   # Inspect what is configured
+   Lotus.list_data_source_names()
+   #=> ["postgres", "mysql", "sqlite"]
+
+   # Create and run a saved query
    {:ok, query} = Lotus.create_query(%{
      name: "Test Query",
-     statement: "SELECT 1 as test"
+     statement: "SELECT 1 AS test"
    })
    Lotus.run_query(query)
    ```
@@ -82,62 +110,70 @@ Everything lives under `lib/lotus/`. The library is roughly split into a public 
 
 - [`Lotus`](../lib/lotus.ex) — Top-level facade. `run_query/2`, `run_statement/3`, `create_query/1`, schema helpers, and dashboard helpers all entry through here.
 - [`Lotus.Supervisor`](../lib/lotus/supervisor.ex) — Boots the configured cache adapter, starts a `Task.Supervisor` (used by dashboard card execution), and compiles the middleware pipeline.
-- [`Lotus.Config`](../lib/lotus/config.ex) — Validates and caches application configuration (data sources, cache profiles, visibility rules, AI settings, middleware, etc.).
+- [`Lotus.Config`](../lib/lotus/config.ex) — Validates and caches application configuration (data sources, cache profiles, visibility rules, AI settings, middleware, adapter registration, resolvers) through a `NimbleOptions` schema.
 - [`Lotus.Telemetry`](../lib/lotus/telemetry.ex) — Emits `:telemetry` events for query execution, schema introspection, and cache hits/misses.
 
 **Query pipeline**
 
-- [`Lotus.Runner`](../lib/lotus/runner.ex) — SQL execution engine. Enforces single-statement, applies the read-only deny list, invokes preflight, runs middleware, executes inside a read-only transaction, and applies column-level visibility policies to the result.
-- [`Lotus.Preflight`](../lib/lotus/preflight.ex) — Uses `EXPLAIN` (per source) to discover which relations a statement will touch before executing it.
+- [`Lotus.Query.Statement`](../lib/lotus/query/statement.ex) — The opaque carrier threaded through the whole pipeline: `:adapter`, `:body` (adapter-native term — SQL text, a JSON map, a DSL AST), `:params` (list for positional binds, map for named binds), and `:meta`.
+- [`Lotus.Runner`](../lib/lotus/runner.ex) — Execution engine. Runs `:before_query` middleware, asks the adapter to sanitize the statement, invokes preflight, executes inside a read-only transaction, and applies column-level visibility policies to the result.
+- [`Lotus.Preflight`](../lib/lotus/preflight.ex) — Asks the adapter which relations a statement will touch before executing it (`EXPLAIN` for the Ecto adapter) and checks them against visibility rules.
 - [`Lotus.Preflight.Relations`](../lib/lotus/preflight/relations.ex) — Process-local staging for relations discovered during preflight so the runner can reuse them when applying column policies.
-- [`Lotus.Middleware`](../lib/lotus/middleware.ex) — Plug-style pipeline compiled into `:persistent_term`. Supports `:before_query`, `:after_query`, and `:after_list_*` schema events.
+- [`Lotus.Middleware`](../lib/lotus/middleware.ex) — Plug-style pipeline compiled into `:persistent_term`. Supports `:before_query`, `:after_query`, `:after_list_schemas`, `:after_list_tables`, `:after_describe_table`, `:after_list_relations`, and `:after_discover`.
 - [`Lotus.Result`](../lib/lotus/result.ex) / [`Lotus.Result.Statistics`](../lib/lotus/result/statistics.ex) — The struct returned from query execution.
+- [`Lotus.UnsupportedOperatorError`](../lib/lotus/unsupported_operator_error.ex) — Raised when a filter asks for an operator the adapter did not declare in `supported_filter_operators/1`. Silent degradation is not an option.
 
 **Saved queries, dashboards, and visualizations**
 
-- [`Lotus.Storage`](../lib/lotus/storage.ex) — CRUD for saved queries persisted through the application's `Ecto.Repo`.
-- [`Lotus.Storage.Query`](../lib/lotus/storage/query.ex) — Schema for saved queries; builds SQL + params from statement text plus user-supplied variables.
+- [`Lotus.Storage`](../lib/lotus/storage.ex) — CRUD for saved queries persisted through the application's `:storage_repo`.
+- [`Lotus.Storage.Query`](../lib/lotus/storage/query.ex) — Schema for saved queries. `compile/2` and `compile!/2` thread a `%Statement{}` through a reduce loop, delegating each `{{variable}}` to the adapter's `substitute_variable/5`. Queries carry a `data_source` and an optional `query_language` (`sql:postgres`, `json:elasticsearch`).
 - [`Lotus.Storage.SchemaCache`](../lib/lotus/storage/schema_cache.ex) — ETS-backed cache of column metadata used for type-aware value casting.
-- [`Lotus.Storage.TypeCaster`](../lib/lotus/storage/type_caster.ex) / `TypeHandler` — Cast user values into parameters appropriate for the target database. Type mapping is handled by each dialect's `db_type_to_lotus_type/1` callback.
+- [`Lotus.Storage.TypeCaster`](../lib/lotus/storage/type_caster.ex) / `TypeHandler` — Cast user values into parameters appropriate for the target source. The `column_info` map carries a resolved `%Lotus.Source.Adapter{}` under `:adapter`; type mapping is handled by the adapter's `db_type_to_lotus_type/2` callback,
+which the Ecto adapter forwards to its dialect's `db_type_to_lotus_type/1`.
 - [`Lotus.Dashboards`](../lib/lotus/dashboards.ex) — CRUD and orchestration for dashboards (cards, filters, filter mappings). Uses the task supervisor to fan out card execution.
 - [`Lotus.Viz`](../lib/lotus/viz.ex) — CRUD and validation for per-query visualization configs.
-- [`Lotus.Query.Filter`](../lib/lotus/query/filter.ex) / [`Lotus.Query.Sort`](../lib/lotus/query/sort.ex) — Runtime filter/sort structs that the source adapters inject into already-prepared SQL.
-- `Lotus.Source.Adapters.Ecto.SQL.*` (`lib/lotus/source/adapters/ecto/sql/`) — Low-level SQL helpers (sanitizer, identifier quoting, filter/sort injectors, validator, transformer).
+- [`Lotus.Query.Filter`](../lib/lotus/query/filter.ex) / [`Lotus.Query.Sort`](../lib/lotus/query/sort.ex) — Runtime filter/sort structs that the adapter's `apply_filters/3` and `apply_sorts/3` inject into an already-prepared statement.
+- `Lotus.Source.Adapters.Ecto.SQL.*` (`lib/lotus/source/adapters/ecto/sql/`) — Low-level SQL helpers (sanitizer, identifier quoting, filter/sort injectors, validator, transformer). These are Ecto-adapter internals, not part of the universal contract.
 
 **Introspection and visibility**
 
-- [`Lotus.Schema`](../lib/lotus/schema.ex) — Lists schemas, lists tables, and inspects table schemas across sources. Automatically applies visibility rules and runs `:after_list_*` middleware.
-- [`Lotus.Visibility`](../lib/lotus/visibility.ex) — Two-level visibility (schema → table) plus column policies. Schema visibility takes precedence over table visibility.
+- [`Lotus.Schema`](../lib/lotus/schema.ex) — `list_schemas/2`, `list_tables/2`, `describe_table/3`, `get_table_stats/3`, and `list_relations/2` across sources. Automatically applies visibility rules and runs the `:after_list_*` middleware.
+- [`Lotus.Visibility`](../lib/lotus/visibility.ex) — Schema and table visibility, where **schema visibility takes precedence**, plus column policies applied to result rows. Together these are the three levels: schema, table, column.
 - [`Lotus.Visibility.Policy`](../lib/lotus/visibility/policy.ex) — Per-column policy (`:omit`, `{:mask, ...}`, `:error`) that the runner applies to result rows.
-- [`Lotus.Visibility.Resolver`](../lib/lotus/visibility/resolver.ex) — Behaviour for plugging in custom visibility resolution; the default lives in [`Lotus.Visibility.Resolvers.Static`](../lib/lotus/visibility/resolvers/static.ex).
+- [`Lotus.Visibility.Resolver`](../lib/lotus/visibility/resolver.ex) — Behaviour for plugging in custom visibility resolution; the default lives in [`Lotus.Visibility.Resolvers.Static`](../lib/lotus/visibility/resolvers/static.ex) and is selected with the `:visibility_resolver` config key.
 
 **Source adapter abstraction**
 
-- [`Lotus.Source`](../lib/lotus/source.ex) — Public facade for data sources. Provides `resolve!/2`, `source_type/1`, `supports_feature?/2`, `hierarchy_label/1`, and other convenience functions that accept adapter structs, source name strings, or raw repo modules.
-- [`Lotus.Source.Adapter`](../lib/lotus/source/adapter.ex) — Behaviour + struct (`%Adapter{name, module, state, source_type}`) that represents a resolved data source. This is what flows through the query pipeline instead of raw repo modules.
+- [`Lotus.Source`](../lib/lotus/source.ex) — Public **facade** (not a behaviour) for data sources: `resolve!/2`, `list_sources/0`, `get_source!/1`, `default_source/0`, `source_type/1`, `supports_feature?/2`, `hierarchy_label/1`, `example_query/3`, `query_language/1`, `editor_config/1`, `limit_query/3`, `supported_filter_operators/1`, `prepare_for_analysis/2`, `name_from_module!/1`. Each accepts an adapter struct, a source name string, or a repo module.
+- [`Lotus.Source.Adapter`](../lib/lotus/source/adapter.ex) — The universal behaviour **and** struct (`%Adapter{name, module, state, source_type}`) that represents a resolved data source. This is what flows through the query pipeline instead of raw repo modules. Most SQL-shaped callbacks are optional with safe defaults, so a non-SQL adapter implements roughly ten callbacks rather than thirty.
 - [`Lotus.Source.Adapters.Ecto`](../lib/lotus/source/adapters/ecto.ex) — Macro provider (`use Lotus.Source.Adapters.Ecto, dialect: ...`) and generic fallback adapter for unknown Ecto repos.
-- [`Lotus.Source.Adapters.Postgres`](../lib/lotus/source/adapters/postgres.ex) / [`MySQL`](../lib/lotus/source/adapters/mysql.ex) / [`SQLite3`](../lib/lotus/source/adapters/sqlite.ex) — Per-dialect adapter modules. Each uses `use Lotus.Source.Adapters.Ecto` with its corresponding dialect.
-- [`Lotus.Source.Adapters.Ecto.Dialect`](../lib/lotus/source/adapters/ecto/dialect.ex) — Behaviour for SQL-dialect-specific callbacks (transaction handling, identifier quoting, introspection queries, type mapping, etc.).
+- [`Lotus.Source.Adapters.Postgres`](../lib/lotus/source/adapters/postgres.ex) / [`MySQL`](../lib/lotus/source/adapters/mysql.ex) / [`SQLite3`](../lib/lotus/source/adapters/sqlite.ex) — Per-dialect adapter modules, each built with the `Ecto` macro.
+- [`Lotus.Source.Adapters.Ecto.Dialect`](../lib/lotus/source/adapters/ecto/dialect.ex) — **Public** behaviour for SQL-dialect-specific callbacks (transaction handling, identifier quoting, introspection queries, placeholders, type mapping, `query_language/0`). This is what an external SQL engine implements.
 - [`Lotus.Source.Adapters.Ecto.Dialects.Postgres`](../lib/lotus/source/adapters/ecto/dialects/postgres.ex) / [`MySQL`](../lib/lotus/source/adapters/ecto/dialects/mysql.ex) / [`SQLite3`](../lib/lotus/source/adapters/ecto/dialects/sqlite.ex) / [`Default`](../lib/lotus/source/adapters/ecto/dialects/default.ex) — Dialect implementations.
-- [`Lotus.Source.Resolver`](../lib/lotus/source/resolver.ex) / [`Lotus.Source.Resolvers.Static`](../lib/lotus/source/resolvers/static.ex) — Behaviour and default implementation for resolving a name/module into an `%Adapter{}`. Alternative resolvers can come from registries or external services.
+- [`Lotus.Source.Resolver`](../lib/lotus/source/resolver.ex) / [`Lotus.Source.Resolvers.Static`](../lib/lotus/source/resolvers/static.ex) — Behaviour and default implementation for resolving a name/module into an `%Adapter{}`, selected with the `:source_resolver` config key. An unresolvable name is an error — it never silently falls back to the default source.
 - [`Lotus.Normalizer.Postgres`](../lib/lotus/normalizer/postgres.ex) / [`Lotus.Normalizer.MySQL`](../lib/lotus/normalizer/mysql.ex) — Normalize driver-specific result shapes into the `Lotus.Result` format.
 
 **Caching**
 
-- [`Lotus.Cache`](../lib/lotus/cache.ex) — Facade that dispatches to the configured cache adapter and emits telemetry. Supports namespaced keys, TTL, and tag-based invalidation.
-- [`Lotus.Cache.Adapter`](../lib/lotus/cache/adapter.ex) — Behaviour for cache backends.
+- [`Lotus.Cache`](../lib/lotus/cache.ex) — Facade that dispatches to the configured cache adapter and emits telemetry. Supports namespaced keys, TTL, and tag-based invalidation. Result entries are tagged `"query:<id>"`, `"source:<name>"`, and — when a scope is given — `"scope:<digest>"`.
+- [`Lotus.Cache.Adapter`](../lib/lotus/cache/adapter.ex) — Behaviour for cache backends (`get/1`, `put/4`, `delete/1`, `get_or_store/4`, `invalidate_tags/1`, `touch/2`, `spec_config/0`).
 - [`Lotus.Cache.ETS`](../lib/lotus/cache/ets.ex) / [`Lotus.Cache.Cachex`](../lib/lotus/cache/cachex.ex) — Built-in backends. ETS is the zero-dependency default; Cachex is the advanced option.
-- [`Lotus.Cache.Key`](../lib/lotus/cache/key.ex) — Stable key derivation from SQL, parameters, adapter name, and search path.
+- [`Lotus.Cache.Key`](../lib/lotus/cache/key.ex) / [`Lotus.Cache.KeyBuilder`](../lib/lotus/cache/key_builder.ex) — `Key` is a thin wrapper that delegates to the configured key builder. `KeyBuilder` is the behaviour (`discovery_key/2`, `result_key/4`) with a public `scope_digest/1` helper; swap it with `cache: %{key_builder: MyApp.KeyBuilder}`.
 
 **Export and AI**
 
-- [`Lotus.Export`](../lib/lotus/export.ex) — Converts `Lotus.Result` to CSV/JSON/JSONL, streams large CSV exports, and ZIPs a full dashboard export.
-- [`Lotus.AI`](../lib/lotus/ai.ex) — Public AI surface (`generate_query/1`, `explain_query/2`, `optimize_query/2`).
-- [`Lotus.AI.SQLGenerator`](../lib/lotus/ai/sql_generator.ex), [`QueryExplainer`](../lib/lotus/ai/query_explainer.ex), [`QueryOptimizer`](../lib/lotus/ai/query_optimizer.ex) — Request orchestration for each AI capability.
+- [`Lotus.Export`](../lib/lotus/export.ex) — Converts `Lotus.Result` to CSV/JSON/JSONL (`to_csv/1`, `to_json/1`, `to_jsonl/1`), streams large CSV exports (`stream_csv/2`), and ZIPs a full dashboard export (`export_dashboard/2`).
+- [`Lotus.AI`](../lib/lotus/ai.ex) — Public AI surface: `generate_query/1`, `generate_query_with_context/1`, `explain_query/1`, `suggest_optimizations/1`, `enabled?/0`, `supports?/2`, `unsupported_reason/2`, `model/0`.
+- [`Lotus.AI.QueryGenerator`](../lib/lotus/ai/query_generator.ex), [`QueryExplainer`](../lib/lotus/ai/query_explainer.ex), [`QueryOptimizer`](../lib/lotus/ai/query_optimizer.ex) — Request orchestration for each AI capability.
 - [`Lotus.AI.Conversation`](../lib/lotus/ai/conversation.ex) — Multi-turn conversation state used for iterative refinement.
-- [`Lotus.AI.Actions`](../lib/lotus/ai/actions.ex) and `lib/lotus/ai/actions/` — Tool definitions the LLM can call (schema listing, column value sampling, SQL validation/execution).
-- `Lotus.AI.Prompts.*` (`lib/lotus/ai/prompts/`) — Prompt templates for SQL generation, explanation, optimization, and variable inference.
+- [`Lotus.AI.Actions`](../lib/lotus/ai/actions.ex) and `lib/lotus/ai/actions/` — Tool definitions the LLM can call (schema listing, column value sampling, statement validation/execution).
+- `Lotus.AI.Prompts.*` (`lib/lotus/ai/prompts/`) — Prompt templates for query generation, explanation, optimization, and variable inference.
 - [`Lotus.AI.SchemaOptimizer`](../lib/lotus/ai/schema_optimizer.ex) — Trims schema context before it is sent to the LLM.
+
+The AI layer is adapter-driven: each adapter's `ai_context/1` supplies its own
+language identifier, example query, syntax notes, and error patterns. Only
+adapters listed in `:trusted_source_adapters` have their free-form text passed
+through to the prompt unchanged; for everything else only `:language` survives.
 
 ### Query Execution Pipeline
 
@@ -148,42 +184,44 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
 │ Lotus.run_query / Lotus.run_statement                                │
 │  • Merge variable defaults + opts[:vars]                             │
 │  • Storage.Query.compile/2 → {:ok, %Statement{}}                     │
+│    (per-variable dispatch to Adapter.substitute_variable/5)          │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │ Lotus.Source.resolve!/2                                              │
 │  • Configured resolver → %Lotus.Source.Adapter{}                     │
+│  • Unknown name → raises; it never falls back to the default         │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│ Dynamic SQL shaping (per-source via Lotus.Source)                    │
+│ Statement shaping (per-adapter, %Statement{} in / %Statement{} out)  │
 │  • apply_filters/3 (Lotus.Query.Filter)                              │
-│  • apply_sorts/2   (Lotus.Query.Sort)                                │
-│  • windowed pagination (limit/offset/count)                          │
+│  • apply_sorts/3   (Lotus.Query.Sort)                                │
+│  • apply_pagination/3 → statement.meta[:count_spec]                  │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │ Lotus.Cache.get_or_store/4                                           │
-│  • Key: sql + params + adapter name + search_path                    │
-│  • Tags: ["query:<id>", "repo:<name>", ...user tags]                 │
+│  • Key: from the configured Lotus.Cache.KeyBuilder                   │
+│  • Tags: ["query:<id>", "source:<name>", "scope:<digest>", ...]      │
 │  • Hit  → return cached Result                                       │
 │  • Miss → run the fetcher below                                      │
 └─────────────────────────────────────────────────────────────────────┘
                                │ miss / :bypass / :refresh
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│ Lotus.Runner.run_statement                                           │
-│  1. Middleware.run(:before_query, _) — may rewrite the statement     │
-│  2. assert_single_statement/1                                        │
-│  3. assert_not_denied/2 (skipped when read_only: false)              │
-│  4. Lotus.Preflight.authorize (EXPLAIN + visibility check)           │
+│ Lotus.Runner.run_statement(%Adapter{}, %Statement{}, opts)           │
+│  1. Telemetry.query_start                                            │
+│  2. Middleware.run(:before_query, _) — may rewrite the statement     │
+│  3. Adapter.sanitize_query (single statement + deny list)            │
+│  4. Adapter.needs_preflight? → Lotus.Preflight.authorize             │
 │  5. Adapter.transaction (read-only) → Adapter.execute_query          │
 │  6. Column policy enforcement (omit / mask / error)                  │
 │  7. Middleware.run(:after_query, _)                                  │
-│  8. Telemetry start/stop/exception                                   │
+│  8. Telemetry.query_stop / query_exception                           │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
@@ -192,28 +230,28 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
 
 A few notes on the pipeline:
 
-- **Variable binding** happens inside `Lotus.Storage.Query.compile/2`, which also consults `Lotus.Storage.SchemaCache` for type-aware casting of user-supplied values.
-- **Filters and sorts** are injected through the source adapter, not concatenated naively — see `Lotus.Source.Adapters.Ecto.SQL.FilterInjector` and `Lotus.Source.Adapters.Ecto.SQL.SortInjector`.
-- **Windowed pagination** rewrites the SQL to fetch a page and (optionally) issue a separate `COUNT(*)` for the exact total.
+- **Variable binding** happens inside `Lotus.Storage.Query.compile/2`, which also consults `Lotus.Storage.SchemaCache` for type-aware casting of user-supplied values. Substitution itself is adapter-owned: prepared-statement adapters push a placeholder into `statement.body` and the value into `statement.params`, while JSON/DSL adapters inline a properly escaped literal. **Those adapters are the injection boundary** — escape through the target language's own encoder, never by string concatenation.
+- **Filters and sorts** are injected through the adapter, not concatenated naively — see `Lotus.Source.Adapters.Ecto.SQL.FilterInjector` and `SortInjector`. An adapter must declare the operators it handles via `supported_filter_operators/1`; anything else raises `Lotus.UnsupportedOperatorError`.
+- **Pagination** has two strategies for `count: :exact`. An engine that returns the total as a side-effect of the main query puts it in `execute_query/4`'s `:total_count` key; everything else places a count spec in `statement.meta[:count_spec]` and Lotus core runs it. The inline count wins when both are present.
 - **Caching** is optional. When no cache adapter is configured, `Lotus.Cache` is a pass-through and the fetcher always runs.
-- **Preflight** issues `EXPLAIN` against the target source. The relations it discovers are stashed in `Lotus.Preflight.Relations` so the runner can look up column visibility policies without re-parsing the SQL.
-- **Middleware** runs first, because a `:before_query` plug may rewrite the statement; sanitization and preflight then apply to whatever it returns. Halting the pipeline from a `:before_query` plug yields `{:error, reason}` to the caller.
+- **Preflight** is skipped when `needs_preflight?/2` returns false (the Ecto adapter keeps the `EXPLAIN` / `SHOW` / `PRAGMA` heuristic internally). The relations it discovers are stashed in `Lotus.Preflight.Relations` so the runner can look up column visibility policies without re-parsing the statement. An adapter that cannot enumerate resources returns `{:unrestricted, reason}`, which is blocked unless the operator opts in with `:allow_unrestricted_resources`.
+- **Middleware runs first**, before sanitization and preflight, because a `:before_query` plug may rewrite the statement — row-level security and tenant predicates are the point of the hook. Sanitization and preflight then apply to whatever will actually execute. Halting from a `:before_query` plug yields `{:error, reason}` to the caller.
 
 ### Schema Introspection Flow
 
 Schema calls follow a simpler path but share the same adapter and middleware infrastructure:
 
 ```
-Lotus.Schema.list_schemas / list_tables / get_table_schema
+Lotus.Schema.list_schemas / list_tables / describe_table / list_relations
   │
   ▼
 Lotus.Source.resolve!/2         (→ %Adapter{})
   │
   ▼
-Lotus.Cache.get_or_store         (optional, keyed by repo + args)
+Lotus.Cache.get_or_store         (optional, discovery_key/2)
   │
   ▼
-Adapter dispatch → source-specific introspection query
+Adapter dispatch → source-specific introspection
   │
   ▼
 Lotus.Visibility filtering       (schema > table > column)
@@ -222,110 +260,156 @@ Lotus.Visibility filtering       (schema > table > column)
 Middleware.run(:after_list_schemas | :after_list_tables | ...)
   │
   ▼
+Middleware.run(:after_discover)
+  │
+  ▼
 Telemetry.schema_introspection_stop
 ```
 
-Column metadata discovered during `get_table_schema/2` is additionally cached in `Lotus.Storage.SchemaCache`, which is what powers type-aware variable casting when queries run.
+Column metadata discovered during `describe_table/3` is additionally cached in
+`Lotus.Storage.SchemaCache`, which is what powers type-aware variable casting
+when queries run.
+
+Note the naming: `describe_table/3` returns **column definitions**;
+`list_schemas/1` and `resolve_table_namespace/3` deal with **namespaces**. The
+v1 rename exists to keep those two meanings of "schema" apart — please preserve
+it when adding callbacks.
 
 ### Adapter Patterns
 
 Lotus has four pluggable extension points. Each is a behaviour plus a default implementation, so you can swap any of them without forking the library.
 
-| Extension point            | Behaviour                                     | Default                                  |
-|----------------------------|-----------------------------------------------|------------------------------------------|
-| Data source adapter        | `Lotus.Source.Adapter`                        | `Lotus.Source.Adapters.{Postgres,MySQL,SQLite3,Ecto}` |
-| Source resolver            | `Lotus.Source.Resolver`                       | `Lotus.Source.Resolvers.Static`          |
-| Visibility resolver        | `Lotus.Visibility.Resolver`                   | `Lotus.Visibility.Resolvers.Static`      |
-| Cache adapter              | `Lotus.Cache.Adapter`                         | `Lotus.Cache.ETS` (or `Lotus.Cache.Cachex`) |
+| Extension point            | Behaviour                                     | Config key              | Default                                  |
+|----------------------------|-----------------------------------------------|-------------------------|------------------------------------------|
+| Data source adapter        | `Lotus.Source.Adapter`                        | `:source_adapters`      | `Lotus.Source.Adapters.{Postgres,MySQL,SQLite3,Ecto}` |
+| SQL dialect (Ecto only)    | `Lotus.Source.Adapters.Ecto.Dialect`          | —                       | `Lotus.Source.Adapters.Ecto.Dialects.*`  |
+| Source resolver            | `Lotus.Source.Resolver`                       | `:source_resolver`      | `Lotus.Source.Resolvers.Static`          |
+| Visibility resolver        | `Lotus.Visibility.Resolver`                   | `:visibility_resolver`  | `Lotus.Visibility.Resolvers.Static`      |
+| Cache adapter              | `Lotus.Cache.Adapter`                         | `cache: %{adapter: _}`  | `Lotus.Cache.ETS` (or `Lotus.Cache.Cachex`) |
+| Cache key builder          | `Lotus.Cache.KeyBuilder`                      | `cache: %{key_builder: _}` | `Lotus.Cache.KeyBuilder.Default`      |
 
 Design notes for adapter authors:
 
 - **Source adapters** carry state in the `%Adapter{}` struct itself (e.g. an Ecto repo module) so the runner never closes over the raw connection. Every introspection callback returns `{:ok, _} | {:error, _}`.
-- **Source resolvers** let you replace the static `data_sources` list with a dynamic registry (database-backed tenants, feature-flagged sources, etc.).
+- **A SQL engine on Ecto** should implement a `Dialect` and `use Lotus.Source.Adapters.Ecto, dialect: MyDialect` rather than implementing the universal behaviour from scratch.
+- **A non-SQL engine** implements `Lotus.Source.Adapter` directly and carries its native payload (JSON map, DSL AST) in `statement.body`. Do not serialize it to a string to satisfy an old SQL-shaped signature.
+- **Source resolvers** let you replace the static `data_sources` map with a dynamic registry (database-backed tenants, feature-flagged sources, etc.).
 - **Visibility resolvers** let you compute schema/table/column policies from external sources instead of config — useful when rules live in a multi-tenant database.
-- **Cache adapters** must implement `get_or_store/4`, `put/4`, and `invalidate_tags/1`. ETS is the zero-dependency option; Cachex is recommended when you need distributed caching or richer stats.
+- **Cache adapters** implement `Lotus.Cache.Adapter`. ETS is the zero-dependency option; Cachex is recommended when you need richer stats.
+
+See the [source adapters guide](source-adapters.md) for the full callback walkthrough.
 
 ### Design Principles
 
 A few opinions run through the codebase; preserving them when you contribute will make review much easier.
 
-1. **Read-only by default, with defense in depth.** Destructive statements are blocked by (a) a regex deny list, (b) preflight authorization using `EXPLAIN`, and (c) a database-level read-only transaction. Each layer exists because the previous one can be bypassed in some edge case. Opting out (`read_only: false`) is a deliberate, explicit flag.
-2. **Pluggable, not hardcoded.** Sources, resolvers, caches, and visibility all go through behaviours. Avoid pattern-matching on concrete modules inside the query pipeline — dispatch through the adapter.
-3. **Visibility is two-level plus column-aware.** Schema visibility is checked before table visibility, and column policies (omit/mask/error) run inside the runner after the result comes back. Any new introspection path must respect all three.
-4. **Session state is scoped and explicit.** Per-request state like statement timeouts and search paths is set by the source adapter at the start of a transaction; there is no hidden global state. `Lotus.Preflight.Relations` is the one place we use the process dictionary, and it's scrubbed per call.
-5. **Type-aware caching.** Query results and schema metadata are cached separately. Result caches are keyed on `sql + params + adapter + search_path` and tagged for targeted invalidation. Column metadata lives in `Lotus.Storage.SchemaCache` so value casting doesn't require re-introspection.
-6. **Observability is first-class.** Every meaningful operation emits `[:lotus, ...]` telemetry events. New features should do the same (look at `Lotus.Telemetry` for helpers).
-7. **Middleware is the extension seam for cross-cutting concerns.** Auditing, access control, and per-tenant overrides belong in middleware plugs — not in the runner itself.
+1. **Read-only by default, with defense in depth.** Destructive statements are blocked by (a) the adapter's sanitizer and deny list, (b) preflight authorization, and (c) a database-level read-only transaction. Each layer exists because the previous one can be bypassed in some edge case. Opting out (`read_only: false`) is a deliberate, explicit flag.
+2. **Pluggable, not hardcoded.** Sources, dialects, resolvers, caches, and visibility all go through behaviours. Avoid pattern-matching on concrete modules inside the query pipeline — dispatch through the adapter.
+3. **Nothing in the pipeline assumes SQL.** The pipeline carries a `%Lotus.Query.Statement{}` whose `:body` is an adapter-opaque term. New core code must not inspect, parse or concatenate it.
+4. **No silent degradation.** If an adapter cannot express a filter operator, enforce visibility, or produce a row total, it says so and Lotus surfaces an error or an honest `nil` — it never quietly returns a different answer than was asked for.
+5. **Visibility is schema, table, and column.** Schema visibility is checked before table visibility, and column policies (omit/mask/error) run inside the runner after the result comes back. Any new introspection path must respect all three.
+6. **Session state is scoped and explicit.** Per-request state like statement timeouts and search paths is set by the adapter at the start of a transaction; there is no hidden global state. `Lotus.Preflight.Relations` is the one place we use the process dictionary, and it's scrubbed per call.
+7. **Type-aware caching.** Query results and schema metadata are cached separately, with keys from a swappable `KeyBuilder` and tags for targeted invalidation. Column metadata lives in `Lotus.Storage.SchemaCache` so value casting doesn't require re-introspection.
+8. **Observability is first-class.** Every meaningful operation emits `[:lotus, ...]` telemetry events. New features should do the same (look at `Lotus.Telemetry` for helpers).
+9. **Middleware is the extension seam for cross-cutting concerns.** Auditing, access control, and per-tenant overrides belong in middleware plugs — not in the runner itself.
 
 ### Where to Look Next
 
 - New to the pipeline? Start in [`Lotus`](../lib/lotus.ex) (`run_query/2`) and follow the calls into [`Lotus.Runner`](../lib/lotus/runner.ex).
-- Working on a new database? See the [Source Adapters guide](source-adapters.md) and mimic [`Lotus.Source.Adapters.Ecto.Dialects.Postgres`](../lib/lotus/source/adapters/ecto/dialects/postgres.ex).
+- Working on a new SQL database? See the [source adapters guide](source-adapters.md) and mimic [`Lotus.Source.Adapters.Ecto.Dialects.Postgres`](../lib/lotus/source/adapters/ecto/dialects/postgres.ex).
+- Working on a non-SQL engine? Read [`Lotus.Source.Adapter`](../lib/lotus/source/adapter.ex) end to end, then look at the in-memory test adapter in `test/support/in_memory_adapter.ex` and its end-to-end test in `test/integration/non_sql/`.
 - Working on caching? [`Lotus.Cache`](../lib/lotus/cache.ex) and [`Lotus.Cache.ETS`](../lib/lotus/cache/ets.ex) are the smallest self-contained example.
 - Working on visibility or auditing? Start in [`Lotus.Visibility`](../lib/lotus/visibility.ex) and [`Lotus.Middleware`](../lib/lotus/middleware.ex).
 - Working on AI features? Begin with [`Lotus.AI`](../lib/lotus/ai.ex) and follow the calls into `lib/lotus/ai/`.
 
 ## Development Workflow
 
+### Branches and Commits
+
+Lotus uses [Conventional Commits](https://www.conventionalcommits.org/) for
+commit messages and PR titles, and a matching branch convention.
+
+**Branch names** — `<type>/<short-desc>`:
+
+```bash
+git checkout -b fix/preload-dashboards
+git checkout -b feat/clickhouse-dialect
+```
+
+**Commit messages and PR titles** — `<type>(<scope>): <description>`:
+
+```
+feat(dashboards): add preload option to list_dashboard_cards
+fix(preflight): honour needs_preflight? for SHOW statements
+docs(contributing): document the docker compose ports
+```
+
+- Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`
+- Scope is optional
+- Description: imperative, lowercase, no trailing period
+
 ### Making Changes
 
-1. **Create a feature branch**
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+1. **Create a branch** following the convention above.
 
 2. **Make your changes**
    - Follow the existing code style
    - Add tests for new functionality
-   - Update documentation as needed
+   - Update the relevant guide under `guides/`
 
 3. **Test your changes**
    ```bash
    # Run all tests
    mix test
 
-   # Run specific test files
+   # Run a specific test file
    mix test test/lotus/storage_test.exs
 
    # Run with coverage
    mix test --cover
    ```
 
-4. **Ensure code quality**
+4. **Run the checks CI runs**
    ```bash
-   # Format code
-   mix format
-
-   # Run static analysis
+   mix format --check-formatted
+   mix compile --warnings-as-errors
+   mix credo --strict
    mix dialyzer
-
-   # Run linting (if available)
-   mix lint
    ```
 
-5. **Commit your changes**
-   ```bash
-   git add .
-   git commit -m "Add feature: your feature description"
-   ```
+   `mix lint` is a shortcut for `mix format` followed by `mix dialyzer`.
 
-6. **Push and create a pull request**
-   ```bash
-   git push origin feature/your-feature-name
-   ```
+5. **Commit and push, then open a pull request.**
+
+### Continuous Integration
+
+`.github/workflows/ci.yml` runs on every pull request and on pushes to `main`.
+It builds a matrix of:
+
+| Elixir | Erlang/OTP | PostgreSQL |
+|--------|------------|------------|
+| 1.18 | 27.3.2 | 15.8-alpine |
+| 1.19 | 27.3.2 | 15.8-alpine |
+| 1.20 | 29.0.2 | 15.8-alpine |
+
+MySQL 8.0 runs as a service in every matrix entry. Each job runs, in order:
+`mix deps.get`, `mix format --check-formatted`, `mix deps.compile`,
+`mix compile --warnings-as-errors`, `mix credo --strict`, `mix test.setup`,
+`mix test`, and `mix dialyzer`. A warning is a failure, so compile cleanly
+before you push.
 
 ### Code Style Guidelines
 
 #### Elixir Style
 
 - Use `mix format` to ensure consistent formatting
-- Keep lines under 100 characters when possible
+- `mix credo --strict` must pass
 - Use descriptive variable and function names
 
 #### Documentation
 
 - All public functions must have `@doc` strings
-- Use `@spec` for type specifications
+- Use `@spec` for type specifications — Dialyzer runs in CI with `:underspecs` enabled
 - Include examples in documentation when helpful
 
 ```elixir
@@ -354,6 +438,10 @@ end
 ```
 
 #### Testing
+
+Tests use ExUnit with [Mimic](https://hex.pm/packages/mimic) for mocking.
+Shared cases live in `test/support/`: `Lotus.Case`, `Lotus.CacheCase`, and
+`Lotus.AICase`, plus fixtures and an in-memory non-SQL adapter.
 
 - Write tests for all new functionality
 - Use descriptive test names
@@ -384,7 +472,7 @@ end
 
 When reporting bugs, please include:
 
-- **Environment**: Elixir version, OTP version, database type and version
+- **Environment**: Elixir version, OTP version, Lotus version, data source type and version
 - **Steps to reproduce**: Clear, step-by-step instructions
 - **Expected behavior**: What you expected to happen
 - **Actual behavior**: What actually happened
@@ -399,6 +487,9 @@ For new features, please include:
 - **Proposed solution**: How would you like it to work?
 - **Alternatives considered**: What other approaches did you consider?
 - **Examples**: Show how the feature would be used
+
+Frame the problem first. A well-described problem gets a better solution than a
+prescribed implementation.
 
 ### Code Contributions
 
@@ -415,16 +506,16 @@ We welcome contributions of all sizes! Here are some areas where help is especia
 
 - New configuration options
 - Performance optimizations
-- Additional query validation features
+- Additional statement validation features
 - Enhanced error messages
 
 #### Advanced Features
 
-- Additional cache backends (Redis, Memcached, distributed caching)
-- Cache statistics and telemetry integration (`Lotus.Cache.stats()`)
+- New source adapters, in-tree or as a companion package
+- Additional cache backends (Redis, distributed caching)
+- Cache statistics and richer telemetry
 - Query performance monitoring and metrics
-- Advanced security features
-- Table visibility rule enhancements
+- Visibility rule enhancements
 
 ## Pull Request Process
 
@@ -432,9 +523,9 @@ We welcome contributions of all sizes! Here are some areas where help is especia
 
 1. **Check existing issues**: Make sure your change isn't already being worked on
 2. **Discuss large changes**: Open an issue to discuss major features or breaking changes
-3. **Update documentation**: Include relevant documentation updates
+3. **Update documentation**: Include relevant guide updates
 4. **Add tests**: Ensure your changes are well-tested
-5. **Follow conventions**: Match the existing code style and patterns
+5. **Follow conventions**: Conventional Commits, and match the existing code style
 
 ### Pull Request Template
 
@@ -465,7 +556,7 @@ Brief description of the changes
 
 ### Review Process
 
-1. **Automated checks**: CI will run tests and style checks
+1. **Automated checks**: CI will run tests, formatting, Credo, and Dialyzer
 2. **Code review**: Maintainers will review your changes
 3. **Feedback**: Address any requested changes
 4. **Approval**: Once approved, changes will be merged
@@ -474,78 +565,72 @@ Brief description of the changes
 
 ### Database Changes
 
+Lotus migrations are versioned per database under `lib/lotus/migrations/`. The
+PostgreSQL chain is currently at V5 (`lib/lotus/migrations/postgres/v1.ex`
+through `v5.ex`); MySQL and SQLite have their own modules.
+
 When making changes that affect the database:
 
-1. **Create migrations**: Use `Lotus.Migrations` for schema changes
-2. **Test migrations**: Ensure migrations work both up and down on PostgreSQL and SQLite
-3. **Update version**: Bump the migration version appropriately
-4. **Test multi-database**: Verify changes work with both PostgreSQL and SQLite adapters
+1. **Add a new version module** rather than editing an existing one — installs in the wild have already run the old ones.
+2. **Test migrations both ways**: ensure `up` and `down` work on PostgreSQL, MySQL, and SQLite.
+3. **Note manual steps**: MySQL and SQLite users have historically needed manual DDL for some changes (see the v1.0.0 `CHANGELOG.md` entry). Say so explicitly in the changelog.
+4. **Test multi-database**: verify changes work across all three built-in adapters.
 
 ### Testing Multi-Database Features
 
-When working on features that affect multiple database types:
+Integration tests carry `@moduletag :postgres`, `:mysql`, or `:sqlite`:
 
 ```bash
-# Test against PostgreSQL
-mix test --exclude sqlite
-
-# Test against SQLite  
+# Only the SQLite-tagged integration tests
 mix test --only sqlite
 
-# Test table visibility across adapters
-mix test test/lotus/visibility_test.exs
+# Everything except the MySQL-tagged tests (useful without a MySQL container)
+mix test --exclude mysql
 
-# Test data source functionality
+# A whole area
+mix test test/lotus/visibility_test.exs
 mix test test/lotus/data_source_test.exs
+mix test test/integration/non_sql
 ```
+
+Unit tests are untagged and always run. `test/test_helper.exs` recreates all
+three databases and runs their support migrations before the suite starts, so
+the containers must be up.
 
 ### Caching Features
 
 When working on caching-related features:
 
 ```bash
-# Test cache functionality
 mix test test/lotus/cache_test.exs
-
-# Test cache integration
+mix test test/lotus/cache_telemetry_test.exs
 mix test test/integration/caching_test.exs
-
-# Test ETS adapter specifically
-mix test test/lotus/cache/ets_test.exs
+mix test test/lotus/cache
 ```
 
-**Contributing New Cache Backends:**
+**Contributing a new cache backend:**
 
-To implement a new cache backend (Redis, Memcached, etc.):
-
-1. **Implement the behaviour**: Create a module that implements `Lotus.Cache`
-2. **Required callbacks**: `get_or_store/4`, `put/4`, `invalidate_tags/1`
-3. **Add tests**: Create comprehensive tests following the ETS adapter pattern
-4. **Add to documentation**: Update configuration guides and examples
-5. **Consider dependencies**: Keep external dependencies optional when possible
-
-**Cache Telemetry and Statistics:**
-
-The caching system would benefit from:
-- Cache hit/miss ratios
-- Memory usage tracking
-- TTL effectiveness metrics
-- Tag invalidation statistics
+1. **Implement the behaviour**: create a module with `@behaviour Lotus.Cache.Adapter`
+2. **Required callbacks**: `get/1`, `put/4`, `delete/1`, `get_or_store/4`, `invalidate_tags/1`, `touch/2`, `spec_config/0`
+3. **Add tests**: follow the ETS adapter's test module
+4. **Document it**: update the [caching guide](caching.md)
+5. **Keep dependencies optional**: mark the driver `optional: true` in `mix.exs`
 
 ### API Changes
 
-For changes to the public API:
+v1.0 removed the entire pre-v1 compatibility layer, and the project intends to
+keep the v1 surface stable. For changes to the public API:
 
-1. **Backward compatibility**: Avoid breaking existing functionality
-2. **Deprecation process**: Deprecate before removing functionality
-3. **Documentation**: Update all relevant documentation
-4. **Examples**: Update examples in guides
+1. **Prefer additive changes**: new optional callbacks with defaults, new options with defaults
+2. **Breaking changes need a major version** and an entry in the upgrade guide
+3. **Document thoroughly**: update `CHANGELOG.md` and every affected guide
+4. **Examples**: update examples in the guides so every code block still runs
 
 ### Performance Considerations
 
-- **Benchmark changes**: Use `:timer.tc/1` or benchmarking tools for performance-critical changes
-- **Memory usage**: Be mindful of memory allocation in hot paths
-- **Database queries**: Optimize query patterns and avoid N+1 queries
+- **Benchmark changes**: use `:timer.tc/1` or benchmarking tools for performance-critical changes
+- **Memory usage**: be mindful of memory allocation in hot paths
+- **Database queries**: optimize query patterns and avoid N+1 queries (`Lotus.Dashboards.run_dashboard/2` preloads all card mappings in one go for exactly this reason)
 
 ## Release Process
 
@@ -553,9 +638,9 @@ For changes to the public API:
 
 Lotus follows [Semantic Versioning](https://semver.org/):
 
-- **Major (1.0.0)**: Breaking changes
-- **Minor (0.2.0)**: New features, backward compatible
-- **Patch (0.0.1)**: Bug fixes, backward compatible
+- **Major (2.0.0)**: Breaking changes
+- **Minor (1.1.0)**: New features, backward compatible
+- **Patch (1.0.1)**: Bug fixes, backward compatible
 
 ### Changelog
 
@@ -589,18 +674,16 @@ We are committed to providing a welcoming and inspiring community for all. Pleas
 
 If you need help:
 
-1. **Check the documentation**: Start with the guides and API documentation
-2. **Search existing issues**: Your question might already be answered
-3. **Ask in discussions**: Use GitHub Discussions for general questions
-4. **Open an issue**: For specific bugs or feature requests
+1. **Check the documentation**: start with the guides and the API documentation on [HexDocs](https://hexdocs.pm/lotus)
+2. **Search existing issues**: your question might already be answered
+3. **Ask in discussions**: use GitHub Discussions for general questions
+4. **Open an issue**: for specific bugs or feature requests
 
 ## Recognition
 
-Contributors are recognized in:
-
-- **CONTRIBUTORS.md**: List of all contributors
-- **Release notes**: Acknowledgment in release announcements
-- **Documentation**: Attribution for significant documentation contributions
+Contributors are recognized in release notes and in the GitHub contributors
+list, and significant documentation contributions are attributed in the guides
+themselves.
 
 ## License
 

--- a/guides/custom-resolvers.md
+++ b/guides/custom-resolvers.md
@@ -2,14 +2,14 @@
 
 Lotus exposes two supported extension points that let you replace how sources and visibility rules are loaded at runtime:
 
-- `Lotus.Source.Resolver` — turns repo names (or modules) into `%Lotus.Source.Adapter{}` structs.
+- `Lotus.Source.Resolver` — turns source names (or modules) into `%Lotus.Source.Adapter{}` structs.
 - `Lotus.Visibility.Resolver` — loads schema, table, and column visibility rules for a given source.
 
 Both are small, stable behaviours. Lotus ships with default static implementations (`Lotus.Source.Resolvers.Static` and `Lotus.Visibility.Resolvers.Static`) that read from application configuration — which is all most applications need. When you need runtime dynamism, custom resolvers let you source this data from anywhere without forking Lotus.
 
 ## When to Use a Custom Resolver
 
-The default static resolvers load configuration at compile time and cache it in `:persistent_term`. That's ideal for applications whose sources and rules never change after boot. Consider a custom resolver when any of the following apply:
+The default static resolvers read application configuration, which `Lotus.Config` validates once and caches in `:persistent_term`. That's ideal for applications whose sources and rules never change after boot. Consider a custom resolver when any of the following apply:
 
 ### Custom `Source.Resolver`
 
@@ -49,13 +49,13 @@ When omitted, the defaults read from `:data_sources`, `:schema_visibility`, `:ta
 
 ## The `Source.Resolver` Behaviour
 
-A source resolver turns query options (`repo_opt`, `fallback`) into `%Lotus.Source.Adapter{}` structs. It also enumerates available sources for schema discovery and admin tooling.
+A source resolver turns query options (`source_opt`, `fallback`) into `%Lotus.Source.Adapter{}` structs. It also enumerates available sources for schema discovery and admin tooling.
 
 ### Callbacks
 
 ```elixir
 @callback resolve(
-            repo_opt :: nil | String.t() | module(),
+            source_opt :: nil | String.t() | module(),
             fallback :: nil | String.t() | module()
           ) :: {:ok, Lotus.Source.Adapter.t()} | {:error, term()}
 
@@ -70,24 +70,37 @@ A source resolver turns query options (`repo_opt`, `fallback`) into `%Lotus.Sour
 
 | Callback | Returns | Used By |
 |---|---|---|
-| `resolve/2` | `{:ok, %Adapter{}}` or `{:error, term()}` | Query execution (`Lotus.run_statement/3`, `Lotus.run_query/2`) |
+| `resolve/2` | `{:ok, %Adapter{}}` or `{:error, :not_found}` | Query execution (`Lotus.run_statement/3`, `Lotus.run_query/2`) |
 | `list_sources/0` | `[%Adapter{}]` | Schema discovery, admin UIs |
 | `get_source!/1` | `%Adapter{}` (raises on missing) | Ad-hoc lookups |
 | `list_source_names/0` | `[String.t()]` | Error messages, admin UIs |
 | `default_source/0` | `{name, %Adapter{}}` | Fallback when no repo is specified |
 
+> ### Return `{:error, :not_found}` on failure {: .warning}
+>
+> `Lotus.Source.resolve!/2` matches exactly two shapes: `{:ok, %Adapter{}}` and `{:error, :not_found}` — the latter becomes an `ArgumentError` naming the configured sources (from your `list_source_names/0`). Any other error tuple raises a `CaseClauseError` instead of that message.
+
 ### Resolution Priority
 
 The default resolver (`Lotus.Source.Resolvers.Static`) follows this priority inside `resolve/2`:
 
-1. `repo_opt` as string name — lookup in `data_sources`, wrap in adapter
-2. `repo_opt` as module — reverse lookup (find name for module), wrap in adapter
+1. `source_opt` as string name — lookup in `data_sources`, wrap in adapter
+2. `source_opt` as module — reverse lookup (find name for module), wrap in adapter
 3. `fallback` as string name — lookup
 4. `fallback` as module — reverse lookup
 5. Both `nil` — use the configured `default_source`
-6. Not found — `{:error, :not_found}`
+6. Otherwise — `{:error, :not_found}`
 
-Custom implementations are free to adopt a different priority but should accept the same arguments so the public API (`Lotus.run_statement/3`, `Lotus.run_query/2`, etc.) continues to work without changes.
+Note step 6: when either position named something that could not be resolved, the static resolver refuses rather than falling back to the default source. A typo in a saved query's `data_source` would otherwise quietly return rows from a different database. Custom implementations are free to adopt a different priority, but should keep that property and accept the same arguments so the public API (`Lotus.run_statement/3`, `Lotus.run_query/2`, etc.) continues to work without changes.
+
+### Building the `%Adapter{}`
+
+Whatever your resolver's lookup strategy, the struct it returns is built by an adapter module's `wrap/2`:
+
+- `Lotus.Source.Adapters.Ecto.wrap/2` for an `Ecto.Repo` module — it picks the right per-dialect adapter (`Adapters.Postgres`, `MySQL`, `SQLite3`) from the repo's Ecto adapter.
+- Your own adapter's `wrap/2` for a non-Ecto source, e.g. `MyApp.Adapters.Elasticsearch.wrap("search", %{url: "http://localhost:9200"})`.
+
+See the [Source Adapters guide](source-adapters.md) for the adapter contract itself.
 
 ### Example: Agent-backed `Source.Resolver`
 
@@ -131,13 +144,14 @@ defmodule MyApp.AgentSourceResolver do
   # ---------------------------------------------------------------------------
 
   @impl true
-  def resolve(repo_opt, fallback) do
+  def resolve(source_opt, fallback) do
     cond do
-      is_binary(repo_opt) -> lookup_by_name(repo_opt)
-      repo_module?(repo_opt) -> lookup_by_module(repo_opt)
+      is_binary(source_opt) -> lookup_by_name(source_opt)
+      repo_module?(source_opt) -> lookup_by_module(source_opt)
       is_binary(fallback) -> lookup_by_name(fallback)
       repo_module?(fallback) -> lookup_by_module(fallback)
-      true -> default_or_error()
+      is_nil(source_opt) and is_nil(fallback) -> default_or_error()
+      true -> {:error, :not_found}
     end
   end
 

--- a/guides/dashboards.md
+++ b/guides/dashboards.md
@@ -10,6 +10,10 @@ A dashboard consists of:
 - **Filters** - Input controls that affect multiple cards simultaneously
 - **Filter mappings** - Connections between filters and query variables
 
+Every function in this guide is available both on the `Lotus` facade (used
+throughout the examples) and on `Lotus.Dashboards`, which is where the full
+documentation lives.
+
 ## Creating a Dashboard
 
 ```elixir
@@ -19,9 +23,12 @@ A dashboard consists of:
 })
 ```
 
+Dashboard names are unique across the install.
+
 ### Dashboard Settings
 
-The `settings` field stores UI preferences as a map:
+The `settings` field stores UI preferences as a map. Keys are normalized to
+strings on write, so `%{theme: "dark"}` is stored as `%{"theme" => "dark"}`:
 
 ```elixir
 Lotus.update_dashboard(dashboard, %{
@@ -34,11 +41,40 @@ Lotus.update_dashboard(dashboard, %{
 
 ### Auto-refresh
 
-Enable periodic refresh by setting `auto_refresh_seconds` (minimum 60):
+Enable periodic refresh by setting `auto_refresh_seconds`. The value must be
+between 60 and 3600 seconds; anything else fails the changeset.
 
 ```elixir
 Lotus.update_dashboard(dashboard, %{auto_refresh_seconds: 300})  # 5 minutes
 ```
+
+### Listing Dashboards
+
+```elixir
+# All dashboards, ordered by name
+Lotus.list_dashboards()
+
+# Preload associations (`:cards`, `:filters`)
+Lotus.list_dashboards(preload: [:cards])
+
+# Case-insensitive search on the dashboard name
+Lotus.list_dashboards_by(search: "sales")
+Lotus.list_dashboards_by(search: "sales", preload: [:cards, :filters])
+```
+
+`list_dashboards_by/1` accepts `:search` and `:preload`. Both
+`list_dashboards/1` and `list_dashboards_by/1` order by name.
+
+### Fetching and Deleting
+
+```elixir
+Lotus.get_dashboard(id)   # => %Dashboard{} | nil
+Lotus.get_dashboard!(id)  # raises Ecto.NoResultsError
+
+{:ok, _} = Lotus.delete_dashboard(dashboard)
+```
+
+Deleting a dashboard cascades to its cards, filters, and filter mappings.
 
 ## Working with Cards
 
@@ -46,12 +82,12 @@ Cards are the building blocks of dashboards. Each card occupies a position in a 
 
 ### Card Types
 
-| Type | Description |
-|------|-------------|
-| `:query` | Displays results from a saved query |
-| `:text` | Markdown text content |
-| `:heading` | Section header |
-| `:link` | Clickable link to external resource |
+| Type | Description | `query_id` |
+|------|-------------|------------|
+| `:query` | Displays results from a saved query | required |
+| `:text` | Markdown text content | must be `nil` |
+| `:heading` | Section header | must be `nil` |
+| `:link` | Clickable link to external resource | must be `nil` |
 
 ### Adding a Query Card
 
@@ -59,7 +95,7 @@ Cards are the building blocks of dashboards. Each card occupies a position in a 
 # First, get or create a query
 {:ok, query} = Lotus.create_query(%{
   name: "Monthly Revenue",
-  statement: "SELECT date_trunc('month', created_at) as month, SUM(amount) as revenue FROM orders GROUP BY 1"
+  statement: "SELECT date_trunc('month', created_at) AS month, SUM(amount) AS revenue FROM orders GROUP BY 1"
 })
 
 # Add it to the dashboard
@@ -72,14 +108,21 @@ Cards are the building blocks of dashboards. Each card occupies a position in a 
 })
 ```
 
+`create_dashboard_card/2` accepts a `%Dashboard{}` or a dashboard id.
+
 ### Layout System
 
-Cards use a 12-column grid with these layout properties:
+Cards use a 12-column grid. `layout` is an embedded schema with these fields:
 
-- `x` - Column position (0-11)
-- `y` - Row position (0+)
-- `w` - Width in columns (1-12)
-- `h` - Height in rows (minimum 2)
+| Field | Meaning | Constraint | Default |
+|-------|---------|------------|---------|
+| `x` | Column position | `0..11` | `0` |
+| `y` | Row position | `>= 0` | `0` |
+| `w` | Width in columns | `1..12` | `6` |
+| `h` | Height in rows | `>= 1` | `4` |
+
+`x + w` must not exceed 12 — a card that extends beyond the grid is rejected
+with a changeset error on `:w`.
 
 ```elixir
 # Full-width card at top
@@ -90,7 +133,10 @@ Cards use a 12-column grid with these layout properties:
 %{x: 6, y: 3, w: 6, h: 4}  # Right
 ```
 
-### Text and Heading Cards
+### Text, Heading, and Link Cards
+
+Non-query cards store their payload in the `content` map (keys are normalized
+to strings) and must leave `query_id` unset.
 
 ```elixir
 # Add a section heading
@@ -110,6 +156,38 @@ Cards use a 12-column grid with these layout properties:
 })
 ```
 
+### Listing and Fetching Cards
+
+```elixir
+# Ordered by position, then id
+Lotus.list_dashboard_cards(dashboard)
+Lotus.list_dashboard_cards(dashboard, preload: [:query, :filter_mappings])
+
+Lotus.get_dashboard_card(card_id)                      # => %DashboardCard{} | nil
+Lotus.get_dashboard_card(card_id, preload: [:query])
+Lotus.get_dashboard_card!(card_id, preload: [:query])  # raises Ecto.NoResultsError
+```
+
+### Reordering Cards
+
+Pass card ids in the order you want; each card's `position` becomes its index
+in the list. The whole reorder runs in one transaction.
+
+```elixir
+:ok = Lotus.reorder_dashboard_cards(dashboard, [card3.id, card1.id, card2.id])
+```
+
+### Updating and Deleting Cards
+
+```elixir
+{:ok, card} = Lotus.update_dashboard_card(card, %{title: "Revenue Chart"})
+
+{:ok, _} = Lotus.delete_dashboard_card(card)
+{:error, :not_found} = Lotus.delete_dashboard_card(-1)
+```
+
+Deleting a card also deletes its filter mappings.
+
 ### Visualization Overrides
 
 Query cards can override the query's default visualization:
@@ -128,15 +206,21 @@ Lotus.update_dashboard_card(card, %{
 
 Filters provide input controls that affect multiple cards. When a user changes a filter value, it's passed to the mapped query variables.
 
-### Filter Types
+### Filter Types and Widgets
 
-| Type | Widget Options | Description |
-|------|----------------|-------------|
-| `:text` | `:input`, `:select` | Free-form text |
-| `:number` | `:input`, `:select` | Numeric values |
-| `:date` | `:date_picker`, `:input` | Single date |
-| `:date_range` | `:date_range_picker` | Start and end dates |
-| `:select` | `:select` | Dropdown selection |
+A filter declares both a `filter_type` and a `widget`. Incompatible pairs are
+rejected by the changeset:
+
+| `filter_type` | Allowed `widget` values |
+|---------------|-------------------------|
+| `:text` | `:input`, `:select` |
+| `:number` | `:input`, `:select` |
+| `:date` | `:date_picker`, `:input` |
+| `:date_range` | `:date_range_picker` |
+| `:select` | `:select` |
+
+A filter's `name` must be a valid identifier (`^[A-Za-z_][A-Za-z0-9_]*$`) and
+unique within its dashboard. `label` is required. `default_value` is a string.
 
 ### Creating Filters
 
@@ -146,7 +230,7 @@ Filters provide input controls that affect multiple cards. When a user changes a
   label: "Date Range",
   filter_type: :date_range,
   widget: :date_range_picker,
-  default_value: "last_30_days",
+  default_value: "2024-01-01,2024-01-31",
   position: 0
 })
 
@@ -166,9 +250,29 @@ Filters provide input controls that affect multiple cards. When a user changes a
 })
 ```
 
+The `config` map holds widget-specific settings (select options, formats,
+validation rules). Keys are normalized to strings.
+
+### Listing, Updating, and Deleting Filters
+
+```elixir
+# Ordered by position, then id
+Lotus.list_dashboard_filters(dashboard)
+
+Lotus.get_dashboard_filter(id)   # => %DashboardFilter{} | nil
+Lotus.get_dashboard_filter!(id)  # raises Ecto.NoResultsError
+
+{:ok, filter} = Lotus.update_dashboard_filter(filter, %{label: "Period"})
+
+{:ok, _} = Lotus.delete_dashboard_filter(filter)
+{:error, :not_found} = Lotus.delete_dashboard_filter(-1)
+```
+
 ### Mapping Filters to Query Variables
 
-Connect filters to query variables using filter mappings:
+Connect filters to query variables using filter mappings. The variable name
+must be a valid identifier, and each `(card, filter, variable_name)` triple is
+unique.
 
 ```elixir
 # Map date_range filter to the "start_date" variable in a card's query
@@ -186,9 +290,28 @@ Lotus.create_filter_mapping(orders_card, date_filter, "order_date")
 Lotus.create_filter_mapping(revenue_card, date_filter, "transaction_date")
 ```
 
+Inspect and remove mappings:
+
+```elixir
+# Mappings for a card, with `:filter` preloaded
+Lotus.list_card_filter_mappings(card)
+
+{:ok, _} = Lotus.delete_filter_mapping(mapping)
+{:error, :not_found} = Lotus.delete_filter_mapping(-1)
+```
+
 ### Transform Configuration
 
-For complex mappings (like splitting a date range), use the `transform` option:
+A mapping can carry an optional `transform` map that reshapes the filter value
+before it reaches the query variable. Lotus ships two transforms, both for
+splitting a **comma-separated** date range:
+
+| `"type"` | Effect |
+|----------|--------|
+| `"date_range_start"` | Takes the part before the comma |
+| `"date_range_end"` | Takes the part after the comma; a value with no comma passes through unchanged |
+
+Any other transform map is a no-op — the raw value is passed through.
 
 ```elixir
 Lotus.create_filter_mapping(card, date_filter, "start_date",
@@ -200,23 +323,35 @@ Lotus.create_filter_mapping(card, date_filter, "end_date",
 )
 ```
 
+With the filter value `"2024-01-01,2024-03-31"`, the card's query receives
+`start_date` = `"2024-01-01"` and `end_date` = `"2024-03-31"`.
+
 ## Running Dashboards
 
-Execute all cards in a dashboard with a single call:
+Execute all query cards in a dashboard with a single call. `run_dashboard/2`
+returns a **plain map** of card id to result — it is not wrapped in an `:ok`
+tuple, because individual cards succeed or fail independently:
 
 ```elixir
-{:ok, results} = Lotus.run_dashboard(dashboard)
-# => %{card_id => {:ok, %Lotus.Result{}} | {:error, reason}}
+results = Lotus.run_dashboard(dashboard)
+# => %{
+#      1 => {:ok, %Lotus.Result{}},
+#      2 => {:error, "Missing required variable: status"}
+#    }
 ```
+
+Non-query cards (`:text`, `:heading`, `:link`) are skipped and do not appear in
+the map.
 
 ### With Filter Values
 
-Pass current filter values to override defaults:
+Pass current filter values to override the filters' `default_value`. Keys are
+filter **names**:
 
 ```elixir
-{:ok, results} = Lotus.run_dashboard(dashboard,
+results = Lotus.run_dashboard(dashboard,
   filter_values: %{
-    "date_range" => "2024-01-01/2024-03-31",
+    "date_range" => "2024-01-01,2024-03-31",
     "region" => "us"
   }
 )
@@ -226,35 +361,49 @@ Pass current filter values to override defaults:
 
 | Option | Description |
 |--------|-------------|
-| `:filter_values` | Map of filter name to value |
-| `:timeout` | Per-card timeout in milliseconds (default: 30000) |
-| `:parallel` | Run cards in parallel (default: true) |
+| `:filter_values` | Map of filter name to value (default: `%{}`) |
+| `:parallel` | Run cards concurrently (default: `true`) |
+| `:timeout` | Per-card timeout in milliseconds (default: `30_000`) |
+
+Any other option is forwarded to `Lotus.run_query/2`, so `:search_path`,
+`:cache`, and `:scope` work here too. A card that exceeds `:timeout` yields
+`{:error, :timeout}`; a card that raises yields `{:error, message}`.
 
 ### Running Individual Cards
 
-Execute a single card:
-
 ```elixir
-{:ok, result} = Lotus.run_dashboard_card(card,
-  filter_values: %{"region" => "eu"}
-)
+{:ok, result} = Lotus.run_dashboard_card(card, filter_values: %{"region" => "eu"})
+
+# A non-query card
+{:error, :not_a_query_card} = Lotus.run_dashboard_card(text_card)
+
+# An unknown card id
+{:error, :not_found} = Lotus.run_dashboard_card(-1)
 ```
+
+`run_dashboard_card/2` takes `:filter_values` plus any `Lotus.run_query/2`
+option.
 
 ## Public Sharing
 
-Share dashboards via secure public links.
+Share dashboards via secure public links. The token is 32 random bytes,
+URL-safe Base64 encoded.
 
 ### Enable Sharing
 
 ```elixir
 {:ok, dashboard} = Lotus.enable_public_sharing(dashboard)
-# dashboard.public_token => "abc123..."
+dashboard.public_token
+# => "k3F1...q8"
 ```
+
+Each call generates a fresh token, so calling it again on an already-shared
+dashboard rotates the link and invalidates the old one.
 
 ### Access by Token
 
 ```elixir
-case Lotus.get_dashboard_by_token("abc123...") do
+case Lotus.get_dashboard_by_token(token) do
   nil -> :not_found
   dashboard -> Lotus.run_dashboard(dashboard)
 end
@@ -264,32 +413,51 @@ end
 
 ```elixir
 {:ok, dashboard} = Lotus.disable_public_sharing(dashboard)
-# dashboard.public_token => nil
+dashboard.public_token
+# => nil
 ```
+
+Disabling clears the token, so any link already handed out stops working.
 
 ## Exporting Dashboards
 
-Export all card results to a ZIP file with one CSV per card:
+Export all query-card results to a ZIP archive with one CSV per card. This
+lives on `Lotus.Export`, not on the `Lotus` facade:
 
 ```elixir
-{:ok, zip_binary} = Lotus.export_dashboard(dashboard,
+{:ok, zip_binary} = Lotus.Export.export_dashboard(dashboard,
   filter_values: %{"region" => "us"}
 )
 
 File.write!("sales_report.zip", zip_binary)
 ```
 
-The ZIP contains files named `{position}_{card_title}.csv` for each query card.
+The archive contains:
+
+- `manifest.json` — dashboard metadata and per-card status
+- one `<slugified_card_title>.csv` per successful query card (`card_<id>.csv`
+  when the card has no title)
+- `<name>.csv.error.txt` for any card that failed, holding the error
+
+`export_dashboard/2` accepts `:filter_values` plus any `Lotus.run_query/2`
+option.
 
 ## Database Migration
 
-Dashboards require migration V3. Run the migration to add the necessary tables:
+Dashboard tables are created by migration V3, which is part of the standard
+Lotus migration chain:
 
 ```elixir
-Lotus.Migrations.up(MyApp.Repo)
+defmodule MyApp.Repo.Migrations.CreateLotusTables do
+  use Ecto.Migration
+
+  def up, do: Lotus.Migrations.up()
+  def down, do: Lotus.Migrations.down()
+end
 ```
 
 This creates:
+
 - `lotus_dashboards`
 - `lotus_dashboard_cards`
 - `lotus_dashboard_filters`
@@ -317,7 +485,7 @@ This creates:
 {:ok, revenue_query} = Lotus.create_query(%{
   name: "Daily Revenue",
   statement: """
-  SELECT date, SUM(amount) as revenue
+  SELECT date, SUM(amount) AS revenue
   FROM orders
   WHERE date BETWEEN {{start_date}} AND {{end_date}}
   GROUP BY date
@@ -327,7 +495,7 @@ This creates:
 {:ok, orders_query} = Lotus.create_query(%{
   name: "Order Count",
   statement: """
-  SELECT COUNT(*) as total
+  SELECT COUNT(*) AS total
   FROM orders
   WHERE created_at BETWEEN {{from}} AND {{to}}
   """
@@ -350,7 +518,7 @@ This creates:
   layout: %{x: 8, y: 0, w: 4, h: 4}
 })
 
-# Map filter to both cards (with different variable names)
+# Map the one filter to both cards (with different variable names)
 Lotus.create_filter_mapping(revenue_card, date_filter, "start_date",
   transform: %{"type" => "date_range_start"}
 )
@@ -365,8 +533,15 @@ Lotus.create_filter_mapping(orders_card, date_filter, "to",
   transform: %{"type" => "date_range_end"}
 )
 
-# Run the dashboard
-{:ok, results} = Lotus.run_dashboard(dashboard,
-  filter_values: %{"period" => "2024-01-01/2024-01-31"}
+# Run the dashboard — note the bare map return
+results = Lotus.run_dashboard(dashboard,
+  filter_values: %{"period" => "2024-01-01,2024-01-31"}
 )
+
+for {card_id, outcome} <- results do
+  case outcome do
+    {:ok, %Lotus.Result{rows: rows}} -> IO.puts("card #{card_id}: #{length(rows)} rows")
+    {:error, reason} -> IO.puts("card #{card_id} failed: #{inspect(reason)}")
+  end
+end
 ```

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -10,6 +10,12 @@ Before starting, make sure you have:
 - A running Elixir application with Ecto and Lotus configured
 - Some data in your database to query
 
+> **Coming from Lotus 0.x?** The API in this guide is v1.0 only. Config keys and
+> several function names changed, and there is no compatibility shim — read
+> [Upgrading to v1.0](upgrading-to-v1.md) first. In particular `Lotus.run_sql`
+> is now `Lotus.run_statement/3` and `Lotus.get_table_schema` is now
+> `Lotus.describe_table/3`.
+
 ## Your First Query
 
 ### Creating a Saved Query
@@ -20,20 +26,28 @@ Let's create and save a simple query:
 # Create a new query
 {:ok, query} = Lotus.create_query(%{
   name: "Count Users",
-  query: %{
-    sql: "SELECT COUNT(*) as user_count FROM users"
-  }
+  statement: "SELECT COUNT(*) AS user_count FROM users"
 })
 
 IO.inspect(query)
 # %Lotus.Storage.Query{
 #   id: 1,
 #   name: "Count Users",
-#   statement: "SELECT COUNT(*) as user_count FROM users",
-#   inserted_at: ~N[2024-01-15 10:30:00],
-#   updated_at: ~N[2024-01-15 10:30:00]
+#   description: nil,
+#   statement: "SELECT COUNT(*) AS user_count FROM users",
+#   variables: [],
+#   data_source: nil,
+#   search_path: nil,
+#   query_language: nil,
+#   inserted_at: ~U[2024-01-15 10:30:00.000000Z],
+#   updated_at: ~U[2024-01-15 10:30:00.000000Z]
 # }
 ```
+
+A query needs a `name` and a `statement`. Everything else is optional:
+`description`, `variables`, `data_source`, `search_path` and `query_language`.
+For Ecto-backed sources the statement is SQL text; for a non-Ecto adapter it is
+whatever that adapter accepts.
 
 ### Running the Query
 
@@ -68,11 +82,17 @@ result.rows
 result.num_rows
 # 1
 
-# The Result struct contains:
-# - columns: list of column names
-# - rows: list of result rows
-# - num_rows: total count of returned rows
+# The %Lotus.Result{} struct contains:
+# - columns:     list of column names
+# - rows:        list of result rows
+# - num_rows:    number of rows in the returned page
+# - duration_ms: execution time in milliseconds (nil if not measured)
+# - command:     the command the adapter reported (e.g. "select"), or nil
+# - meta:        adapter and pagination metadata (see Paging Through Results)
 ```
+
+`Lotus.Result.to_encodable/1` returns a JSON-safe map of the same fields, with
+row values normalized (UUIDs, dates, decimals and so on).
 
 ## Ad-hoc Queries
 
@@ -126,13 +146,14 @@ IO.inspect(source_names)
 You can store queries with a specific data source, so they automatically execute against the correct database:
 
 ```elixir
-# Create a query that will run against the analytics database
+# Create a query that will run against the analytics database.
+# Stored queries take no positional params — use {{variables}} instead.
 {:ok, analytics_query} = Lotus.create_query(%{
   name: "Daily Page Views",
-  query: %{
-    sql: "SELECT COUNT(*) FROM page_views WHERE date = $1",
-    params: [Date.utc_today()]
-  },
+  statement: "SELECT COUNT(*) FROM page_views WHERE date = {{on_date}}",
+  variables: [
+    %{name: "on_date", type: :date, label: "Date", default: Date.to_iso8601(Date.utc_today())}
+  ],
   data_source: "analytics"
 })
 
@@ -191,6 +212,36 @@ config :lotus,
 {:ok, result} = Lotus.run_query(query)
 ```
 
+### Recording the Query Language
+
+A saved query can record the language it was written for in `query_language`,
+as a `family:dialect` identifier — `"sql:postgres"`, `"json:elasticsearch"`.
+A bare family (`"sql"`) is also accepted.
+
+```elixir
+{:ok, query} = Lotus.create_query(%{
+  name: "Recent Signups",
+  statement: "SELECT id, email FROM users WHERE created_at > NOW() - INTERVAL '7 days'",
+  data_source: "postgres",
+  query_language: "sql:postgres"
+})
+```
+
+When the query runs, Lotus compares the recorded language with the language of
+the resolved data source. A mismatch stops execution instead of handing the
+statement to an engine that cannot parse it:
+
+```elixir
+{:error, reason} = Lotus.run_query(query, repo: "sqlite")
+IO.puts(reason)
+# Query was written for "sql:postgres" but data source "sqlite" speaks "sql:sqlite"
+```
+
+The comparison is exact, not family-level: `sql:postgres` and `sql:sqlite` share
+a family but are not interchangeable. `query_language` is optional — leave it
+`nil` and the query runs against whatever source it resolves to, with the
+language derived from that source's adapter.
+
 ## Managing Saved Queries
 
 ### Listing All Queries
@@ -222,9 +273,7 @@ IO.puts(query.name)
 # Update an existing query
 {:ok, updated_query} = Lotus.update_query(query, %{
   name: "Total User Count",
-  query: %{
-    sql: "SELECT COUNT(*) as total_users FROM users WHERE deleted_at IS NULL"
-  }
+  statement: "SELECT COUNT(*) AS total_users FROM users WHERE deleted_at IS NULL"
 })
 
 IO.puts(updated_query.name)
@@ -408,10 +457,7 @@ You can save a `search_path` with your queries to make them automatically resolv
 # Create a query that looks in reporting schema first, then public
 {:ok, query} = Lotus.create_query(%{
   name: "Customer Report",
-  query: %{
-    sql: "SELECT COUNT(*) FROM customers WHERE active = true",
-    params: []
-  },
+  statement: "SELECT COUNT(*) FROM customers WHERE active = true",
   search_path: "reporting, public",
   data_source: "postgres"
 })
@@ -466,24 +512,31 @@ Here are common patterns for using `search_path`:
 # Create queries that work across different schema contexts
 {:ok, report_query} = Lotus.create_query(%{
   name: "Monthly Revenue",
-  query: %{
-    sql: """
-    SELECT 
-      DATE_TRUNC('month', created_at) as month,
-      SUM(amount) as revenue
-    FROM orders 
-    WHERE created_at >= $1 
-    GROUP BY 1 
-    ORDER BY 1
-    """
-  },
+  statement: """
+  SELECT
+    DATE_TRUNC('month', created_at) AS month,
+    SUM(amount) AS revenue
+  FROM orders
+  WHERE created_at >= {{since}}
+  GROUP BY 1
+  ORDER BY 1
+  """,
+  variables: [
+    %{name: "since", type: :date, label: "Since", default: "2024-01-01"}
+  ],
   search_path: "reporting, public",
   data_source: "postgres"
 })
 
-# Use the same query structure for different contexts
-{:ok, prod_data} = Lotus.run_query(report_query, [~D[2024-01-01]])
-{:ok, staging_data} = Lotus.run_query(report_query, [~D[2024-01-01]], search_path: "staging, public")
+# Use the same query structure for different contexts.
+# run_query/2 takes options only — values go through `vars:`.
+{:ok, prod_data} = Lotus.run_query(report_query, vars: %{"since" => "2024-01-01"})
+
+{:ok, staging_data} =
+  Lotus.run_query(report_query,
+    vars: %{"since" => "2024-01-01"},
+    search_path: "staging, public"
+  )
 ```
 
 #### Mixed Schema Access
@@ -491,19 +544,17 @@ Here are common patterns for using `search_path`:
 ```elixir
 # Query that needs tables from multiple schemas in search order
 {:ok, complex_query} = Lotus.create_query(%{
-  name: "User Activity Summary", 
-  query: %{
-    sql: """
-    SELECT 
-      u.name,
-      COUNT(e.id) as event_count,
-      MAX(s.last_login) as last_seen
-    FROM users u
-    LEFT JOIN events e ON u.id = e.user_id  -- from analytics schema
-    LEFT JOIN sessions s ON u.id = s.user_id  -- from public schema
-    GROUP BY u.id, u.name
-    """
-  },
+  name: "User Activity Summary",
+  statement: """
+  SELECT
+    u.name,
+    COUNT(e.id) AS event_count,
+    MAX(s.last_login) AS last_seen
+  FROM users u
+  LEFT JOIN events e ON u.id = e.user_id  -- from analytics schema
+  LEFT JOIN sessions s ON u.id = s.user_id  -- from public schema
+  GROUP BY u.id, u.name
+  """,
   search_path: "public, analytics",  # users in public, events in analytics
   data_source: "postgres"
 })
@@ -534,8 +585,8 @@ Lotus validates `search_path` values to prevent injection attacks:
   search_path: "invalid-name, 123schema"  # hyphens and leading numbers not allowed
 })
 
-errors_on(changeset)
-# %{search_path: ["must be a comma-separated list of identifiers"]}
+changeset.errors
+# [search_path: {"must be a comma-separated list of identifiers", []}]
 ```
 
 ### search_path with Other Databases
@@ -613,12 +664,37 @@ attrs = %{
   ]
 }
 
-q = Lotus.Storage.Query.new(attrs) |> Repo.insert!()
+{:ok, q} = Lotus.create_query(attrs)
 
-# Use compile/2 for parameterized queries
+# compile/2 turns a stored query plus its variable values into an
+# executable %Lotus.Query.Statement{}. run_query/2 does this for you;
+# call it directly when you want to inspect what will be sent.
 Lotus.Storage.Query.compile(q, %{"since" => "2024-01-01"})
-# => {:ok, %Lotus.Query.Statement{body: "SELECT * FROM users WHERE org_id = $1 AND created_at >= $2 AND status = $3", params: [1, ~D[2024-01-01], "active"]}}
+# On PostgreSQL, against a table whose org_id is an integer column and
+# whose created_at is a date column:
+# => {:ok,
+#     %Lotus.Query.Statement{
+#       adapter: Lotus.Source.Adapters.Postgres,
+#       body: "SELECT * FROM users WHERE org_id = $1::integer AND created_at >= $2::date AND status = $3",
+#       params: [1, ~D[2024-01-01], "active"],
+#       meta: %{}
+#     }}
 ```
+
+The `::integer` / `::date` suffixes are not fixed per variable type, so the same
+query compiles differently against a different table. Lotus looks up the type of
+the column each variable is compared against and uses that; the declared
+variable type is only the fallback, used when the column type is unknown or
+plain text. See [Variable Type Casting](#variable-type-casting) below.
+
+`compile/2` returns `{:error, reason}` when a required variable has no value, a
+list variable is empty, or a supplied value fails type casting. `compile!/2` is
+the raising variant and returns the `%Statement{}` directly.
+
+> **Renamed in v1.0.** `compile/2` was `to_sql_params/2` in 0.x, and it returned
+> a bare `{sql, params}` tuple. The `body` field is adapter-native — SQL text for
+> Ecto sources, a JSON payload or AST for others — so it is no longer always a
+> string.
 
 ### Dynamic Dropdown Options
 
@@ -642,8 +718,8 @@ The `options_query` should return two columns:
 ### Variable Features
 
 - **Safe substitution**: Variables are converted to database-specific placeholders with automatic type casting (`$1::integer` for PostgreSQL, `CAST(? AS SIGNED)` for MySQL, `?` for SQLite)
-- **Structured variables**: Define variables with type, label, and default values for better UI integration  
-- **Type support**: Supports text, number, integer, date, datetime, time, boolean, and json types with automatic database casting
+- **Structured variables**: Define variables with type, label, and default values for better UI integration
+- **Declared types**: A variable declares one of `:text`, `:number` or `:date`. Richer types (integer, boolean, datetime, uuid, json, arrays and more) are inferred from the column the variable is compared against
 - **Widget controls**: Specify input or select widgets for UI rendering
 - **Static options**: Use `static_options` for predefined dropdown choices
 - **Dynamic options**: Use `options_query` to populate dropdowns from database queries
@@ -654,19 +730,32 @@ The `options_query` should return two columns:
 
 ## Variable Type Casting
 
-Lotus automatically generates type-specific SQL placeholders based on your variable types, ensuring proper data handling across different databases:
+For SQL sources, Lotus generates a type-specific placeholder for every
+substituted variable, so the database engine receives the value in the right
+type.
+
+**How the type is chosen**, in order:
+
+1. The type of the column the variable is compared against, when Lotus can
+   introspect it and it is not plain text. This wins, because the column knows
+   better than the declaration.
+2. The variable's declared `:type` (`:text`, `:number` or `:date`).
+3. No type — the value is passed through untouched.
 
 ### PostgreSQL Type Casting
 - `:integer` → `$1::integer`
-- `:number` → `$1::numeric` 
+- `:number` / `:decimal` → `$1::numeric`
+- `:float` → `$1::real`
+- `:uuid` → `$1::uuid`
 - `:date` → `$1::date`
 - `:datetime` → `$1::timestamp`
 - `:time` → `$1::time`
 - `:boolean` → `$1::boolean`
 - `:json` → `$1::jsonb`
+- `:binary` → `$1::bytea`
 - `:text` (default) → `$1`
 
-### MySQL Type Casting  
+### MySQL Type Casting
 - `:integer` → `CAST(? AS SIGNED)`
 - `:number` → `CAST(? AS DECIMAL)`
 - `:date` → `CAST(? AS DATE)`
@@ -679,7 +768,11 @@ Lotus automatically generates type-specific SQL placeholders based on your varia
 ### SQLite
 SQLite uses untyped `?` placeholders for all variable types, as it handles type conversion automatically.
 
-This type casting ensures that your data is properly handled by the database engine and can prevent runtime type errors.
+### Non-SQL sources
+Placeholders are an adapter decision, not a Lotus one. An adapter for a JSON or
+DSL engine inlines the value as a properly escaped literal in its own payload
+instead of adding a bind placeholder. See the
+[Source Adapters guide](source-adapters.md).
 
 ## Error Handling
 
@@ -730,6 +823,51 @@ You can customize query execution with options:
 ])
 ```
 
+Both `run_query/2` and `run_statement/3` accept the same option list:
+`:timeout`, `:statement_timeout_ms`, `:read_only`, `:search_path`, `:repo`,
+`:vars`, `:cache`, `:window`, `:filters`, `:sorts`, `:context` and `:scope`.
+
+## Paging Through Results
+
+Pass `:window` to return one page of rows instead of the whole result set:
+
+```elixir
+{:ok, page} = Lotus.run_query(query, window: [limit: 50, offset: 100])
+
+page.num_rows
+# 50 — always the number of rows in the returned page
+
+page.meta.window
+# %{limit: 50, offset: 100}
+```
+
+Ask for a total with `count: :exact`:
+
+```elixir
+{:ok, page} = Lotus.run_query(query, window: [limit: 50, offset: 0, count: :exact])
+
+page.meta.total_count
+# 1842 — rows before the window was applied
+page.meta.total_mode
+# :exact
+```
+
+`meta.total_mode` reports what you asked for, not how the source produced it. A
+source that cannot produce a total still reports `:exact` with
+`total_count: nil`, so an honest "unknown" is never confused with zero. With
+`count: :none` (the default) `meta` carries only `:window`.
+
+Windows also work on ad-hoc statements, and each page is cached separately:
+
+```elixir
+{:ok, page} = Lotus.run_statement("SELECT * FROM orders ORDER BY id", [],
+  window: [limit: 25, offset: 0, count: :exact]
+)
+```
+
+Set `config :lotus, default_page_size: 100` to change the limit used when a
+window names no `:limit`.
+
 ## Best Practices
 
 ### 1. Use Descriptive Names
@@ -738,13 +876,13 @@ You can customize query execution with options:
 # Good
 Lotus.create_query(%{
   name: "Monthly Active Users Report",
-  query: %{sql: "..."}
+  statement: "..."
 })
 
 # Avoid
 Lotus.create_query(%{
   name: "Query 1",
-  query: %{sql: "..."}
+  statement: "..."
 })
 ```
 
@@ -814,6 +952,7 @@ Once you have queries and visualizations, you can combine them into dashboards f
   card_type: :query,
   query_id: query.id,
   title: "Monthly Revenue",
+  position: 0,
   layout: %{x: 0, y: 0, w: 6, h: 4}
 })
 
@@ -843,3 +982,7 @@ Now that you understand the basics, explore:
 
 - [Dashboards](dashboards.md) - Combine queries into interactive views
 - [Configuration](configuration.md) - Learn about all available configuration options
+- [Advanced Variables](advanced-variables.md) - Optional clauses, list variables and dynamic options
+- [Visibility](visibility.md) - Control which schemas, tables and columns queries can reach
+- [Source Adapters](source-adapters.md) - Add a SQL dialect or a non-SQL data source
+- [Upgrading to v1.0](upgrading-to-v1.md) - Porting an app from the 0.x API

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -6,8 +6,18 @@ This guide walks you through setting up Lotus in your Elixir application.
 
 - Elixir 1.18 or later
 - OTP 27 or later
-- An Ecto-based application with PostgreSQL, MySQL, or SQLite
+- An Ecto repository on PostgreSQL, MySQL, or SQLite for Lotus storage
   - **SQLite**: Version 3.8.0+ recommended for database-level read-only protection
+
+Lotus keeps its saved queries, visualizations and dashboards in one Ecto
+repository — the *storage repo*. The databases that queries actually run
+against — the *data sources* — do not have to be Ecto repos in v1.0. Any module
+that implements the `Lotus.Source.Adapter` behaviour can be registered as a
+source. See the [Source Adapters guide](source-adapters.md).
+
+> **Upgrading from 0.x?** v1.0 renames configuration keys, public functions and
+> a database column, and there is no compatibility shim. Read
+> [Upgrading to v1.0](upgrading-to-v1.md) before you change anything.
 
 ## Step 1: Add Dependency
 
@@ -29,7 +39,7 @@ Add Lotus configuration to your `config/config.exs`:
 
 ```elixir
 config :lotus,
-  ecto_repo: MyApp.Repo,        # Where Lotus stores queries
+  storage_repo: MyApp.Repo,     # Where Lotus stores saved queries
   default_source: "main",       # Default data source for queries (required with multiple sources)
   data_sources: %{              # Where queries execute
     "main" => MyApp.Repo,
@@ -39,11 +49,67 @@ config :lotus,
 
 ### Configuration Options
 
-- `ecto_repo` (required): Repository where Lotus stores saved queries
-- `data_sources` (required): Map of data sources where queries can be executed
-- `default_source`: Default data source name to use when none specified (required with multiple sources)
+Only `:storage_repo` is required. Everything else has a default.
+
+- `storage_repo` (required): Ecto repository where Lotus stores its query definitions
+- `data_sources`: Map of named data sources where queries can be executed (default: `%{}`). Values are Ecto repo modules, or config maps for non-Ecto adapters
+- `default_source`: Data source name to use when a query names none. Must be a key in `data_sources`; Lotus raises at boot if it is not
+- `read_only`: Blocks writes (INSERT, UPDATE, DELETE, DDL) at the application and database level (default: `true`)
 - `unique_names`: Whether to enforce unique query names (default: `true`)
-- `table_visibility`: Rules controlling which tables can be accessed (optional)
+- `default_page_size`: Global default page size for windowed pagination (default: `nil`, which uses the built-in default)
+- `table_visibility` / `schema_visibility` / `column_visibility`: Rules controlling which schemas, tables and columns Lotus can reach — see the [Visibility Guide](visibility.md)
+- `allow_unrestricted_resources`: Opt-in for sources whose adapter cannot report the resources a statement touches (default: `false`) — see below
+- `cache`: Cache adapter, namespace and profiles — see the [Caching Guide](caching.md)
+- `middleware`: Hooks around query execution and schema discovery — see the [Middleware Guide](middleware.md)
+- `source_adapters` / `trusted_source_adapters` / `source_resolver` / `visibility_resolver`: Extension points for custom adapters and resolvers — see the [Source Adapters guide](source-adapters.md) and [Custom Resolvers](custom-resolvers.md)
+
+> **Renamed in v1.0.** `:ecto_repo` is now `:storage_repo`, `:data_repos` is now
+> `:data_sources`, and `:default_repo` is now `:default_source`. There is no
+> compatibility shim: Lotus reads only the new names, so a leftover 0.x key has
+> no effect and the app fails as though the setting were missing. See
+> Troubleshooting below.
+
+### Non-SQL Data Sources
+
+A data source entry may be a config map instead of a repo module, which is how
+non-Ecto adapters are configured:
+
+```elixir
+config :lotus,
+  storage_repo: MyApp.Repo,
+  data_sources: %{
+    "main" => MyApp.Repo,
+    "events" => %{adapter: MyApp.ElasticsearchAdapter, url: "http://localhost:9200"}
+  }
+```
+
+`%{adapter: MyAdapter, ...}` is the canonical form: the named module is used
+directly and the whole map is handed to it as state. Use `:source_adapters` only
+when an entry does not name its adapter and you want Lotus to find the owner by
+asking each registered module — exactly one must claim it, or resolution raises.
+
+Before it runs a statement, Lotus asks the adapter which resources the
+statement touches, so it can apply visibility rules. Some engines cannot answer
+that — they control access at their own layer (an Elasticsearch index, for
+example). Lotus blocks those statements unless you opt in:
+
+```elixir
+config :lotus,
+  # Opt in for one source only (recommended)
+  data_sources: %{
+    "events" => %{
+      adapter: MyApp.ElasticsearchAdapter,
+      url: "http://localhost:9200",
+      allow_unrestricted_resources: true
+    }
+  }
+
+# Or globally, for every such source
+config :lotus, allow_unrestricted_resources: true
+```
+
+The per-source setting always wins over the global flag, in both directions.
+See the [Visibility Guide](visibility.md) for the full rule model.
 
 ## Step 3: Run Migrations
 
@@ -75,6 +141,31 @@ Run the migration:
 mix ecto.migrate
 ```
 
+This creates the `lotus_queries`, `lotus_query_visualizations`,
+`lotus_dashboards`, `lotus_dashboard_cards`, `lotus_dashboard_filters` and
+`lotus_dashboard_card_filter_mappings` tables in your storage repo.
+
+`Lotus.Migrations.up/1` and `down/1` dispatch on the storage repo's adapter and
+accept a `:prefix` option if you keep Lotus tables in another schema:
+
+```elixir
+def up, do: Lotus.Migrations.up(prefix: "analytics")
+def down, do: Lotus.Migrations.down(prefix: "analytics")
+```
+
+`Lotus.Migrations.migrated_version/1` reports the version the database is on.
+
+> **Postgres is versioned; MySQL and SQLite are not.** The Postgres migration
+> runs a numbered chain (V1..V5), so `mix ecto.migrate` applies later changes —
+> including the v1.0 `data_repo` → `data_source` rename and the new
+> `query_language` column — on its own. The MySQL and SQLite migrations are
+> single-file and unversioned, so a host upgrading an existing 0.x install must
+> run those two statements by hand before starting v1.0 app code. Lotus raises a
+> migration error naming the rename statement if it finds the old `data_repo`
+> column; the `query_language` column is not checked, so add it at the same
+> time. Fresh installs are unaffected on every database. The exact SQL is in
+> [Upgrading to v1.0](upgrading-to-v1.md).
+
 ## Step 4: Configure Caching (Optional)
 
 Lotus is an OTP application — its supervisor starts automatically with your app, so you do not need to add `Lotus` to your application's supervision tree.
@@ -84,7 +175,7 @@ To enable caching, just add a `:cache` entry to your Lotus configuration:
 ```elixir
 # config/config.exs
 config :lotus,
-  ecto_repo: MyApp.Repo,
+  storage_repo: MyApp.Repo,
   data_sources: %{"main" => MyApp.Repo},
   cache: %{
     adapter: Lotus.Cache.ETS,
@@ -150,7 +241,7 @@ You can use different database types for storage and data:
 
 ```elixir
 config :lotus,
-  ecto_repo: MyApp.Repo,          # PostgreSQL for Lotus storage
+  storage_repo: MyApp.Repo,       # PostgreSQL for Lotus storage
   default_source: "postgres",     # Default data source for queries
   data_sources: %{
     "postgres" => MyApp.Repo,     # PostgreSQL data
@@ -295,7 +386,17 @@ Once installed, visit `/lotus` in your application (or whatever path you mounted
 
 ### Common Issues
 
-**Configuration Error**: If you see `ArgumentError` with "Invalid :lotus config: required :ecto_repo option not found", ensure your repository is properly configured in your application config.
+**Configuration Error**: If you see an `ArgumentError` with `Invalid :lotus config: required :storage_repo option not found, received options: [...]`, Lotus cannot find a storage repository. Check that `config :lotus, storage_repo: MyApp.Repo` is set — and if you are coming from 0.x, that you renamed `:ecto_repo` to `:storage_repo`.
+
+Lotus reads only the v1.0 key names from your application environment, so a
+leftover 0.x key is not reported by name — it is simply ignored, and you see the
+symptom instead: `:ecto_repo` surfaces as the missing `:storage_repo` above,
+while a leftover `:data_repos` leaves `:data_sources` empty and the first query
+raises `No data source available for query execution.`. If you see either,
+rename `:ecto_repo` to `:storage_repo`, `:data_repos` to `:data_sources`, and
+`:default_repo` to `:default_source`. See [Upgrading to v1.0](upgrading-to-v1.md).
+
+**Default Source Not Found**: `Invalid :lotus config: :default_source "x" is not a key in :data_sources` means `:default_source` names a source you did not configure. Lotus checks this at boot rather than on the first query.
 
 **Migration Issues**: If migrations fail, ensure your database is running and your repository configuration is correct.
 

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -282,9 +282,8 @@ With Lotus Web, your team gets:
 
 | Lotus Version | Lotus Web Version |
 |---------------|-------------------|
-| 0.9.x         | 0.4.x            |
-| 0.8.x         | 0.3.x            |
-| 0.6.x - 0.7.x | 0.3.x            |
+| 1.0.x         | 1.0.x             |
+| 0.16.x        | 0.14.x            |
 
 The dependency constraints in `mix.exs` will automatically ensure compatible versions are installed.
 

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -16,7 +16,7 @@ Add `lotus` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:lotus, "~> 1.0.0-rc.1"}
+    {:lotus, "~> 1.0"}
   ]
 end
 ```
@@ -240,8 +240,8 @@ Add `lotus_web` to your dependencies:
 ```elixir
 def deps do
   [
-    {:lotus, "~> 1.0.0-rc.1"},
-    {:lotus_web, "~> 1.0.0-rc.1"}
+    {:lotus, "~> 1.0"},
+    {:lotus_web, "~> 1.0"}
   ]
 end
 ```

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -37,14 +37,14 @@ Each middleware receives a payload map whose contents depend on the pipeline eve
 
 ### Discovery event ordering
 
-Discovery calls (`Lotus.list_schemas/2`, `list_tables/2`, `get_table_schema/3`, `list_relations/2`) fire **two** events per call:
+Discovery calls (`Lotus.list_schemas/2`, `Lotus.list_tables/2`, `Lotus.describe_table/3`, `Lotus.list_relations/2`) fire **two** events per call:
 
-1. The **kind-specific event** (`:after_list_schemas`, `:after_list_tables`, `:after_get_table_schema`, or `:after_list_relations`). The payload uses a key that matches the returned value (e.g. `:tables`, `:columns`). Register this event when you want the full kind-specific payload.
+1. The **kind-specific event** (`:after_list_schemas`, `:after_list_tables`, `:after_describe_table`, or `:after_list_relations`). The payload uses a key that matches the returned value (e.g. `:tables`, `:columns`). Register this event when you want the full kind-specific payload.
 2. The **unified `:after_discover` event**. The payload is always `%{kind:, source:, result:, scope:, context:}`. Register this event when you want a single middleware module that handles every discovery kind by dispatching on `:kind`.
 
 If any middleware in either phase halts, later middleware do not run and the caller receives `{:error, reason}`. The kind-specific event always runs before `:after_discover`; halting in the kind-specific phase short-circuits `:after_discover`.
 
-The `:kind` value in the unified event is one of `:list_schemas`, `:list_tables`, `:get_table_schema`, or `:list_relations`. Pattern-match on it and mutate `:result` in-place:
+The `:kind` value in the unified event is one of `:list_schemas`, `:list_tables`, `:describe_table`, or `:list_relations`. Pattern-match on it and mutate `:result` in-place:
 
 ```elixir
 defmodule MyApp.DiscoveryAuditMiddleware do
@@ -111,14 +111,39 @@ config :lotus,
 
 Middleware runs in the order listed. Multiple middleware can be chained on the same event.
 
-## Context
+The config is compiled once — `init/1` runs at compile time and the result is
+stored in `:persistent_term`. Reloading the config recompiles the pipeline, and
+**an empty (or absent) `:middleware` config clears it**: a reload that no longer
+declares middleware actually turns it off rather than leaving the previous
+pipeline in place.
 
-A `:context` key carries opaque user data (e.g. the current user) through to middleware. Lotus never inspects this value — it's purely for your application's use.
+## Context and Scope
+
+Two separate options reach middleware, and they are not interchangeable.
+
+`:context` is opaque caller data (e.g. the current user, a request id). Lotus
+never inspects it and it never affects execution. It is present on every event
+payload.
+
+`:scope` identifies *who is asking*. Lotus hashes it into cache keys and passes
+it to the visibility resolver, so a resolver can hide tables or mask columns per
+tenant or per role. It is present on the discovery event payloads
+(`:after_list_*`, `:after_discover`), not on `:before_query` / `:after_query`.
 
 ```elixir
-# Pass context when running a query
-Lotus.run_statement("SELECT * FROM orders", [], context: %{user_id: current_user.id})
+# Pass both when running a query
+Lotus.run_statement("SELECT * FROM orders", [],
+  context: %{user_id: current_user.id},
+  scope: %{tenant_id: current_user.tenant_id}
+)
 ```
+
+> **The result cache key includes `:scope` but never `:context`.** A plug that
+> masks or filters results per actor must have the caller pass a `:scope` that
+> identifies that actor. If the actor is only carried in `:context`, two callers
+> share one cache key and one caller's masked result is served to the other.
+> `Lotus.invalidate_scope/1` clears both the discovery and result cache entries
+> for a given scope.
 
 ```elixir
 defmodule MyApp.AccessControlMiddleware do
@@ -138,7 +163,9 @@ end
 
 ### Audit Logging
 
-Log every query execution with the user who ran it:
+Log each query execution with the user who ran it. Note that `:before_query`
+runs inside the result cache, so this records cache misses only — see
+[Caching](#caching) below.
 
 ```elixir
 defmodule MyApp.QueryAuditMiddleware do
@@ -146,13 +173,17 @@ defmodule MyApp.QueryAuditMiddleware do
 
   def init(opts), do: opts
 
-  def call(%{sql: sql, context: context} = payload, _opts) do
+  def call(%{statement: statement, source: source, context: context} = payload, _opts) do
     user_id = Map.get(context || %{}, :user_id, "anonymous")
-    Logger.info("[Lotus] user=#{user_id} sql=#{inspect(sql)}")
+    Logger.info("[Lotus] user=#{user_id} source=#{source} body=#{inspect(statement.body)}")
     {:cont, payload}
   end
 end
 ```
+
+`statement.body` is adapter-opaque: SQL text for an Ecto-backed source, a JSON
+map or DSL term for others. Use `inspect/1` rather than string interpolation so
+the plug works for every source type.
 
 ### Row-Level Security
 
@@ -295,7 +326,27 @@ defmodule MyApp.TableFilterMiddleware do
 end
 ```
 
-## Caching and Context
+## Caching
+
+Query middleware and discovery middleware sit on opposite sides of their caches.
+
+### Query middleware runs inside the result cache
+
+`:before_query` and `:after_query` run inside the result cache callback, so on a
+cache **hit** neither event fires — the cached rows are returned as they were
+stored. This matters in two ways:
+
+- **Side-effecting plugs skip cached runs.** An audit plug on `:before_query`
+  records misses, not hits. Log from the caller if you need every attempt.
+- **Per-actor filtering needs `:scope`, not `:context`.** The result cache key
+  hashes `:scope` and ignores `:context`, so a plug that redacts rows per user
+  must have the caller pass a `:scope` identifying that user — otherwise every
+  caller shares one key and one user's redacted rows are served to the next.
+
+Pass `cache: :bypass` on a call that must never be served from the cache, or
+`cache: :refresh` to re-run and re-seed it.
+
+### Discovery middleware runs outside the schema cache
 
 Discovery middleware (`:after_list_*`, `:after_discover`) runs **outside** the schema cache callback. The adapter result with visibility filtering applied is cached; middleware re-runs on every call against that cached result.
 
@@ -308,11 +359,13 @@ Discovery middleware (`:after_list_*`, `:after_discover`) runs **outside** the s
 When a middleware returns `{:halt, reason}`, the pipeline stops immediately and Lotus returns `{:error, reason}` to the caller. This is useful for enforcing access control, rate limiting, or any validation that should prevent execution:
 
 ```elixir
-def call(%{sql: sql} = payload, _opts) do
-  if String.contains?(String.downcase(sql), "pg_sleep") do
+def call(%{statement: %{body: body}} = payload, _opts) when is_binary(body) do
+  if String.contains?(String.downcase(body), "pg_sleep") do
     {:halt, "pg_sleep is not allowed"}
   else
     {:cont, payload}
   end
 end
+
+def call(payload, _opts), do: {:cont, payload}
 ```

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -1,12 +1,18 @@
 # Overview
 
-Lotus is a lightweight library that provides safe, read-only SQL query execution and management for Elixir applications using Ecto. It's designed to help you organize and execute analytical queries while maintaining strict safety controls.
+Lotus is an embeddable BI engine for Elixir applications. It gives you safe,
+read-only query execution against one or more data sources, persistent query
+storage, dashboards, caching, visibility controls, and AI-assisted query
+generation — all running inside your own application, with no extra service to
+deploy.
 
 ## Why Lotus?
 
-Modern applications often need to run complex analytical queries for reporting, business intelligence, or data exploration. However, executing arbitrary SQL in production environments comes with significant risks:
+Modern applications often need to run analytical queries for reporting,
+business intelligence, or data exploration. Executing arbitrary queries in
+production comes with significant risks:
 
-- **Security concerns**: Unrestricted SQL access can lead to data breaches or accidental damage
+- **Security concerns**: Unrestricted access can lead to data breaches or accidental damage
 - **Performance issues**: Poorly written queries can impact application performance
 - **Organization challenges**: Ad-hoc queries scattered across codebases are hard to maintain
 - **Reusability problems**: Useful queries get lost or duplicated
@@ -16,82 +22,143 @@ Lotus addresses these challenges by providing:
 ## Key Benefits
 
 ### 🔐 Safety First
-- **Read-only execution**: Built-in protections prevent destructive operations by default (configurable with `read_only: false`)
-- **Statement validation**: Queries are checked before execution
-- **Database-level guards**: PostgreSQL (`transaction_read_only`), MySQL (`transaction_read_only`), and SQLite 3.8.0+ (`PRAGMA query_only`)
-- **Session state preservation**: Automatically snapshots and restores original database session settings to prevent connection pool pollution
-- **Table visibility controls**: Configurable rules block access to sensitive tables
-- **Multi-layered security**: Defense-in-depth with preflight authorization
-- **Timeout controls**: Configurable timeouts prevent runaway queries
+- **Read-only execution**: Destructive operations are blocked by default (configurable with `read_only: false`)
+- **Statement validation**: Every statement is sanitized by its adapter before execution — what counts as a write is the adapter's judgement, not a regex
+- **Database-level guards**: PostgreSQL (`SET LOCAL transaction_read_only`), MySQL (`transaction_read_only`) and SQLite 3.8.0+ (`PRAGMA query_only`)
+- **Session state preservation**: Original session settings are snapshotted and restored to prevent connection pool pollution
+- **Preflight authorization**: Before a statement runs, Lotus resolves the tables it touches and checks them against your visibility rules
+- **Three-level visibility**: Schema, table and column rules — including column masking (`:null`, `:sha256`, partial and fixed values). See [Visibility](visibility.md)
+- **Timeout controls**: Configurable execution and statement timeouts prevent runaway queries
+
+### 🔌 Pluggable Data Sources
+- **Adapter contract**: Every source sits behind `Lotus.Source.Adapter`, so Lotus is not tied to SQL or to Ecto
+- **First-party adapters**: PostgreSQL, MySQL and SQLite, built on Ecto (`Lotus.Source.Adapters.Postgres`, `.MySQL`, `.SQLite3`)
+- **External adapters**: [`lotus_elasticsearch`](https://github.com/elixir-lotus/lotus_elasticsearch) and [`lotus_clickhouse`](https://github.com/elixir-lotus/lotus_clickhouse) ship as separate packages
+- **Many sources at once**: Configure as many named data sources as you need and query each by name
+- **Write your own**: See [Source Adapters](source-adapters.md)
 
 ### 📦 Organized Storage
-- **Persistent queries**: Save and organize your SQL queries
-- **Version control friendly**: Queries are stored in your database, not scattered in code
-- **Easy retrieval**: Simple API to find and execute saved queries
-
-### 🏗️ Framework Agnostic
-- **Ecto integration**: Works with any Ecto-based application
-- **Multi-database support**: Supports PostgreSQL, MySQL, and SQLite simultaneously
-- **Flexible architecture**: Separate storage and execution repositories
-- **Minimal dependencies**: Lightweight with few external requirements
+- **Persistent queries**: Save queries with a name, description, typed variables, a data source and an optional search path
+- **Version control friendly**: Queries live in your database, not scattered through code
+- **Easy retrieval**: A simple API to find and execute saved queries
 
 ### ⚡ Developer Friendly
-- **Simple API**: Intuitive functions for creating and running queries
-- **Type safety**: Structured results with proper error handling
-- **Configuration**: Flexible setup to match your application's needs
-- **Schema introspection**: Discover tables, inspect schemas, and gather statistics
+- **Simple API**: `Lotus.run_query/2` for saved queries, `Lotus.run_statement/3` for ad-hoc ones
+- **Type safety**: Structured `Lotus.Result` values with consistent error handling
+- **Result and schema caching**: Two independent caches with tag-based and scope-aware invalidation. See [Caching](caching.md)
+- **Middleware**: Plug-style hooks on query execution and schema discovery. See [Middleware](middleware.md)
+- **Telemetry**: `:telemetry` events for execution, caching and introspection. See [Telemetry](telemetry.md)
+- **Schema introspection**: Discover schemas, tables, columns, relations and statistics
 
 ## Core Concepts
 
+### Sources
+A source is a named data store Lotus can query — `"main"`, `"warehouse"`. Each
+one resolves to a `Lotus.Source.Adapter` struct that knows how to talk to the
+underlying engine. `Lotus.Source.list_sources/0`, `get_source!/1` and
+`default_source/0` are the entry points. Queries and introspection calls name a
+source; an unnamed call uses the configured default.
+
 ### Queries
-A query in Lotus is a saved SQL statement with metadata like name and creation time. Queries are stored in your database and can be executed repeatedly.
+A saved query (`Lotus.Storage.Query`) holds a `statement`, a name and
+description, embedded variable definitions, and the `data_source` it belongs to. Variables use
+`{{variable_name}}` syntax with `[[optional blocks]]`, and each adapter decides
+how a variable is substituted — a bind placeholder for SQL, an escaped literal
+for JSON or DSL engines. See [Advanced Variables](advanced-variables.md).
+
+A query may also record the `query_language` it was written for
+(`sql:postgres`, `json:elasticsearch`). If the source it runs against speaks a
+different language, Lotus refuses the run rather than handing the statement to
+an engine that cannot parse it.
+
+### Statements
+Everything Lotus executes is a `%Lotus.Query.Statement{}`. Its `:body` is
+adapter-opaque — SQL text for the Ecto-backed adapters, a JSON map or a DSL AST
+for others — and `:params` carries the bound values (a list for positional
+binds, a map for named ones). The same struct is what middleware and telemetry
+receive.
 
 ### Execution
-All SQL execution happens through Lotus's runner, which enforces read-only restrictions and provides consistent error handling and timeout management.
+All execution goes through `Lotus.Runner`, which runs one pipeline for every
+source: `:before_query` middleware (which may rewrite the statement), adapter
+sanitization, preflight authorization, execution, column policy enforcement,
+then `:after_query` middleware.
 
 ### Results
-Query results are returned in a structured format (`Result`) that includes the data and column information.
+Results come back as a `Lotus.Result` struct with `columns`, `rows`,
+`num_rows`, `duration_ms`, `command` and a `meta` map (connection id,
+`total_count` for windowed queries, and so on).
 
 ### Visualizations
-Visualizations are saved chart configurations attached to queries. Lotus stores the config as an opaque map, giving consumers full flexibility over the structure. Frontend applications like Lotus Web can transform this config into concrete chart specs (Vega-Lite, Recharts, etc.).
+Visualizations are saved chart configurations attached to queries. Lotus stores
+the config as an opaque map, giving consumers full flexibility over the
+structure. Frontend applications like Lotus Web transform this config into
+concrete chart specs (Vega-Lite, Recharts, etc.).
 
-Before saving, you can use `Lotus.validate_visualization_config/2` to verify that field references in your config exist in the query results and that numeric aggregations apply to numeric columns. This validation is optional and does not enforce any particular config structure.
+Before saving, `Lotus.validate_visualization_config/2` verifies that field
+references in your config exist in the query results and that numeric
+aggregations apply to numeric columns. This validation is optional and does not
+enforce any particular config structure.
 
 ### Dashboards
-Dashboards combine multiple queries into a single, interactive view. Each dashboard contains cards arranged in a 12-column grid layout, with support for:
+Dashboards combine multiple queries into a single, interactive view. Each
+dashboard contains cards arranged in a 12-column grid layout, with support for:
 
-- **Query cards** - Display results from saved queries with optional visualization overrides
-- **Text/heading cards** - Add context with markdown text or section headings
-- **Link cards** - Quick navigation to related resources
+- **Query cards** — results from saved queries, with optional visualization overrides
+- **Text/heading cards** — markdown text or section headings
+- **Link cards** — quick navigation to related resources
 
-Dashboard filters let users control data across multiple cards simultaneously. A single filter (like a date range picker) can map to different query variables in each card, enabling coordinated filtering without modifying individual queries.
+Dashboard filters let users control data across multiple cards at once. A single
+filter (a date range picker, say) can map to different query variables in each
+card, so cards filter together without changing the underlying queries. See
+[Dashboards](dashboards.md).
+
+### AI
+Lotus can generate, explain and optimize queries with an LLM. The prompts are
+assembled from each adapter's own `ai_context/1` — its query language, example
+query, syntax notes and error patterns — so the AI writes for the source it is
+pointed at rather than assuming SQL. Free-form context from untrusted adapters
+is stripped before it reaches the prompt. See
+[AI Query Generation](ai_query_generation.md).
 
 ### Schema Introspection
-Lotus provides comprehensive schema discovery tools to explore database structure, list tables across schemas, inspect column definitions, and gather table statistics.
+`Lotus.list_schemas/2`, `list_tables/2`, `describe_table/3`,
+`get_table_stats/3` and `list_relations/2` explore a source's structure. Every
+result is filtered through your visibility rules and cached. See
+[Schema Introspection](schema-introspection.md).
 
 ## Use Cases
 
-Lotus is perfect for:
+Lotus is a good fit for:
 
 - **Reporting dashboards**: Execute saved queries to generate reports
 - **Data exploration**: Safely allow analysts to run custom queries
 - **Business intelligence**: Organize and execute analytical queries
 - **Metrics collection**: Store and run queries for application metrics
-- **Data exports**: Generate data extracts with saved, tested queries
+- **Data exports**: Generate CSV, JSON or JSONL extracts with `Lotus.Export`
 - **Database administration**: Explore table structures and gather statistics
-- **Multi-tenant applications**: Manage schema-per-tenant architectures
+- **Multi-tenant applications**: Scope visibility, caching and middleware per tenant
 
 ## Lotus Web UI
 
-For teams that need a visual interface, [Lotus Web](https://github.com/elixir-lotus/lotus_web) provides a Phoenix LiveView-powered dashboard that you can mount directly in your application. It's a lightweight alternative to complex BI tools like Metabase or Grafana, offering:
+For teams that need a visual interface,
+[Lotus Web](https://github.com/elixir-lotus/lotus_web) provides a Phoenix
+LiveView dashboard you can mount directly in your application. It's a
+lightweight alternative to Metabase or Redash, offering:
 
-- **Web-based SQL editor** with syntax highlighting
+- **Query editor** with syntax highlighting and autocomplete
+- **AI assistant** for generating, explaining and optimizing queries
 - **Interactive query management** and organization
 - **Schema exploration** to browse tables and columns
-- **Real-time query execution** with clean result visualization
-- **Multi-database support** to query different repositories
-- **Zero additional infrastructure** - runs inside your Phoenix app
+- **Charts and dashboards** with grid layouts, auto-refresh and public sharing
+- **Multi-source support** to query different data sources
+- **Zero additional infrastructure** — runs inside your Phoenix app
 
 ## What's Next?
 
-Continue with the [Installation Guide](installation.md) to set up Lotus in your application, then check out [Getting Started](getting-started.md) for your first queries.
+Continue with the [Installation Guide](installation.md) to set up Lotus in your
+application, then [Getting Started](getting-started.md) for your first queries.
+[Configuration](configuration.md) covers the full set of options.
+
+Upgrading from v0.16.x? Start with [Upgrading to v1.0](upgrading-to-v1.md) —
+v1 is a rewrite, not a drop-in replacement.

--- a/guides/schema-introspection.md
+++ b/guides/schema-introspection.md
@@ -1,118 +1,146 @@
 # Schema Introspection
 
-Lotus provides powerful schema introspection capabilities for exploring database structure across multiple database types and schemas. This guide covers how to discover tables, inspect table schemas, and gather statistics about your data.
+Lotus can explore the structure of every configured data source: its
+namespaces, its tables and views, the columns of a table, and basic
+statistics. This guide covers the discovery API, the options every
+discovery call accepts, and how visibility, caching and middleware apply
+to the results.
 
-## Overview
+## A note on the word "schema"
 
-The Schema module (`Lotus.Schema`) provides functions to:
+In Lotus v1 **"schema" always means namespace** — a PostgreSQL schema, a
+MySQL database, a BigQuery dataset. The structure of a table (its
+columns, types and constraints) is called **columns**, and the function
+that returns it is `Lotus.describe_table/3`.
 
-- List tables across databases and schemas
-- Inspect table structure and column information
-- Get table statistics like row counts
-- Work with multi-schema PostgreSQL databases
-- Support PostgreSQL, MySQL, and SQLite databases
+Pre-v1 code that called `Lotus.get_table_schema` must call
+`Lotus.describe_table/3` instead. There is no alias — the old name is
+gone.
 
-All Schema functions respect the configured table visibility rules, ensuring you only see tables you're allowed to access.
+## The discovery API
 
-## Listing Tables
+`Lotus.Schema` holds the implementation; `Lotus` delegates to it, and the
+`Lotus.*` names are the ones to use.
 
-### Basic Usage
+| Function | Returns |
+| --- | --- |
+| `Lotus.list_schemas/2` | visible namespace names, `[String.t()]` |
+| `Lotus.list_tables/2` | `{schema, table}` tuples, or plain table names for a schema-less source |
+| `Lotus.list_relations/2` | always `{schema \| nil, table}` tuples |
+| `Lotus.describe_table/3` | column definitions for one table |
+| `Lotus.get_table_stats/3` | a stats map, at minimum `%{row_count: n}` |
 
-List all tables in your database:
+Every one of them applies the configured visibility rules before
+returning. See the [Visibility guide](visibility.md).
+
+The first argument is a configured source: its name (`"postgres"`) or,
+for Ecto-backed sources, the repo module (`MyApp.ReportingRepo`).
 
 ```elixir
-# List tables from the default public schema (PostgreSQL)
 {:ok, tables} = Lotus.list_tables("postgres")
-# Returns [{"public", "users"}, {"public", "posts"}, {"public", "comments"}]
+{:ok, tables} = Lotus.list_tables(MyApp.ReportingRepo)
+```
 
-# List tables from SQLite (no schema concept)
+An unknown source raises rather than returning an error tuple:
+
+```elixir
+Lotus.list_tables("nonexistent")
+# ** (ArgumentError) Data source "nonexistent" not configured.
+#    Available sources: ["postgres", "sqlite"]
+```
+
+## Relations are two-level
+
+Lotus names every resource with exactly two levels: `{schema | nil,
+table}`. Visibility rules, deny lists, `describe_table/3`, the preflight
+relation set — all of them speak that shape, and core never grows a third
+element.
+
+`nil` in the first position means "unqualified": a source with no
+namespace concept at all (SQLite tables, Elasticsearch indices), or a
+name the caller left unqualified.
+
+An engine with a **deeper** hierarchy flattens everything above the leaf
+into the schema part, keeping its own separator:
+
+- BigQuery `project.dataset.table` → `{"project.dataset", "table"}`
+- A catalog/schema/table engine → `{"catalog.schema", "table"}`
+
+The adapter owns that flattening. Core compares the schema part verbatim
+against your visibility rules, so a deny rule must be written in the
+flattened spelling the adapter emits.
+
+## Listing schemas
+
+```elixir
+{:ok, schemas} = Lotus.list_schemas("postgres")
+# ["public", "reporting", "analytics"]
+
+{:ok, schemas} = Lotus.list_schemas("mysql")
+# ["app_production", "analytics_db"]   (in MySQL, schemas are databases)
+
+{:ok, schemas} = Lotus.list_schemas("sqlite")
+# []                                   (SQLite has no namespaces)
+```
+
+System schemas (`pg_catalog`, `information_schema`, ...) are always
+filtered out.
+
+## Listing tables
+
+```elixir
+# Default namespaces for the source
+{:ok, tables} = Lotus.list_tables("postgres")
+# [{"public", "users"}, {"public", "posts"}]
+
+# A schema-less source returns plain strings
 {:ok, tables} = Lotus.list_tables("sqlite")
-# Returns ["products", "orders", "order_items"]
+# ["products", "orders", "order_items"]
 ```
 
-**Return Format:**
-- **PostgreSQL**: Returns tuples of `{schema, table}` like `{"public", "users"}`
-- **SQLite**: Returns simple strings like `"products"` (no schema concept)
-
-### Working with PostgreSQL Schemas
-
-PostgreSQL databases often use multiple schemas to organize tables. Lotus provides several ways to work with schemas:
-
-#### Specific Schema
-
-List tables from a specific schema:
+### Choosing namespaces
 
 ```elixir
-# List only tables in the reporting schema
+# One schema
 {:ok, tables} = Lotus.list_tables("postgres", schema: "reporting")
-# Returns [{"reporting", "customers"}, {"reporting", "revenue"}, {"reporting", "metrics"}]
 
-# List from analytics schema
-{:ok, tables} = Lotus.list_tables("postgres", schema: "analytics")
-# Returns [{"analytics", "events"}, {"analytics", "sessions"}, {"analytics", "pageviews"}]
-```
-
-#### Multiple Schemas
-
-List tables from multiple specific schemas:
-
-```elixir
-# List from both reporting and analytics schemas
+# Several schemas
 {:ok, tables} = Lotus.list_tables("postgres", schemas: ["reporting", "analytics"])
-# Returns [
-#   {"analytics", "events"},
-#   {"analytics", "sessions"},
-#   {"reporting", "customers"},
-#   {"reporting", "revenue"}
-# ]
-```
 
-#### Using search_path
-
-Use PostgreSQL's search_path concept to list tables from multiple schemas in priority order:
-
-```elixir
-# List tables using search_path (similar to PostgreSQL's native behavior)
+# A PostgreSQL-style search_path string
 {:ok, tables} = Lotus.list_tables("postgres", search_path: "reporting, analytics, public")
-# Returns tables from all three schemas
 ```
 
-### Including Views
+`:schema`, `:schemas` and `:search_path` are checked in that order; the
+first one present wins. When none is given, the adapter's default
+namespaces are used. Entries that are blank or `$user` are dropped.
 
-By default, only tables are listed. To include views:
+Requesting a namespace that visibility denies fails the whole call:
 
 ```elixir
-# Include both tables and views
-{:ok, relations} = Lotus.list_tables("postgres", 
+Lotus.list_tables("postgres", schemas: ["public", "pg_catalog"])
+# {:error, "Schema(s) not visible: pg_catalog"}
+```
+
+### Including views
+
+```elixir
+{:ok, relations} = Lotus.list_tables("postgres",
   search_path: "reporting, public",
   include_views: true
 )
-# Returns both tables and views from the specified schemas
 ```
 
-### Using Repository Modules
+Views are excluded by default.
 
-You can also use repository modules directly instead of repository names:
+## Describing a table
 
-```elixir
-# Use the repository module directly
-{:ok, tables} = Lotus.list_tables(MyApp.ReportingRepo, schema: "reporting")
-
-# Works with any configured repository
-{:ok, tables} = Lotus.list_tables(MyApp.AnalyticsRepo)
-```
-
-## Getting Table Schema
-
-Inspect the structure of a specific table to see columns, types, and constraints:
-
-### Basic Table Schema
+`Lotus.describe_table/3` returns the column definitions of one table.
 
 ```elixir
-# Get schema for a table
-{:ok, schema} = Lotus.get_table_schema("postgres", "users")
+{:ok, columns} = Lotus.describe_table("postgres", "users")
 
-# Each column entry contains:
+# Each entry:
 # %{
 #   name: "id",
 #   type: "bigint",
@@ -121,302 +149,295 @@ Inspect the structure of a specific table to see columns, types, and constraints
 #   primary_key: true
 # }
 
-# Inspect the columns
-Enum.each(schema, fn col ->
+Enum.each(columns, fn col ->
   IO.puts("#{col.name}: #{col.type}#{if col.nullable, do: "", else: " NOT NULL"}")
 end)
-# id: bigint NOT NULL
-# name: varchar(255) NOT NULL
-# email: varchar(255) NOT NULL
-# created_at: timestamp
-# updated_at: timestamp
 ```
 
-### Schema-Specific Tables
-
-For PostgreSQL tables in non-public schemas:
+The table is located the same way as in `list_tables/2` — `:schema`,
+`:schemas` or `:search_path`, first match wins:
 
 ```elixir
-# Get schema for a table in the reporting schema
-{:ok, schema} = Lotus.get_table_schema("postgres", "customers", schema: "reporting")
+{:ok, columns} = Lotus.describe_table("postgres", "customers", schema: "reporting")
 
-# Using search_path to find the table
-{:ok, schema} = Lotus.get_table_schema("postgres", "revenue", 
+{:ok, columns} = Lotus.describe_table("postgres", "revenue",
   search_path: "reporting, analytics, public"
 )
-# Searches for 'revenue' table in each schema in order
 ```
 
-### Column Information
-
-The schema information includes detailed column metadata:
+Working with the result is plain list handling:
 
 ```elixir
-{:ok, schema} = Lotus.get_table_schema("postgres", "products")
+{:ok, columns} = Lotus.describe_table("postgres", "products")
 
-# Find specific column information
-price_col = Enum.find(schema, &(&1.name == "price"))
-# %{
-#   name: "price",
-#   type: "numeric(10,2)",
-#   nullable: false,
-#   default: "0.00",
-#   primary_key: false
-# }
-
-# Check for primary keys
-primary_keys = Enum.filter(schema, & &1.primary_key)
-# [%{name: "id", type: "bigint", primary_key: true, ...}]
-
-# Find nullable columns
-nullable_cols = Enum.filter(schema, & &1.nullable)
+price = Enum.find(columns, &(&1.name == "price"))
+primary_keys = Enum.filter(columns, & &1.primary_key)
+nullable = Enum.filter(columns, & &1.nullable)
 ```
 
-### SQLite Schema
-
-SQLite schema information has the same structure but different type representations:
+SQLite reports the same map shape with its own type spellings:
 
 ```elixir
-{:ok, schema} = Lotus.get_table_schema("sqlite", "products")
-
-# SQLite types are simpler
-# %{
-#   name: "id",
-#   type: "INTEGER",
-#   nullable: true,  # SQLite represents PKs differently
-#   default: nil,
-#   primary_key: true
-# }
+{:ok, columns} = Lotus.describe_table("sqlite", "products")
+# %{name: "id", type: "INTEGER", nullable: true, default: nil, primary_key: true}
 ```
 
-## Getting Table Statistics
+### Column visibility in the result
 
-Get basic statistics about a table:
+Column rules (see the [Visibility guide](visibility.md)) are applied to
+the description too:
+
+- a column whose policy sets `show_in_schema?: false` is **removed** from
+  the list entirely;
+- a column with any other non-`nil` policy gains a `:visibility` key
+  holding `%{action: ..., mask: ...}`, so a UI can label it as masked or
+  blocked before anyone runs a query.
 
 ```elixir
-# Get row count for a table
+{:ok, columns} = Lotus.describe_table("postgres", "users")
+
+Enum.find(columns, &(&1.name == "ssn"))
+# %{name: "ssn", type: "text", ..., visibility: %{action: :mask, mask: :sha256}}
+```
+
+## Table statistics
+
+```elixir
 {:ok, stats} = Lotus.get_table_stats("postgres", "users")
-# Returns %{row_count: 1234}
+# %{row_count: 1234}
 
-# For tables in specific schemas
 {:ok, stats} = Lotus.get_table_stats("postgres", "customers", schema: "reporting")
-# Returns %{row_count: 5678}
-
-# Using search_path
-{:ok, stats} = Lotus.get_table_stats("postgres", "events",
-  search_path: "analytics, public"
-)
 ```
 
-## Listing Relations
+Lotus asks the adapter first. A source whose adapter implements the
+optional `c:Lotus.Source.Adapter.table_stats/3` callback answers from
+that callback and may return extra keys alongside `:row_count` (on-disk
+size, segment counts, a last-analyzed timestamp) — callers should
+tolerate extras. An adapter that does not implement it falls back to
+`SELECT COUNT(*)` against the quoted relation, which only makes sense for
+SQL sources.
 
-The `list_relations` function returns tables with full schema information, useful for building UIs:
+Unlike the other discovery calls, `get_table_stats/3` fires no middleware
+events. It accepts `:schema`, `:schemas`, `:search_path`, `:cache` and
+`:scope`.
+
+## Listing relations
+
+`Lotus.list_relations/2` is `list_tables/2` that always keeps the
+namespace, which is what a table picker in a UI usually wants:
 
 ```elixir
-# Get all relations (tables) with schema information
 {:ok, relations} = Lotus.list_relations("postgres", search_path: "reporting, public")
-# Always returns tuples: [{"reporting", "customers"}, {"public", "users"}, ...]
+# [{"reporting", "customers"}, {"public", "users"}, ...]
 
-# For SQLite, includes nil schema
 {:ok, relations} = Lotus.list_relations("sqlite")
-# Returns [{nil, "products"}, {nil, "orders"}, ...]
+# [{nil, "products"}, {nil, "orders"}, ...]
 ```
 
-This is particularly useful when you need consistent schema information across different database types.
+It takes the same `:schema` / `:schemas` / `:search_path` /
+`:include_views` options as `list_tables/2`.
 
-## Multi-Tenant Scenarios
+## `:scope` and `:context`
 
-Schema introspection is particularly useful in multi-tenant applications:
+`list_schemas/2`, `list_tables/2`, `list_relations/2` and
+`describe_table/3` all accept two opaque caller-supplied values. They do
+different jobs:
 
-### Schema-per-Tenant
+- **`:scope`** is handed to the visibility resolver
+  (`c:Lotus.Visibility.Resolver.table_rules_for/2` and friends receive
+  `(source_name, scope)`) and is hashed into the cache key. Different
+  scopes therefore produce independent cached entries.
+- **`:context`** is threaded into the middleware payloads only. It never
+  reaches the resolver and never changes the cache key.
+
+```elixir
+# Per-role rules, cached separately per role
+{:ok, tables} = Lotus.list_tables("postgres", scope: %{role: :admin})
+
+# Per-tenant middleware filtering, shared cache
+{:ok, tables} = Lotus.list_tables("postgres", context: %{tenant: "acme"})
+```
+
+Keep scope low-cardinality (per-role, per-tenant) so the cache still
+hits. A resolver that reads runtime context — the process dictionary,
+say — instead of using its `scope` argument will cache incorrectly; put
+context-dependent logic in middleware, or pass it as scope.
+
+Scoped rules are not only a discovery concern. As of v1 they are enforced
+at execution time as well: `Lotus.Preflight.authorize/4` takes the scope,
+and `Lotus.Runner` passes the `:scope` option through to it. See
+[Visibility](visibility.md#scoped-rules-are-enforced-at-execution-time).
+
+Cached entries for one scope can be dropped on their own:
+
+```elixir
+:ok = Lotus.invalidate_scope(%{role: :admin})
+```
+
+## Middleware events
+
+Every discovery call fires two events (see `Lotus.Middleware`):
+
+1. the kind-specific event, with a kind-specific payload;
+2. the unified `:after_discover` event, with
+   `%{kind:, source:, result:, scope:, context:}`.
+
+| Call | Kind-specific event | Payload keys |
+| --- | --- | --- |
+| `list_schemas/2` | `:after_list_schemas` | `:schemas`, `:source`, `:scope`, `:context` |
+| `list_tables/2` | `:after_list_tables` | `:tables`, `:source`, `:scope`, `:context` |
+| `describe_table/3` | `:after_describe_table` | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
+| `list_relations/2` | `:after_list_relations` | `:relations`, `:source`, `:scope`, `:context` |
+
+Two v1 changes to note: the event formerly called
+`:after_get_table_schema` is now `:after_describe_table`, and the payload
+key formerly called `:repo` is now `:source`.
+
+Both events run **outside** the cache callback, so only the raw,
+visibility-filtered adapter result is cached. Context-sensitive
+middleware is therefore safe to use without poisoning the cache, at the
+cost of running the middleware pipeline on every call.
+
+## Caching
+
+Discovery results are cached by Lotus itself when a cache adapter is
+configured — there is no need to build your own layer. The default
+profile is `:schema` for the listing and description calls and `:results`
+for `get_table_stats/3`.
+
+```elixir
+# Use the configured cache (default)
+{:ok, tables} = Lotus.list_tables("postgres")
+
+# Custom profile or TTL
+{:ok, tables} = Lotus.list_tables("postgres", cache: [profile: :schema, ttl_ms: 300_000])
+
+# Skip the cache for this call
+{:ok, tables} = Lotus.list_tables("postgres", cache: :bypass)
+
+# Run the call and overwrite the cached entry
+{:ok, tables} = Lotus.list_tables("postgres", cache: :refresh)
+```
+
+Entries are tagged `"source:<name>"` and `"schema:<kind>"` (plus
+`"scope:<digest>"` when a scope is given), so they can be invalidated by
+tag. See the [Caching guide](caching.md).
+
+## Error handling
+
+```elixir
+# Table not found in the searched namespaces
+{:error, msg} = Lotus.describe_table("postgres", "nonexistent")
+# "Table 'nonexistent' not found in schemas: public"
+
+{:error, msg} = Lotus.describe_table("postgres", "users", schema: "reporting")
+# "Table 'users' not found in schemas: reporting"
+
+# Table blocked by visibility rules
+{:error, msg} = Lotus.describe_table("postgres", "api_keys")
+# "Table 'public.api_keys' is not visible by Lotus policy"
+
+# Namespace blocked by visibility rules
+{:error, msg} = Lotus.list_tables("postgres", schemas: ["public", "restricted"])
+# "Schema(s) not visible: restricted"
+```
+
+A source name that is not configured raises `ArgumentError` — it is a
+configuration mistake, not a runtime condition.
+
+## Multi-tenant patterns
+
+### Schema-per-tenant
 
 ```elixir
 defmodule MyApp.TenantInspector do
   def list_tenant_tables(tenant_id) do
-    schema_name = "tenant_#{tenant_id}"
-    Lotus.list_tables("postgres", schema: schema_name)
+    Lotus.list_tables("postgres", schema: "tenant_#{tenant_id}")
   end
 
-  def get_tenant_table_info(tenant_id, table_name) do
-    schema_name = "tenant_#{tenant_id}"
-    
-    with {:ok, schema} <- Lotus.get_table_schema("postgres", table_name, 
-                            schema: schema_name),
-         {:ok, stats} <- Lotus.get_table_stats("postgres", table_name,
-                           schema: schema_name) do
-      {:ok, %{
-        columns: schema,
-        row_count: stats.row_count
-      }}
+  def tenant_table_info(tenant_id, table_name) do
+    schema = "tenant_#{tenant_id}"
+
+    with {:ok, columns} <- Lotus.describe_table("postgres", table_name, schema: schema),
+         {:ok, stats} <- Lotus.get_table_stats("postgres", table_name, schema: schema) do
+      {:ok, %{columns: columns, row_count: stats.row_count}}
     end
   end
 end
-
-# Usage
-{:ok, tables} = MyApp.TenantInspector.list_tenant_tables(123)
-{:ok, info} = MyApp.TenantInspector.get_tenant_table_info(123, "users")
 ```
 
-### Shared Tables with Tenant-Specific Schemas
+### Tenant-scoped visibility
+
+When the rules themselves differ per tenant, pass `:scope` so the
+resolver sees the tenant and the cache keeps the results apart:
 
 ```elixir
-# Core tables in public, tenant data in separate schemas
-defmodule MyApp.SchemaExplorer do
-  def explore_database do
-    # Get shared tables
-    {:ok, shared} = Lotus.list_tables("postgres", schema: "public")
-    
-    # Get tenant-specific tables
-    {:ok, tenant_123} = Lotus.list_tables("postgres", schema: "tenant_123")
-    {:ok, tenant_456} = Lotus.list_tables("postgres", schema: "tenant_456")
-    
-    %{
-      shared_tables: shared,
-      tenants: %{
-        tenant_123: tenant_123,
-        tenant_456: tenant_456
-      }
-    }
-  end
-end
+{:ok, tables} = Lotus.list_tables("postgres", scope: %{tenant_id: 42})
+{:ok, result} = Lotus.run_query(query, scope: %{tenant_id: 42})
 ```
 
-## Building Admin Tools
+Pass the same scope to execution. Without it, a table hidden from a
+tenant in the explorer would still return its rows from a query.
 
-Schema introspection is perfect for building administrative interfaces:
+## Building admin tools
 
 ```elixir
 defmodule MyApp.AdminDashboard do
-  def database_overview(repo_name) do
-    # Get all tables
-    {:ok, tables} = Lotus.list_tables(repo_name, 
-      search_path: "reporting, analytics, public",
-      include_views: true
-    )
-    
-    # Get stats for each table
-    table_stats = Enum.map(tables, fn {schema, table} ->
-      {:ok, stats} = Lotus.get_table_stats(repo_name, table, schema: schema)
-      
-      %{
-        schema: schema,
-        table: table,
-        row_count: stats.row_count
-      }
+  def database_overview(source) do
+    {:ok, relations} =
+      Lotus.list_relations(source,
+        search_path: "reporting, analytics, public",
+        include_views: true
+      )
+
+    relations
+    |> Enum.map(fn {schema, table} ->
+      {:ok, stats} = Lotus.get_table_stats(source, table, schema: schema)
+      %{schema: schema, table: table, row_count: stats.row_count}
     end)
-    
-    # Sort by row count
-    Enum.sort_by(table_stats, & &1.row_count, :desc)
+    |> Enum.sort_by(& &1.row_count, :desc)
   end
-  
-  def table_details(repo_name, schema_name, table_name) do
-    with {:ok, columns} <- Lotus.get_table_schema(repo_name, table_name, 
-                             schema: schema_name),
-         {:ok, stats} <- Lotus.get_table_stats(repo_name, table_name,
-                           schema: schema_name) do
+
+  def table_details(source, schema, table) do
+    with {:ok, columns} <- Lotus.describe_table(source, table, schema: schema),
+         {:ok, stats} <- Lotus.get_table_stats(source, table, schema: schema) do
       %{
-        name: table_name,
-        schema: schema_name,
+        name: table,
+        schema: schema,
         columns: columns,
         column_count: length(columns),
         row_count: stats.row_count,
-        primary_keys: Enum.filter(columns, & &1.primary_key) |> Enum.map(& &1.name),
-        nullable_columns: Enum.filter(columns, & &1.nullable) |> Enum.map(& &1.name)
+        primary_keys: columns |> Enum.filter(& &1.primary_key) |> Enum.map(& &1.name)
       }
     end
   end
 end
-
-# Usage in a LiveView or controller
-overview = MyApp.AdminDashboard.database_overview("postgres")
-details = MyApp.AdminDashboard.table_details("postgres", "reporting", "customers")
 ```
 
-## Error Handling
+`list_relations/2` is the right call here: it keeps the namespace for
+every source, so the same code works against PostgreSQL and SQLite.
 
-Schema functions return clear errors for common issues:
+## Introspection and query building
 
-```elixir
-# Table not found
-{:error, msg} = Lotus.get_table_schema("postgres", "nonexistent")
-# "Table 'nonexistent' not found in schemas: public"
-
-# Table not in specified schema
-{:error, msg} = Lotus.get_table_schema("postgres", "users", schema: "reporting")
-# "Table 'users' not found in schemas: reporting"
-
-# Table blocked by visibility rules
-{:error, msg} = Lotus.get_table_schema("postgres", "api_keys")
-# "Table 'public.api_keys' is not visible by Lotus policy"
-
-# Invalid repository name
-{:error, msg} = Lotus.list_tables("nonexistent_repo")
-# "Data repo 'nonexistent_repo' not configured"
-```
-
-## Performance Considerations
-
-Schema introspection queries are generally fast, but keep in mind:
-
-1. **Caching**: Consider caching schema information if you're building UIs that frequently request it
-2. **Large Schemas**: Databases with many schemas or tables may take longer to list
-3. **Views**: Including views (`include_views: true`) may slow down queries in databases with complex views
-
-```elixir
-defmodule MyApp.SchemaCache do
-  use GenServer
-  
-  def get_tables(repo_name, opts \\ []) do
-    key = {repo_name, opts}
-    
-    case :ets.lookup(:schema_cache, key) do
-      [{^key, tables, timestamp}] ->
-        if timestamp > System.system_time(:second) - 300 do  # 5 minute cache
-          {:ok, tables}
-        else
-          refresh_tables(repo_name, opts)
-        end
-      [] ->
-        refresh_tables(repo_name, opts)
-    end
-  end
-  
-  defp refresh_tables(repo_name, opts) do
-    case Lotus.list_tables(repo_name, opts) do
-      {:ok, tables} = result ->
-        :ets.insert(:schema_cache, {{repo_name, opts}, tables, System.system_time(:second)})
-        result
-      error ->
-        error
-    end
-  end
-end
-```
-
-## Integration with Query Building
-
-Use schema introspection to help build queries:
+Use discovery to check a table before writing a query against it:
 
 ```elixir
 defmodule MyApp.QueryBuilder do
-  def build_count_query(repo_name, schema_name, table_name) do
-    # Verify table exists
-    case Lotus.get_table_schema(repo_name, table_name, schema: schema_name) do
-      {:ok, _schema} ->
-        # Table exists, build query
-        sql = if schema_name do
-          "SELECT COUNT(*) as total FROM #{schema_name}.#{table_name}"
-        else
-          "SELECT COUNT(*) as total FROM #{table_name}"
-        end
-        
+  def build_count_query(source, schema, table) do
+    case Lotus.describe_table(source, table, schema: schema) do
+      {:ok, _columns} ->
+        statement =
+          if schema,
+            do: "SELECT COUNT(*) AS total FROM #{schema}.#{table}",
+            else: "SELECT COUNT(*) AS total FROM #{table}"
+
         Lotus.create_query(%{
-          name: "Count #{schema_name}.#{table_name}",
-          query: %{sql: sql},
-          data_source: repo_name,
-          search_path: schema_name
+          name: "Count #{schema}.#{table}",
+          statement: statement,
+          data_source: source,
+          search_path: schema
         })
-        
+
       {:error, reason} ->
         {:error, "Cannot create query: #{reason}"}
     end
@@ -424,77 +445,66 @@ defmodule MyApp.QueryBuilder do
 end
 ```
 
-## Best Practices
+Never interpolate a user-supplied table name into a statement. Resolve it
+through `list_relations/2` first and use the value Lotus returned, so a
+name that visibility denies never reaches the SQL.
 
-### 1. Use Specific Schemas When Possible
+An ad-hoc check runs through `Lotus.run_statement/3` (renamed from
+`run_sql/3` in v1):
 
 ```elixir
-# Good - explicit schema
+def preview(source, schema, table) do
+  with {:ok, _columns} <- Lotus.describe_table(source, table, schema: schema),
+       {:ok, result} <-
+         Lotus.run_statement("SELECT * FROM #{schema}.#{table} LIMIT 10", [], repo: source) do
+    {:ok, result}
+  end
+end
+```
+
+## Best practices
+
+### Name the namespace when you know it
+
+```elixir
+# Precise
 {:ok, tables} = Lotus.list_tables("postgres", schema: "reporting")
 
-# Less specific - searches multiple schemas
+# Broader, and slower on a database with many schemas
 {:ok, tables} = Lotus.list_tables("postgres", search_path: "reporting, analytics, public")
 ```
 
-### 2. Handle Different Database Types
+### Prefer `list_relations/2` for code that must work everywhere
 
-```elixir
-def list_all_tables(repo_name) do
-  case Lotus.list_tables(repo_name) do
-    {:ok, tables} when is_list(tables) ->
-      # Handle both tuple format (PostgreSQL) and string format (SQLite)
-      normalized = Enum.map(tables, fn
-        {schema, table} -> "#{schema}.#{table}"  # PostgreSQL
-        table when is_binary(table) -> table      # SQLite
-      end)
-      {:ok, normalized}
-    error ->
-      error
-  end
-end
-```
+`list_tables/2` collapses to plain strings when every relation is
+unqualified, which means the caller has two shapes to handle.
+`list_relations/2` always returns `{schema | nil, table}`.
 
-### 3. Check Table Existence Before Operations
+### Let visibility do the filtering
 
-```elixir
-def safe_query_table(repo_name, table_name, schema_name \\ "public") do
-  with {:ok, _schema} <- Lotus.get_table_schema(repo_name, table_name, schema: schema_name),
-       {:ok, result} <- Lotus.run_statement("SELECT * FROM #{schema_name}.#{table_name} LIMIT 10", 
-                          [], repo: repo_name) do
-    {:ok, result}
-  else
-    {:error, reason} -> {:error, "Cannot query table: #{reason}"}
-  end
-end
-```
-
-### 4. Use Table Visibility for Security
-
-Configure table visibility rules to ensure schema introspection only shows allowed tables:
+Discovery already applies the rules. Configure them once instead of
+filtering the results by hand:
 
 ```elixir
 config :lotus,
   table_visibility: %{
     default: [
-      # Bare strings block tables across ALL schemas
-      deny: [
-        "api_keys",         # Blocks api_keys in any schema
-        "user_passwords",   # Blocks user_passwords in any schema
-        "audit_logs"        # Blocks audit_logs in any schema
-      ]
+      # Bare strings match the table name in any namespace
+      deny: ["api_keys", "user_passwords", "audit_logs"]
     ],
     reporting: [
       allow: [
-        {"reporting", ~r/.*/},  # All reporting schema tables
-        {"public", "users"},    # Specific public.users table
-        "summaries"             # Allow 'summaries' table in any schema
+        {"reporting", ~r/.*/},
+        {"public", "users"},
+        "summaries"
       ]
     ]
   }
 ```
 
-## Next Steps
+## Next steps
 
-- Learn about [Configuration](configuration.md) for table visibility rules
-- Explore [Getting Started](getting-started.md) for query execution with schemas
-- Check the [API Reference](https://hexdocs.pm/lotus) for detailed function documentation
+- [Visibility](visibility.md) — schema, table and column rules, scopes and preflight
+- [Caching](caching.md) — profiles, TTLs and tag invalidation
+- [Middleware](middleware.md) — the discovery events in full
+- [Source adapters](source-adapters.md) — implementing introspection for a new engine

--- a/guides/source-adapters.md
+++ b/guides/source-adapters.md
@@ -9,16 +9,19 @@ database connection, or an external REST / DSL engine — is represented as a
 `%Lotus.Source.Adapter{}` struct that the runner, preflight, cache, and
 introspection modules all accept identically.
 
-`Lotus.Source` provides convenience functions (`resolve!/2`, `source_type/1`,
-`supports_feature?/2`, `hierarchy_label/1`, `query_language/1`,
+`Lotus.Source` is a public facade — not a behaviour. It provides convenience
+functions (`resolve!/2`, `list_sources/0`, `get_source!/1`, `default_source/0`,
+`source_type/1`, `supports_feature?/2`, `hierarchy_label/1`, `example_query/3`,
+`query_language/1`, `editor_config/1`, `limit_query/3`,
 `supported_filter_operators/1`, `prepare_for_analysis/2`) that accept adapter
 structs, source-name strings, or repo modules and resolve lazily as needed.
 
 For SQL databases backed by Ecto, per-dialect adapter modules
 (`Lotus.Source.Adapters.Postgres`, `Lotus.Source.Adapters.MySQL`,
 `Lotus.Source.Adapters.SQLite3`) handle dialect-specific behaviour. External
-adapters for other databases or non-SQL data sources are registered via the
-`:source_adapters` config.
+adapters for other databases or non-SQL data sources are named in their
+`data_sources` entry (`%{adapter: MyAdapter, ...}`) or registered via the
+`:source_adapters` config — see [Registration](#registration).
 
 ## How It Works
 
@@ -32,11 +35,12 @@ The adapter struct carries four fields:
 | `source_type` | `atom()` | Database kind — `:postgres`, `:mysql`, `:sqlite`, `:other`, or any atom an external adapter declares |
 
 When a query is executed, Lotus asks the configured **source resolver** to turn
-a repo name (or module) into an `%Adapter{}` struct. The resolver iterates
-through registered adapters (external first, then built-in per-dialect, then
-the generic Ecto fallback), calling `can_handle?/1` on each until one claims
-the entry. That adapter's `wrap/2` builds the struct, and from that point
-every pipeline stage dispatches through `Adapter` helpers.
+a source name (or module) into an `%Adapter{}` struct. An entry that names its
+adapter — `%{adapter: MyAdapter, ...}`, the canonical form — is handed straight
+to that module's `wrap/2`. Any other entry is offered to every registered
+adapter's `can_handle?/1`, and exactly one must claim it. From that point every
+pipeline stage dispatches through `Lotus.Source.Adapter` helpers, which pass
+`adapter.state` as the first argument to the adapter module's callbacks.
 
 ```
 User calls Lotus.run_statement("SELECT 1", [], repo: "main")
@@ -59,33 +63,69 @@ All pipeline callbacks operate on a `%Lotus.Query.Statement{}`:
 
 ```elixir
 %Lotus.Query.Statement{
-  adapter: MyApp.Adapters.Echo,   # module that owns this text
-  text:    "SELECT * FROM t",     # adapter-native payload (term())
-  params:  [],                    # bound parameter values
+  adapter: MyApp.Adapters.Echo,   # module that owns this body's shape
+  body:    "SELECT * FROM t",     # adapter-native payload (term())
+  params:  [],                    # bound values — list or map
   meta:    %{}                    # adapter-specific metadata
 }
 ```
 
-The `:body` field is deliberately typed `term()` — SQL text for Ecto-backed
-adapters, a JSON body for Elasticsearch, a DSL AST for other engines. The
+The field carrying the query is `:body`, not `:text`. It is deliberately typed
+`term()` — SQL text for Ecto-backed adapters, a decoded JSON map for
+Elasticsearch, a DSL AST for other engines. Core never inspects it. The
 pipeline is a series of pure `statement -> statement` transforms; adapters
 return new structs rather than mutating in place.
 
-Relevant keys inside `:meta`:
+`:params` is a **list** for positional binds, in the order the driver expects,
+or a **map** for engines with named binds (`%{"since" => ~D[2026-01-01]}`),
+where ordering is meaningless. Adapters that inline values into `:body` leave
+it as `[]`.
+
+Build one with `Lotus.Query.Statement.new/2` (`:body` is the only enforced
+key):
+
+```elixir
+statement = Lotus.Query.Statement.new("SELECT * FROM users WHERE id = $1", [42])
+```
+
+Core reserves two `:meta` keys; everything else in the map belongs to the
+adapter:
 
 - `:count_spec` — placed by `apply_pagination/3` when the caller requested
   `count: :exact` and the adapter uses Strategy B (separate count query).
   Shape: `%{query: adapter-native, params: list()}`. Lotus core runs it
   through the same adapter. See "Exact counts" below.
+- `:search_path` — reserved for schema-isolation hints. Callers pass
+  `:search_path` as an option (it reaches `apply_pagination/3` and
+  `execute_query/4` in `opts`); adapters must not repurpose the meta key.
+
+### Pipeline order
+
+Where each callback fires, for a stored query executed through
+`Lotus.run_query/2`:
+
+1. `transform_statement/2` — in `Lotus.Storage.Query.compile/2`, before any
+   `{{var}}` is extracted. `statement.params` is `[]` here.
+2. `substitute_variable/5` / `substitute_list_variable/5` — one call per
+   variable, folded over the statement by the same compile step.
+3. `transform_bound_query/3` — after binding, values now visible.
+4. `apply_filters/3`, then `apply_sorts/3` — filter and sort column names are
+   run through `validate_identifier/3` and operators through
+   `supported_filter_operators/1` before dispatch.
+5. `apply_pagination/3` — sees a statement that already carries filters and
+   sorts.
+6. `sanitize_query/3` — inside `Lotus.Runner.run_statement/3`, after the
+   `:before_query` middleware may have rewritten the statement.
+7. `needs_preflight?/2` → `extract_accessed_resources/2` — visibility preflight.
+8. `execute_query/4` — the driver boundary.
 
 ## Exact counts — two adapter strategies
 
 When the caller requests `count: :exact`, the adapter picks one of two
 strategies to surface the pre-pagination total:
 
-**Strategy A — inline count** (new for engines where count comes back with
-the data). `execute_query/4` includes `:total_count` directly in its result
-map:
+**Strategy A — inline count**, for engines where the count comes back with the
+data. `execute_query/4` includes `:total_count` directly in its result map:
 
 ```elixir
 {:ok, %{columns: [...], rows: [...], num_rows: 3, total_count: 1_247}}
@@ -164,7 +204,26 @@ config :lotus,
 ```
 
 All keys are optional. When omitted, the defaults read from static application
-config.
+config (`Lotus.Source.Resolvers.Static` and
+`Lotus.Visibility.Resolvers.Static`).
+
+`:allow_unrestricted_resources` is also a **reserved key inside a source's own
+config map**, where it overrides the global flag for that source in both
+directions — `true` opts a single source in under a strict global default,
+`false` keeps one source locked down under a permissive one:
+
+```elixir
+config :lotus,
+  allow_unrestricted_resources: false,
+  data_sources: %{
+    "main"   => MyApp.Repo,
+    "search" => %{
+      adapter: MyApp.Adapters.Elasticsearch,
+      url: "http://localhost:9200",
+      allow_unrestricted_resources: true
+    }
+  }
+```
 
 ## Building a Custom Adapter
 
@@ -174,20 +233,28 @@ Two paths, depending on whether your data source uses Ecto.
 
 Use this when Ecto already ships a driver for the database (e.g. `Tds` for
 MSSQL) but Lotus does not ship a built-in dialect for it.
+[`lotus_clickhouse`](https://github.com/elixir-lotus/lotus_clickhouse) is a
+shipped example of this path.
 
 1. Write a **Dialect module** implementing `Lotus.Source.Adapters.Ecto.Dialect`.
    The dialect encapsulates all SQL-specific behaviour (dialect-specific
    placeholder syntax, identifier quoting, EXPLAIN variant, introspection
-   queries, built-in deny rules).
+   queries, built-in deny rules). `Lotus.Source.Adapters.Ecto.Dialect` is a
+   **public, documented contract** — external SQL adapters are expected to
+   implement it rather than the universal behaviour directly.
 2. Write an **adapter module** that pulls in the shared Ecto machinery via
    `use Lotus.Source.Adapters.Ecto, dialect: ...`. The macro injects default
    implementations for every `Lotus.Source.Adapter` callback, delegating to
    the dialect where appropriate. All callbacks are `defoverridable`.
-3. **Register** via `:source_adapters`.
+3. **Register** the adapter module in `:source_adapters`. The macro-generated
+   `can_handle?/1` claims any repo whose `__adapter__/0` equals your dialect's
+   `ecto_adapter/0`, so `data_sources` entries stay plain repo modules.
 
 ```elixir
 defmodule MyApp.Dialects.MSSQL do
   @behaviour Lotus.Source.Adapters.Ecto.Dialect
+
+  alias Lotus.Query.Statement
 
   # -- Identity ---------------------------------------------------------------
   @impl true
@@ -225,6 +292,15 @@ defmodule MyApp.Adapters.MSSQL do
 end
 ```
 
+The macro asserts at compile time that `:dialect` is a module implementing
+`Lotus.Source.Adapters.Ecto.Dialect` (skipped when the dialect is still being
+co-compiled, where Elixir's own `@behaviour` warnings catch mismatches).
+
+Two SQL primitives that were universal callbacks before v1 —
+`param_placeholder/3` and `limit_offset_placeholders/2` — live on the dialect
+only. They are prepared-statement details, and nothing outside the Ecto path
+calls them.
+
 #### Dialect callbacks
 
 Callbacks are organized by category. All required callbacks must be
@@ -259,23 +335,35 @@ ignores a caller-supplied `:search_path` for that source.
 | `describe_table/3` | Introspection |
 | `resolve_table_namespace/3` | Introspection |
 
-**Optional** (defaults provided by `Lotus.Source.Adapters.Ecto`):
+**Optional** (defaults supplied by `Lotus.Source.Adapters.Ecto`) — the exact
+list in `@optional_callbacks` on `Lotus.Source.Adapters.Ecto.Dialect`:
 
-| Callback | Category | Default |
+| Callback | Category | Default when not implemented |
 |---|---|---|
-| `supports_feature?/1` | Identity | Returns `false` |
+| `set_statement_timeout/2` | Transaction & session | Not called; Lotus relies on the driver-level `:timeout` passed to `execute_query/4` |
+| `set_search_path/2` | Transaction & session | Not called; a caller-supplied `:search_path` is ignored for that source |
+| `supports_feature?/1` | Identity | `false` for every feature |
 | `hierarchy_label/0` | Identity | `"Tables"` |
 | `example_query/2` | Identity | Generic `SELECT value_column FROM table` |
-| `editor_config/0` | Editor | Empty config (`%{language: "sql", keywords: [], ...}`) |
-| `extract_accessed_resources/2` | Visibility | Dialect-specific SQL analysis via `EXPLAIN` + fallback |
+| `editor_config/0` | Editor | `%{language: "sql", keywords: [], types: [], functions: [], context_boundaries: []}` |
+| `ai_context/0` | AI | Generic-SQL context synthesized from `query_language/0`, with an empty `:error_patterns` list |
+| `extract_accessed_resources/2` | Visibility | `{:unrestricted, "dialect ... does not implement extract_accessed_resources/2"}` — visibility is **not** enforced until you implement it |
+| `needs_preflight?/1` | Visibility | The Ecto adapter's SQL heuristic: `false` for statements starting with `EXPLAIN`, `SHOW` or `PRAGMA`, `true` otherwise |
 | `transform_statement/1` | Statement rewriting | Statement unchanged |
-| `needs_preflight?/1` | Visibility | Dialect-specific (skips `EXPLAIN`, `SHOW`, `PRAGMA`) |
-| `db_type_to_lotus_type/1` | Type mapping | Maps common SQL types to Lotus types |
+| `db_type_to_lotus_type/1` | Type mapping | `:text` |
+
+Statement-carrying dialect callbacks (`apply_filters/2`, `apply_sorts/2`,
+`query_plan/3`, `limit_query/2`, `transform_statement/1`,
+`needs_preflight?/1`, `extract_accessed_resources/2`) take and return
+`%Lotus.Query.Statement{}`, where `statement.body` is always SQL text and
+`statement.params` the bound values in driver order.
 
 ### B. Non-Ecto adapter (REST, document store, DSL)
 
 Use this for data sources that do not use Ecto at all — Elasticsearch, Mongo,
-ClickHouse's native DSL, a REST API.
+a REST API.
+[`lotus_elasticsearch`](https://github.com/elixir-lotus/lotus_elasticsearch)
+is a shipped example of this path.
 
 Implement `Lotus.Source.Adapter` directly. Lotus ships a first-party reference
 implementation in its own test suite at
@@ -283,23 +371,32 @@ implementation in its own test suite at
 an in-memory DSL-map adapter that exercises the full contract. A copy of it
 makes a useful starting point for a new adapter.
 
-Below is an abbreviated stub showing the shape of every required callback —
-see the in-memory adapter for full implementations and the DSL-to-rows
-executor.
+The compiler only demands the nine callbacks that have no default —
+`execute_query/4`, `transaction/3`, `list_tables/3`, `describe_table/3`,
+`builtin_denies/1`, `health_check/1`, `disconnect/1`, `format_error/2` and
+`source_type/1`. Everything else is optional with a documented default (see
+[Required vs Optional Callbacks](#required-vs-optional-callbacks)), but a
+useful adapter implements well beyond the minimum — in particular
+`extract_accessed_resources/2`, without which every statement is blocked by
+preflight unless the operator opts the source out of visibility enforcement.
+
+Below is an abbreviated stub — see the in-memory adapter for full
+implementations and the DSL-to-rows executor.
 
 ```elixir
 defmodule MyApp.Adapters.Echo do
   @behaviour Lotus.Source.Adapter
 
-  alias Lotus.Query.Statement
-
   # -- Registration -----------------------------------------------------------
+  # `wrap/2` receives the whole `data_sources` entry and returns the struct.
+  # `can_handle?/1` is only consulted for entries that do NOT name their
+  # adapter module — see "Registration" below.
   @impl true
   def can_handle?(%{adapter: :echo}), do: true
   def can_handle?(_), do: false
 
   @impl true
-  def wrap(name, %{adapter: :echo} = config) do
+  def wrap(name, config) when is_binary(name) and is_map(config) do
     %Lotus.Source.Adapter{
       name: name,
       module: __MODULE__,
@@ -309,15 +406,16 @@ defmodule MyApp.Adapters.Echo do
   end
 
   # -- Query execution --------------------------------------------------------
-  # The :statement argument is whatever query language the source understands
-  # (SQL, JSON DSL, Cypher, etc.). Return a result map with :columns, :rows,
-  # :num_rows — Lotus wraps it into %Lotus.Result{}.
+  # Core unwraps the statement here: `body` is `statement.body` and `params`
+  # is `statement.params`, whatever your query language makes of them. Return
+  # a result map with :columns, :rows, :num_rows (plus :total_count when you
+  # use the inline count strategy) — Lotus wraps it into %Lotus.Result{}.
   @impl true
-  def execute_query(_state, statement, params, _opts) do
+  def execute_query(_state, body, params, _opts) do
     {:ok,
      %{
        columns: ["statement", "param_count"],
-       rows: [[inspect(statement), length(params)]],
+       rows: [[inspect(body), length(params)]],
        num_rows: 1
      }}
   end
@@ -392,31 +490,57 @@ defmodule MyApp.Adapters.Echo do
 end
 ```
 
-Register it and use it like any other source:
+Register it and use it like any other source. The canonical entry names the
+adapter module outright, so no `:source_adapters` registration is needed. This
+adapter does not implement `extract_accessed_resources/2`, so preflight would
+block every statement — the source opts out of visibility enforcement
+explicitly:
 
 ```elixir
 config :lotus,
-  source_adapters: [MyApp.Adapters.Echo],
-  data_sources: %{"echo" => %{adapter: :echo}}
+  data_sources: %{
+    "echo" => %{
+      adapter: MyApp.Adapters.Echo,
+      allow_unrestricted_resources: true
+    }
+  }
 
 {:ok, result} = Lotus.run_statement("hello", [1, 2, 3], repo: "echo")
 # result.rows #=> [["\"hello\"", 3]]
 ```
 
+A real adapter implements `extract_accessed_resources/2` instead of opting
+out.
+
 ## Required vs Optional Callbacks
 
-The full `Lotus.Source.Adapter` contract has ~30 callbacks. Most non-SQL
-adapters implement every one of them; the optional list is for adapters that
-legitimately cannot support a feature.
+The full `Lotus.Source.Adapter` contract is 41 callbacks, nine of which are
+required. Most non-SQL adapters implement far more than the minimum; the
+optional list is for adapters that legitimately cannot support a feature.
 
-**Optional with documented defaults** — omit when not applicable:
+**Required** — no default; the compiler warns if you omit one:
+
+| Callback | Purpose |
+|---|---|
+| `execute_query(state, body, params, opts)` | The driver boundary. Returns `{:ok, %{columns:, rows:, num_rows:}}`, optionally with `:total_count`. |
+| `transaction(state, fun, opts)` | Run `fun` (arity 1, receives `state`) inside a transaction. |
+| `list_tables(state, schemas, opts)` | `{:ok, [{schema_or_nil, table}]}`. `opts` carries `:include_views`. |
+| `describe_table(state, schema, table)` | `{:ok, [column_def]}` — `%{name, type, nullable, default, primary_key}`. |
+| `builtin_denies(state)` | Always-hidden relations, as `{schema_pattern, table_pattern}` tuples. |
+| `health_check(state)` | `:ok` or `{:error, reason}`. |
+| `disconnect(state)` | Release resources. |
+| `format_error(state, error)` | Driver error → human-readable string. |
+| `source_type(state)` | The source-type atom. Open — any atom your adapter declares. |
+
+**Optional with documented defaults** — omit when not applicable. This table
+mirrors `@optional_callbacks` in `Lotus.Source.Adapter`:
 
 | Callback | Default | When to implement |
 |---|---|---|
-| `sanitize_query/3` | `:ok` | When you need to block specific statement shapes (read-only enforcement, destructive-op blocking). |
-| `transform_statement/2` | statement unchanged | Dialect-specific rewrites applied **before** variable binding. |
+| `sanitize_query/3` | `:ok` | When you need to block specific statement shapes (read-only enforcement, destructive-op blocking). `opts` carries `:read_only`. |
+| `transform_statement/2` | statement unchanged | Language-specific rewrites of the stored template, applied **before** `{{var}}` placeholders are extracted (`params` is still `[]`). |
 | `transform_bound_query/3` | statement unchanged | Rewrites applied **after** variable binding (when values are visible). |
-| `apply_pagination/3` | statement unchanged | Support `window: [limit:, offset:, count:]` in your source's native syntax. |
+| `apply_pagination/3` | statement unchanged | Page a statement in your source's native syntax. `opts` carries `:limit` (required), `:offset`, `:count` and `:search_path`. |
 | `needs_preflight?/2` | `true` | Skip preflight for read-only introspection statements (`EXPLAIN`, `SHOW`, `PRAGMA`, etc.). |
 | `substitute_variable/5` | `{:error, :unsupported}` | Support `{{var}}` in stored queries. **Security boundary — see below.** |
 | `substitute_list_variable/5` | `{:error, :unsupported}` | Support list variables. |
@@ -438,10 +562,71 @@ legitimately cannot support a feature.
 | `quote_identifier/2` | identifier unchanged | Quote an identifier. Languages without quoting omit it. |
 | `apply_filters/3` | statement unchanged | Bake runtime filters into the statement. |
 | `apply_sorts/3` | statement unchanged | Bake runtime sorts into the statement. |
-| `query_plan/3` | `{:ok, nil}` | Execution plan, when the engine exposes one. |
+| `query_plan/3` | `{:ok, nil}` | Execution plan, when the engine exposes one. Takes `(state, %Statement{}, opts)` — the statement carries its own bound values in `:params`, there is no separate params argument. Returning `{:ok, nil}` is legitimate for an engine with no plan. |
 | `supports_feature?/2` | `false` | Declare capabilities. See `t:Lotus.Source.Adapter.feature/0`. |
 | `db_type_to_lotus_type/2` | `:text` | Map engine column types onto Lotus value types. |
 | `editor_config/1` | empty editor shape | Keywords, types and functions for editor completions. |
+| `query_language/1` | `"sql"` | Declare the `family:dialect` identifier for your language. See [Query Language Identifiers](#query-language-identifiers). |
+| `can_handle?/1` | not consulted | Claim a `data_sources` entry that does not name your module. |
+| `wrap/2` | — | Build the `%Adapter{}` from a `data_sources` entry. Required in practice: the resolver calls it for every entry it routes to your adapter. |
+
+Two notes on that table. `can_handle?/1` and `wrap/2` are optional to the
+compiler because an adapter can be constructed by hand (or by a custom
+resolver), but any adapter registered through `:data_sources` needs `wrap/2`.
+And a default that returns "nothing" is not always the safe choice:
+`extract_accessed_resources/2` defaulting to `{:unrestricted, _}` means an
+adapter that omits it enforces no visibility at all.
+
+## Universal Callbacks
+
+Five callbacks exist so non-SQL sources reach parity with the SQL path
+instead of being special-cased in core:
+
+- **`validate_statement(state, statement, opts)`** — can the engine parse and
+  prepare this statement without running it? SQL adapters implement it with
+  `EXPLAIN`; Elasticsearch uses `_validate`; an engine with no such endpoint
+  omits the callback and inherits `:ok` (trust-on-execute). Callers
+  neutralize unbound `{{var}}` placeholders first — adapters see the
+  statement as-is.
+- **`parse_qualified_name(state, name)`** — `{:ok, [component]}`, coarsest
+  first, leaf last, at most two components. `"public.users"` →
+  `["public", "users"]`; a flat index name → `["logs-2025-01"]`.
+- **`validate_identifier(state, kind, value)`** — `kind` is `:schema`,
+  `:table` or `:column`. Core calls this on filter and sort column names
+  before dispatching them to `apply_filters/3` / `apply_sorts/3`; an
+  identifier your adapter rejects raises `ArgumentError`. The default is
+  permissive, so declare your grammar if user-supplied names reach your
+  statement builder.
+- **`supported_filter_operators(state)`** — the `Lotus.Query.Filter`
+  operators your `apply_filters/3` actually handles. Core raises
+  `Lotus.UnsupportedOperatorError` on anything outside the list rather than
+  degrading silently, and `Lotus.Source.supported_filter_operators/1` gates
+  the operator dropdown per source. The default is every operator in
+  `Lotus.Query.Filter.operators/0`, so narrow it if you cannot implement them
+  all.
+- **`needs_preflight?(state, statement)`** — `false` for read-only
+  introspection statements that touch no visible relation. Core no longer
+  sniffs SQL prefixes; this callback owns the skip path. The built-in Ecto
+  adapter keeps the `EXPLAIN` / `SHOW` / `PRAGMA` heuristic internally.
+
+## Declaring Features
+
+`supports_feature?(state, feature)` answers capability questions from core and
+the built-in UI. The feature type is open — answer `false` for anything you do
+not recognise (a catch-all clause) — but these atoms have defined meaning:
+
+| Feature | Meaning |
+|---|---|
+| `:schema_hierarchy` | The source has a real namespace level above tables, so the UI shows a schema picker. False for flat sources (SQLite, Elasticsearch) and for MySQL, whose databases are configured per source. |
+| `:search_path` | The source honours a session-level namespace search path, so a caller-supplied `:search_path` is meaningful. |
+| `:arrays` | The query language has a first-class array type, so a list variable can bind as one value instead of N placeholders. |
+| `:json` | The source can store and query JSON documents; the editor offers JSON-aware affordances. |
+| `:make_interval` | SQL-specific: the engine has `make_interval`, so `INTERVAL '{{n}} days'` can be rewritten into a parameterized call instead of inlining the value. |
+| `:dynamic_options` | A query against this source can return a flat list of values suitable for a variable's dropdown, so the UI offers query-based option population. True for every SQL source; false where the language returns shaped documents rather than rows (Elasticsearch), and the user types the options by hand. |
+
+`source_type/1` is likewise an open atom: `:postgres`, `:mysql`, `:sqlite`,
+`:other`, or whatever your adapter declares (`:clickhouse`,
+`:elasticsearch`). Core never matches on an exhaustive list.
 
 ## The Security Boundaries
 
@@ -450,9 +635,14 @@ injection or authorization gaps.
 
 ### 1. `substitute_variable/5` — adapter owns injection safety
 
-When a stored query contains `{{var_name}}`, Lotus calls your adapter's
-`substitute_variable/5` with the already-cast value. The adapter decides how
-to embed it:
+When a stored query contains `{{var_name}}`, `Lotus.Storage.Query.compile/2`
+folds each variable through your adapter — `substitute_variable(state,
+statement, var_name, value, type)` for a scalar, `substitute_list_variable(
+state, statement, var_name, values, type)` for a list — and each call returns
+`{:ok, %Statement{}}` or `{:error, reason}`. The value arrives already cast by
+core; `type` is the resolved Lotus type atom (`:integer`, `:uuid`, …), which
+you may ignore. Core never touches placeholders or param arrays itself. The
+adapter decides how to embed the value:
 
 - **SQL prepared-statement adapters** (`Lotus.Source.Adapters.Ecto`) append a
   placeholder (`$1`, `?`, …) to `statement.body` and push the value into
@@ -638,7 +828,7 @@ context boundaries for the web UI's editor:
 @impl true
 def editor_config(_state) do
   %{
-    language: "sql",
+    language: "sql:clickhouse",
     keywords: ~w(PREWHERE FINAL SAMPLE SETTINGS FORMAT ENGINE),
     types:    ~w(UInt8 UInt64 Float64 Array LowCardinality Nullable),
     functions: [
@@ -651,16 +841,62 @@ def editor_config(_state) do
 end
 ```
 
-Fields:
+Required fields:
 
-- `language` — parser to use on the JS side (`"sql"` for all SQL dialects, or
-  your own language identifier for custom editors)
-- `keywords` — dialect-specific keywords merged with standard keywords
-- `types` — dialect-specific type names
-- `functions` — name + description + argument template
+- `language` — the query-language identifier (`"sql:postgres"`,
+  `"json:elasticsearch"`, …). Drives CodeMirror language selection.
+- `keywords`, `types` — flat lists feeding the "complete any keyword anywhere"
+  fallback (used when `:context_schema` is absent) and the AI prompt pipeline.
+- `functions` — `%{name, detail, args}` entries for signature help.
 - `context_boundaries` — keywords that mark clause boundaries for
   context-aware completions (e.g. ClickHouse's `PREWHERE` is treated like
-  `WHERE` for column suggestions)
+  `WHERE` for column suggestions). SQL-only; ignored for JSON DSLs.
+
+Optional fields:
+
+- `dialect_spec` — SQL tokenizer options, forwarded verbatim (camelCased) to
+  CodeMirror 6's `SQLDialect.define()`, so an external SQL adapter reaches
+  tokenization parity with the built-in grammars. Only meaningful for SQL
+  languages; an adapter that sits on a built-in CM6 dialect (Postgres, MySQL,
+  SQLite, MSSQL, MariaSQL, Cassandra, PLSQL) omits it and gets that grammar.
+  Keys mirror `@codemirror/lang-sql`'s `SQLDialectSpec` — see
+  `t:Lotus.Source.Adapter.dialect_spec/0`.
+
+  ```elixir
+  dialect_spec: %{
+    identifier_quotes: "`",
+    hash_comments: true,
+    double_quoted_strings: false,
+    case_insensitive_identifiers: true
+  }
+  ```
+
+- `context_schema` — structural schema for a JSON DSL, driving parent-aware
+  completion (only `must` / `should` / `filter` inside Elasticsearch's `bool`,
+  field names inside `match`). Omit it for SQL adapters; omitting it in a JSON
+  DSL adapter degrades the editor to flat keyword suggestions at every key
+  position. `:children` values are either a list of valid child keys or one of
+  the marker atoms `:fields`, `:array_of_query`, `:named_aggregation`,
+  `:range_operators` — see `t:Lotus.Source.Adapter.context_schema/0`.
+
+  ```elixir
+  context_schema: %{
+    root: ["query", "aggs", "sort"],
+    children: %{
+      "query" => ["match", "term", "bool"],
+      "bool" => ["must", "should", "filter"],
+      "must" => :array_of_query,
+      "match" => :fields
+    },
+    value_literals: %{"order" => ["asc", "desc"]}
+  }
+  ```
+
+Unknown top-level keys are dropped at the dispatch layer, and `:keywords`
+(2000), `:types` (2000), `:functions` (500), `:context_schema.root` (200) and
+`:context_schema.children` (500) are truncated past those limits with a
+one-time `Logger.warning/1` per adapter — a large payload otherwise ships to
+every editor session.
 
 For large function lists, extract into a dedicated `EditorConfig` submodule
 (see `lotus_clickhouse` for an example with 300+ functions).
@@ -745,28 +981,51 @@ established meaning and are kept for recognizability:
 
 ## Registration
 
-Custom adapters are registered via `:source_adapters`:
+A `:data_sources` entry takes one of three forms, and the form decides how the
+default resolver finds the adapter.
+
+**1. `%{adapter: Module, ...}` — the canonical form.** The named module is used
+directly: no probing, no ambiguity, and the whole map is handed to its
+`wrap/2` as state. Prefer it. The module must be loaded and export `wrap/2`,
+or resolution raises with the offending entry.
 
 ```elixir
 config :lotus,
-  source_adapters: [MyApp.Adapters.MSSQL, MyApp.Adapters.Elasticsearch]
+  data_sources: %{
+    "search" => %{adapter: MyApp.Adapters.Elasticsearch, url: "http://localhost:9200"}
+  }
 ```
 
-**Resolution order.** When the resolver wraps a `:data_sources` entry:
+**2. An `Ecto.Repo` module.** Matched against the built-in Ecto adapters by the
+repo's Ecto adapter — `Ecto.Adapters.Postgres` → `Lotus.Source.Adapters.Postgres`,
+`Ecto.Adapters.MyXQL` → `MySQL`, `Ecto.Adapters.SQLite3` → `SQLite3` — falling
+back to the generic `Lotus.Source.Adapters.Ecto` with the `Default` dialect.
 
-1. External adapters (from `:source_adapters`), in list order
-2. Built-in per-dialect adapters (`Adapters.Postgres`, `Adapters.MySQL`,
-   `Adapters.SQLite3`)
-3. Generic Ecto fallback (`Adapters.Ecto` with `Default` dialect)
+**3. Any other term** (a map with no adapter module, a tuple, a tagged atom).
+Offered to every module in `:source_adapters` plus the built-in Ecto adapters
+via `can_handle?/1`:
 
-The first adapter whose `can_handle?/1` returns `true` wins. External adapters
-can override built-in handling for a given Ecto adapter if needed.
+```elixir
+config :lotus,
+  source_adapters: [MyApp.Adapters.MSSQL, MyApp.Adapters.Echo]
+```
+
+**Exactly one adapter must claim the entry.** If several return `true` from
+`can_handle?/1`, resolution **raises** rather than picking the first — the
+error names the competing modules and tells the operator to settle it by
+naming the adapter in the entry. If none claims it and the entry is an atom,
+it falls back to the Ecto adapter; if none claims a non-atom entry,
+resolution raises.
+
+Probing is a convenience, not a priority list. An adapter whose
+`can_handle?/1` is broad will collide with another one sooner or later — form
+1 is the way out.
 
 ## Custom Resolvers
 
 Both extension points feeding the adapter pipeline are pluggable behaviours:
 
-- `Lotus.Source.Resolver` — resolves repo opts into `%Adapter{}` structs
+- `Lotus.Source.Resolver` — resolves a source name or module into an `%Adapter{}` struct
 - `Lotus.Visibility.Resolver` — loads schema / table / column visibility rules
 
 Both ship with static defaults (`Lotus.Source.Resolvers.Static`,
@@ -782,7 +1041,16 @@ See the [Custom Resolvers guide](custom-resolvers.md) for contracts, full
 - [`test/support/in_memory_adapter.ex`](../test/support/in_memory_adapter.ex)
   — first-party non-SQL reference adapter (DSL-map payloads, capability gates,
   ai_context) shipped in Lotus's own test suite.
-- [`lotus_elasticsearch`](https://github.com/elixir-lotus/lotus_elasticsearch) —
-  real-world non-Ecto adapter against the Elasticsearch Query DSL.
 - [`lotus_clickhouse`](https://github.com/elixir-lotus/lotus_clickhouse) —
-  external Ecto-backed adapter with a large `editor_config`.
+  worked example of **path A**: an Ecto-backed adapter speaking SQL over HTTP,
+  built from a dialect module plus a one-line
+  `use Lotus.Source.Adapters.Ecto`, with a large `editor_config` and a
+  `dialect_spec`.
+- [`lotus_elasticsearch`](https://github.com/elixir-lotus/lotus_elasticsearch) —
+  worked example of **path B**: a non-SQL adapter over the Elasticsearch JSON
+  Query DSL. Shows inlined (escaped) variable substitution, the inline count
+  strategy, `{:unrestricted, _}` visibility, and a `context_schema` for the
+  editor.
+
+Both packages were written against this guide; if something here disagrees
+with `Lotus.Source.Adapter`, the behaviour module is the authority.

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -11,22 +11,39 @@ with monitoring tools like Phoenix LiveDashboard, AppSignal, Datadog, and others
 | Event                         | Measurements                   | Metadata                                      |
 |-------------------------------|--------------------------------|-----------------------------------------------|
 | `[:lotus, :query, :start]`    | `system_time`                  | `source`, `statement`, `context`                         |
-| `[:lotus, :query, :stop]`     | `duration`, `row_count`        | `source`, `statement`, `context`, `result`               |
+| `[:lotus, :query, :stop]`     | `duration`, `row_count`        | `source`, `statement`, `context`, `row_count`, `result`  |
 | `[:lotus, :query, :exception]`| `duration`                     | `source`, `statement`, `context`, `kind`, `reason`, `stacktrace` |
 
 Duration is measured in native time units. Use `System.convert_time_unit/3` to
-convert to milliseconds or microseconds.
+convert to milliseconds or microseconds. On `:stop`, `row_count` appears in both
+the measurements and the metadata — it is the same value.
 
 The `source` field is the data source name (`"main"`, `"warehouse"`), not a
 repo module. The `statement` field is a `%Lotus.Query.Statement{}`: read
 `statement.body` for the adapter-native payload (SQL text for Ecto-backed
 sources, a JSON object or AST for others) and `statement.params` for the bound
-values.
+values. Pre-v1 `:repo`, `:sql` and `:params` metadata keys are gone.
 
 The `context` field carries whatever value the caller passed as the `:context`
 option to `Lotus.run_statement/3` or `Lotus.run_query/2`. It defaults to `nil` when
 not provided. Typical uses include request IDs, controller names, or
-OpenTelemetry span contexts for trace correlation.
+OpenTelemetry span contexts for trace correlation. The `:scope` option is **not**
+in the metadata — it is caller identity used for cache keys and visibility, not
+instrumentation.
+
+The events bracket the whole `Lotus.Runner` pipeline, so `:start` fires before
+middleware, sanitization and preflight run. Any failure among those — a halted
+`:before_query` plug, a denied table, a driver error — ends the run at
+`:exception`, not `:stop`.
+
+Because Lotus turns those failures into `{:error, reason}` rather than letting
+them raise, the `:exception` metadata is uniform: `kind` is always `:error`,
+`reason` is the `{:error, reason}` tuple the caller receives, and `stacktrace`
+is `[]`. Match on `reason` rather than expecting an exception struct.
+
+Query telemetry is emitted from the runner, which sits **inside** the result
+cache. A query served from cache emits no `[:lotus, :query, *]` events at all;
+`[:lotus, :cache, :hit]` is the event to count for those.
 
 ### Cache Operations
 
@@ -44,7 +61,13 @@ OpenTelemetry span contexts for trace correlation.
 | `[:lotus, :schema, :introspection, :stop]`  | `duration`    | `operation`, `repo`, `result` |
 
 The `operation` field is one of: `:list_schemas`, `:list_tables`,
-`:get_table_schema`, `:get_table_stats`, or `:list_relations`.
+`:describe_table`, `:get_table_stats`, or `:list_relations`.
+
+The `result` field is `:ok` or `:error`.
+
+> **Note:** these two events kept the metadata key `:repo`, unlike the query
+> events which renamed it to `:source`. The value is the same thing in both —
+> the data source *name* (`"main"`), not an Ecto repo module.
 
 ## Setup
 
@@ -97,7 +120,8 @@ defmodule MyApp.LotusInstrumentation do
       "Lotus query failed",
       duration_ms: duration_ms,
       reason: inspect(metadata.reason),
-      source: metadata.source
+      source: metadata.source,
+      statement: inspect(metadata.statement.body)
     )
   end
 

--- a/guides/visibility.md
+++ b/guides/visibility.md
@@ -1,41 +1,64 @@
 # Visibility Rules
 
-Lotus provides a comprehensive visibility system that controls which schemas and tables are accessible through the API. This system operates on two levels with clear precedence rules to ensure security while maintaining flexibility.
+Lotus decides what a query and an explorer are allowed to see with one
+rule set, applied at three levels: **schemas** (namespaces), **tables**
+and **columns**. The levels have a clear precedence, so security holds by
+default while leaving room for fine-grained exceptions.
 
 ## Overview
 
-The visibility system uses a **two-level hierarchy**:
+1. **Schema visibility** — highest precedence. A denied schema blocks
+   every table in it, whatever the table rules say.
+2. **Table visibility** — checked only inside allowed schemas.
+3. **Column visibility** — applied to the columns of a result set and to
+   the output of `Lotus.describe_table/3`.
 
-1. **Schema visibility** (higher precedence)
-2. **Table visibility** (lower precedence)
+Rules are enforced in three places:
 
-**Key principle**: If a schema is denied, all tables within it are automatically blocked, regardless of table-level rules.
+- **Discovery** — `Lotus.list_schemas/2`, `list_tables/2`,
+  `list_relations/2`, `describe_table/3` and `get_table_stats/3` filter
+  their results.
+- **Execution preflight** — before a statement runs, Lotus asks the
+  adapter which relations the statement touches and blocks the query if
+  any of them is denied. This catches access through views and
+  subqueries.
+- **Result columns** — column policies omit, mask or reject columns in
+  the returned rows.
 
 ## Database-Specific Schema Behavior
 
-Understanding how "schemas" work across different database systems is crucial for configuring visibility rules correctly:
+"Schema" means namespace throughout Lotus, and namespaces differ per
+engine:
 
 ### PostgreSQL
-- **True namespaced schemas**: Multiple schemas exist within a single database
+- **True namespaced schemas**: several schemas inside one database
 - **Examples**: `public`, `reporting`, `analytics`, `tenant_123`
 - **System schemas**: `pg_catalog`, `information_schema`, `pg_toast`, `pg_temp_*`
 - **Qualified names**: `reporting.customers`, `public.users`
 
 ### MySQL
-- **Schemas = Databases**: In MySQL, "schema" and "database" are synonymous
+- **Schemas = databases**: the two words mean the same thing
 - **Examples**: `lotus_production`, `analytics_db`, `warehouse`
 - **System schemas**: `mysql`, `information_schema`, `performance_schema`, `sys`
-- **Behavior**: When you connect to MySQL, you can access tables across different databases/schemas
 - **Qualified names**: `analytics_db.customers`, `warehouse.sales`
 
 ### SQLite
-- **No schema support**: SQLite is schema-less
-- **Schema visibility**: Not applicable (always empty list)
-- **Tables**: Exist at the database level without namespace prefixes
+- **No namespaces**: `Lotus.list_schemas/2` returns `[]`
+- Relations are `{nil, table}`; schema rules do not apply
+
+### Engines with a deeper hierarchy
+
+Lotus names every resource as exactly two levels, `{schema | nil,
+table}`. An adapter for an engine with more levels flattens everything
+above the leaf into the schema part, keeping its own separator — BigQuery
+`project.dataset.table` becomes `{"project.dataset", "table"}`. Core
+compares that string verbatim, so write your rules in the flattened
+spelling the adapter emits.
 
 ## Configuration
 
-Configure visibility rules in your application config:
+Visibility rules live in your application config, keyed by data source
+name (matching a key of `:data_sources`) or `:default`:
 
 ```elixir
 config :lotus,
@@ -43,10 +66,9 @@ config :lotus,
   schema_visibility: %{
     default: [
       deny: ["restricted_schema", ~r/^temp_/],
-      allow: :all  # or specific schemas
+      allow: :all  # or a list of specific schemas
     ],
     postgres: [
-      # Only allow public and tenant schemas
       allow: ["public", ~r/^tenant_\d+$/],
       deny: ["legacy_schema"]
     ],
@@ -64,31 +86,33 @@ config :lotus,
       allow: []  # empty = allow all (except denied)
     ],
     postgres: [
-      # Data warehouse example
       allow: [
         {"public", ~r/^dim_/},      # Dimension tables
         {"public", ~r/^fact_/},     # Fact tables
         {"analytics", ~r/.*/}       # All analytics tables
       ],
       deny: [
-        {"public", ~r/^staging_/},  # Block staging tables
-        {"public", ~r/_temp$/}      # Block temp tables
+        {"public", ~r/^staging_/},
+        {"public", ~r/_temp$/}
       ]
     ]
   }
 ```
 
+The source keys are matched by name against the entries of
+`:data_sources` (renamed from `:data_repos` in v1). A source with no
+entry of its own falls back to `:default`.
+
 ## Rule Syntax
 
 ### Schema Rules
 
-Schema rules use simpler patterns since they only match schema names:
+Schema rules match a namespace name:
 
-- `"exact_name"` - Matches exact schema name
-- `~r/pattern/` - Regex pattern for dynamic matching
-- `:all` - Special value for allow rules (allows all schemas)
+- `"exact_name"` — exact match
+- `~r/pattern/` — regex match
+- `:all` — allow value that permits every schema
 
-**Examples**:
 ```elixir
 allow: ["public", "reporting", ~r/^tenant_\w+$/]
 deny: ["restricted", ~r/^temp_/]
@@ -96,70 +120,72 @@ deny: ["restricted", ~r/^temp_/]
 
 ### Table Rules
 
-Table rules support multiple formats for maximum flexibility:
+Table rules take several shapes:
 
-- `{"schema", "table"}` - Exact schema.table match
-- `{"schema", ~r/pattern/}` - Regex table pattern in specific schema
-- `{~r/schema_pattern/, "table"}` - Table in schemas matching pattern
-- `"table"` - Table name in any schema (global rule)
+- `{"schema", "table"}` — exact schema + table
+- `{"schema", ~r/pattern/}` — table pattern inside one schema
+- `{~r/schema_pattern/, "table"}` — table in every matching schema
+- `{nil, "table"}` — table in a source with no namespace (SQLite)
+- `"table"` — table name in any schema (global rule)
 
-**Examples**:
 ```elixir
 allow: [
   {"public", "users"},           # Specific table
-  {"reporting", ~r/^daily_/},    # Tables starting with "daily_" in reporting
-  {~r/^tenant_/, "customers"},   # customers table in any tenant schema
-  "products"                     # products table in any schema
+  {"reporting", ~r/^daily_/},    # daily_* in reporting
+  {~r/^tenant_/, "customers"},   # customers in every tenant schema
+  "products"                     # products in any schema
 ]
 ```
 
+A `nil` schema pattern matches only a relation whose schema is `nil` or
+`""`. That keeps SQLite-shaped rules from matching PostgreSQL relations.
+
 ## Precedence and Evaluation
 
-### 1. Schema Gating (First)
+### 1. Schema gating (first)
+
 ```elixir
-if not allowed_schema?(schema) do
+if not allowed_schema?(source, schema) do
   deny  # Schema denied → everything in it blocked
 else
   # Schema allowed → proceed to table rules
 end
 ```
 
-### 2. Deny Always Wins (Second)
-```elixir
-if deny_rule_matches?(schema, table) do
-  deny  # Any deny rule blocks access
-else
-  # Check allow posture
-end
-```
+### 2. Deny always wins (second)
 
-### 3. Schema-Scoped Allow Posture (Third)
-For each schema, compute its "allow posture":
+Any matching deny rule — built-in or your own — blocks access, even if an
+allow rule also matches.
 
-- **Has allow posture**: Allow rules exist that could apply to this schema
-- **No allow posture**: No allow rules target this schema
+### 3. Schema-scoped allow posture (third)
+
+Allow rules are scoped to the schemas they name, not global. For a given
+schema, Lotus first collects the allow rules that could apply to it:
+
+- **Some rules target this schema** → default-deny: the relation must
+  match one of them.
+- **No rule targets this schema** → default-allow: everything not denied
+  is visible.
 
 ```elixir
 # Rules: allow: [{"restricted", "allowed_table"}]
 
-# For "restricted" schema:
-allow_posture? = true   # Has rule targeting "restricted"
-# → Default-deny: only "allowed_table" allowed
-
-# For "public" schema:
-allow_posture? = false  # No rules targeting "public"
-# → Default-allow: all tables allowed (unless denied)
+{"restricted", "any_table"}   # denied  — the schema has an allow posture
+{"restricted", "allowed_table"} # allowed
+{"public", "any_table"}       # allowed — no allow rule targets "public"
 ```
+
+Bare-string rules (`"products"`) carry no schema, so they never create an
+allow posture for a schema; they only widen what matches.
 
 ## Practical Examples
 
-### Multi-Tenant SaaS Application
+### Multi-tenant SaaS application
 
 ```elixir
 config :lotus,
   schema_visibility: %{
     postgres: [
-      # Only allow public and tenant schemas
       allow: ["public", ~r/^tenant_\d+$/],
       deny: ["admin_schema", "system_logs"]
     ]
@@ -168,12 +194,12 @@ config :lotus,
     postgres: [
       allow: [
         {"public", ~r/^shared_/},        # Shared lookup tables
-        {~r/^tenant_/, "users"},         # User table in each tenant
-        {~r/^tenant_/, "orders"},        # Order table in each tenant
-        {~r/^tenant_/, "products"}       # Product table in each tenant
+        {~r/^tenant_/, "users"},
+        {~r/^tenant_/, "orders"},
+        {~r/^tenant_/, "products"}
       ],
       deny: [
-        {~r/^tenant_/, "internal_logs"}, # Hide logs from all tenants
+        {~r/^tenant_/, "internal_logs"},
         "api_keys"                       # Hide API keys globally
       ]
     ]
@@ -181,12 +207,12 @@ config :lotus,
 ```
 
 **Result**:
-- ✅ `tenant_123.users` → Allowed
-- ✅ `public.shared_categories` → Allowed
-- ❌ `tenant_123.internal_logs` → Denied (table rule)
-- ❌ `admin_schema.anything` → Denied (schema rule)
+- `tenant_123.users` → allowed
+- `public.shared_categories` → allowed
+- `tenant_123.internal_logs` → denied (table rule)
+- `admin_schema.anything` → denied (schema rule)
 
-### Data Warehouse
+### Data warehouse
 
 ```elixir
 config :lotus,
@@ -199,20 +225,20 @@ config :lotus,
   table_visibility: %{
     postgres: [
       allow: [
-        {"public", ~r/^dim_/},         # Dimension tables
-        {"public", ~r/^fact_/},        # Fact tables
-        {"warehouse", ~r/.*/},         # All warehouse tables
-        {"analytics", ~r/^report_/}    # Only report tables in analytics
+        {"public", ~r/^dim_/},
+        {"public", ~r/^fact_/},
+        {"warehouse", ~r/.*/},
+        {"analytics", ~r/^report_/}
       ],
       deny: [
-        {"public", ~r/^raw_/},         # Hide raw data tables
-        {"warehouse", ~r/_backup$/}    # Hide backup tables
+        {"public", ~r/^raw_/},
+        {"warehouse", ~r/_backup$/}
       ]
     ]
   }
 ```
 
-### MySQL Multi-Database Setup
+### MySQL multi-database setup
 
 ```elixir
 config :lotus,
@@ -226,113 +252,269 @@ config :lotus,
   table_visibility: %{
     mysql: [
       allow: [
-        {"lotus_production", ~r/^public_/},    # Only public tables from main DB
-        {"analytics_warehouse", ~r/.*/},       # All analytics tables
-        {"reporting_db", ~r/^report_/}         # Only reports from reporting DB
+        {"lotus_production", ~r/^public_/},
+        {"analytics_warehouse", ~r/.*/},
+        {"reporting_db", ~r/^report_/}
       ],
       deny: [
-        "user_passwords",                      # Hide globally
-        {"lotus_production", ~r/^internal_/}   # Hide internal tables
+        "user_passwords",
+        {"lotus_production", ~r/^internal_/}
       ]
     ]
   }
 ```
 
-## Testing Visibility Rules
+## Scoped Rules
 
-You can test your visibility configuration using the programmatic API:
+Static config covers most applications. When the rules themselves depend
+on who is asking — a role, a tenant, a feature flag — implement
+`Lotus.Visibility.Resolver` and point the `:visibility_resolver` config
+key at it:
 
 ```elixir
-# Test schema visibility
+config :lotus, visibility_resolver: MyApp.VisibilityResolver
+```
+
+Every callback takes the source name and an opaque `scope`:
+
+```elixir
+defmodule MyApp.VisibilityResolver do
+  @behaviour Lotus.Visibility.Resolver
+
+  @impl true
+  def schema_rules_for(_source_name, %{role: :admin}), do: [allow: :all]
+  def schema_rules_for(_source_name, _scope), do: [allow: ["public"]]
+
+  @impl true
+  def table_rules_for(_source_name, %{tenant_id: id}),
+    do: [allow: [{"tenant_#{id}", ~r/.*/}, {"public", ~r/^shared_/}]]
+
+  def table_rules_for(source_name, _scope),
+    do: Lotus.Config.rules_for_source_name(source_name)
+
+  @impl true
+  def column_rules_for(source_name, _scope),
+    do: Lotus.Config.column_rules_for_source_name(source_name)
+end
+```
+
+The default resolver, `Lotus.Visibility.Resolvers.Static`, ignores scope
+and returns the config-based rules shown above.
+
+Callers pass the scope with the `:scope` option:
+
+```elixir
+{:ok, tables} = Lotus.list_tables("postgres", scope: %{tenant_id: 42})
+{:ok, columns} = Lotus.describe_table("postgres", "orders", scope: %{tenant_id: 42})
+```
+
+Scope is hashed into the discovery cache key, so each scope caches
+independently. Keep it low-cardinality (per role, per tenant) for a
+useful hit rate, and drop one scope's entries with:
+
+```elixir
+:ok = Lotus.invalidate_scope(%{tenant_id: 42})
+```
+
+A resolver that reads ambient runtime state (the process dictionary, for
+example) instead of its `scope` argument will cache incorrectly: the
+first caller's rules get stored under a key that ignores them. Pass the
+value as scope, or move the logic into middleware.
+
+See the [Custom Resolvers guide](custom-resolvers.md) for contracts and
+testing guidance.
+
+### Scoped rules are enforced at execution time
+
+As of v1, scoped rules are not a discovery-only filter. Execution
+preflight takes a scope too — `Lotus.Preflight.authorize/4` receives it,
+and `Lotus.Runner` passes the `:scope` option straight through:
+
+```elixir
+{:ok, result} = Lotus.run_query(query, scope: %{tenant_id: 42})
+{:ok, result} = Lotus.run_statement("SELECT * FROM orders", [], scope: %{tenant_id: 42})
+```
+
+**Pass the same scope to execution that you passed to discovery.** Omit
+it and only the unscoped rules apply at run time: a table your resolver
+hides from one tenant would disappear from the explorer while a query
+still returned its rows.
+
+## Execution Preflight
+
+Before running a statement, Lotus asks the adapter which relations the
+statement will touch, then checks each of them against the rules. For
+SQL sources this uses the engine's own planner, so a denied table reached
+through a view or a subquery is still caught.
+
+`c:Lotus.Source.Adapter.extract_accessed_resources/2` returns one of
+three things:
+
+| Return | Meaning |
+| --- | --- |
+| `{:ok, MapSet.t({schema \| nil, table})}` | the relations the statement touches |
+| `{:error, reason}` | extraction failed; the query is rejected with the formatted error |
+| `{:unrestricted, reason}` | this engine cannot say statically which resources a query reads |
+
+A blocked query returns:
+
+```elixir
+{:error, "Query touches blocked table(s): [\"public.api_keys\"]"}
+```
+
+Whether preflight runs at all is the adapter's decision, via
+`c:Lotus.Source.Adapter.needs_preflight?/2`. The built-in Ecto adapter
+skips it for `EXPLAIN` / `SHOW` / `PRAGMA` statements. Lotus core no
+longer sniffs SQL prefixes itself.
+
+### `{:unrestricted, reason}` and `:allow_unrestricted_resources`
+
+Some engines cannot tell, before execution, which resources a query
+reads — Elasticsearch gates access at the index level, for instance. Such
+an adapter returns `{:unrestricted, reason}`.
+
+In v0.x this was a silent `:skip`: the statement ran with no visibility
+check and nothing said so. In v1 it is an explicit operator decision.
+**By default, preflight blocks the statement**:
+
+```elixir
+{:error,
+ "Preflight blocked: source \"elastic\" cannot enforce visibility at the adapter layer " <>
+ "(index-level access control). Set `config :lotus, :allow_unrestricted_resources, true` " <>
+ "or opt in per-source via `allow_unrestricted_resources: true` in the source's " <>
+ "data_sources entry."}
+```
+
+Opt in globally:
+
+```elixir
+config :lotus, allow_unrestricted_resources: true
+```
+
+or — better — for the one source that needs it, in its `:data_sources`
+config map:
+
+```elixir
+config :lotus,
+  data_sources: %{
+    "postgres" => MyApp.Repo,
+    "elastic" => %{
+      adapter: MyApp.ElasticAdapter,
+      url: "http://localhost:9200",
+      allow_unrestricted_resources: true
+    }
+  }
+```
+
+The per-source value wins over the global flag in both directions: a
+source set to `false` stays locked down even under a permissive global
+default.
+
+Opting in means trusting that adapter — or the engine's own access
+control — to enforce visibility. Lotus table rules will not apply to the
+statement. Column policies still apply to the result columns, but only
+the column-only rules (see below).
+
+## Testing Visibility Rules
+
+Check your configuration from IEx:
+
+```elixir
+# Through the discovery API
 {:ok, schemas} = Lotus.list_schemas("postgres")
-# Returns only visible schemas
-
-# Test table visibility
 {:ok, tables} = Lotus.list_tables("postgres", schema: "public")
-# Returns only visible tables in public schema
 
-# Direct visibility check
+# Direct checks
 Lotus.Visibility.allowed_schema?("postgres", "restricted")
-# Returns true/false
+# => false
 
 Lotus.Visibility.allowed_relation?("postgres", {"public", "users"})
-# Returns true/false
+# => true
+
+# With a scope
+Lotus.Visibility.allowed_relation?("postgres", {"tenant_42", "orders"}, %{tenant_id: 42})
+
+# Filter helpers
+Lotus.Visibility.filter_schemas(["public", "pg_catalog"], "postgres")
+# => ["public"]
+
+Lotus.Visibility.filter_relations([{"public", "users"}, {"public", "api_keys"}], "postgres")
+# => [{"public", "users"}]
+
+# Validate requested namespaces
+Lotus.Visibility.validate_schemas(["public", "pg_catalog"], "postgres")
+# => {:error, :schema_not_visible, denied: ["pg_catalog"]}
 ```
+
+Each of these takes an optional trailing `scope` argument, defaulting to
+`nil`.
 
 ## Error Handling
 
-When schema visibility blocks access, you'll receive clear error messages:
-
 ```elixir
-# Trying to list tables in denied schema
+# Listing a denied namespace
 {:error, "Schema(s) not visible: pg_catalog, restricted"} =
   Lotus.list_tables("postgres", schemas: ["public", "pg_catalog", "restricted"])
 
-# Validation helper
-{:error, :schema_not_visible, denied: ["pg_catalog"]} =
-  Lotus.Visibility.validate_schemas(["public", "pg_catalog"], "postgres")
+# Describing a denied table
+{:error, "Table 'public.api_keys' is not visible by Lotus policy"} =
+  Lotus.describe_table("postgres", "api_keys")
+
+# Running a statement that touches a denied table
+{:error, "Query touches blocked table(s): [\"public.api_keys\"]"} =
+  Lotus.run_statement("SELECT * FROM api_keys")
 ```
 
 ## Built-in Security
 
-Lotus automatically denies system schemas to prevent accidental exposure:
+Lotus denies its own and the engine's internals regardless of your rules.
 
-### PostgreSQL Built-ins
-- `pg_catalog` - System catalog
-- `information_schema` - SQL standard metadata
-- `pg_toast` - TOAST storage
-- `~r/^pg_temp/` - Temporary schemas
-- `~r/^pg_toast/` - Additional TOAST schemas
+### PostgreSQL schemas
+`pg_catalog`, `information_schema`, `pg_toast`, `~r/^pg_temp/`, `~r/^pg_toast/`
 
-### MySQL Built-ins
-- `mysql` - MySQL system database
-- `information_schema` - SQL standard metadata
-- `performance_schema` - Performance monitoring
-- `sys` - Diagnostic information
+### MySQL schemas
+`mysql`, `information_schema`, `performance_schema`, `sys`
 
-### All Databases
-- Migration tables (e.g., `schema_migrations`)
-- Lotus internal tables (e.g., `lotus_queries`)
+### Tables, every source
+- the repo's migration table (`schema_migrations`, or whatever
+  `:migration_source` is set to, in the repo's
+  `:migration_default_prefix`)
+- SQLite internals (`~r/^sqlite_/`)
+- Lotus's own storage tables: `lotus_queries`,
+  `lotus_query_visualizations`, `lotus_dashboards`,
+  `lotus_dashboard_cards`, `lotus_dashboard_filters`,
+  `lotus_dashboard_card_filter_mappings`
 
-These built-in denies always apply, even if your custom rules would allow them. This ensures security by default.
-
-## Migration from Table-Only Rules
-
-If you're upgrading from table-only visibility rules:
-
-1. **Review existing rules**: Identify any schema-specific patterns
-2. **Extract schema rules**: Move schema-level restrictions to `schema_visibility`
-3. **Test thoroughly**: Schema rules take precedence and can block more than expected
-4. **Use validation**: Test your configuration with `Lotus.Visibility.validate_schemas/2`
+These denies always apply, even where your rules would allow them.
 
 ## Best Practices
 
-1. **Start restrictive**: Use allow lists for sensitive environments
-2. **Layer security**: Use schema rules for broad restrictions, table rules for fine-tuning
-3. **Test configurations**: Use the programmatic API to verify your rules work as expected
-4. **Document your rules**: Complex visibility configurations should be documented for your team
-5. **Consider performance**: Schema-level filtering is more efficient than table-level
-6. **MySQL considerations**: Remember that schemas = databases in MySQL
-7. **Regex careful**: Test regex patterns thoroughly to avoid unintended matches
+1. **Start restrictive**: use allow lists in sensitive environments
+2. **Layer the levels**: schema rules for broad cuts, table rules for
+   fine-tuning, column rules for individual fields
+3. **Test the configuration**: use the direct-check API above
+4. **Pass scope everywhere**: discovery and execution, or the two
+   disagree
+5. **Document complex rule sets** for your team
+6. **Prefer schema-level filtering**: it is cheaper than table-level
+7. **MySQL**: remember that schemas are databases
+8. **Test your regexes**: an over-broad pattern silently exposes tables
 
 ## Common Patterns
 
-### Development vs Production
+### Development vs production
 
 ```elixir
-# Development - more permissive
+# Development — more permissive
 config :lotus,
   schema_visibility: %{
     default: [allow: :all, deny: ["dangerous_schema"]]
   }
 
-# Production - restrictive allowlist
+# Production — restrictive allowlist
 config :lotus,
   schema_visibility: %{
-    default: [
-      allow: ["public", "reporting"],
-      deny: []  # not needed with restrictive allow
-    ]
+    default: [allow: ["public", "reporting"]]
   }
 ```
 
@@ -342,15 +524,15 @@ config :lotus,
 config :lotus,
   schema_visibility: %{
     postgres: [
-      allow: ["public", ~r/^tenant_[a-f0-9]{8}$/],  # UUID-based tenants
-      deny: []
+      allow: ["public", ~r/^tenant_[a-f0-9]{8}$/]  # UUID-based tenants
     ]
   }
 ```
 
-### Supabase Configuration
+### Supabase
 
-When using Supabase as your database, it includes many additional system schemas that you typically don't want your users to query directly through Lotus. It's recommended to configure Lotus with schema deny rules to hide these internal schemas:
+Supabase adds many internal schemas that your users should not query
+through Lotus. Deny them explicitly:
 
 ```elixir
 config :lotus,
@@ -359,34 +541,30 @@ config :lotus,
       deny: [
         "auth",           # Supabase authentication
         "extensions",     # PostgreSQL extensions
-        "graphql",        # GraphQL schema
-        "graphql_public", # Public GraphQL schema
+        "graphql",
+        "graphql_public",
         "pgbouncer",      # Connection pooler
-        "realtime",       # Realtime subscriptions
-        "storage",        # File storage
+        "realtime",
+        "storage",
         "vault",          # Secrets management
-        "pg_catalog",     # PostgreSQL system catalog
-        "information_schema", # SQL standard metadata
-        "pg_toast"        # TOAST storage
+        "pg_catalog",
+        "information_schema",
+        "pg_toast"
       ]
     ]
   }
 ```
 
-This configuration ensures that:
-- Users can only query your application's schemas (like `public`)
-- Supabase's internal schemas remain hidden from the Lotus interface
-- System schemas are properly protected from accidental exposure
-
-**Note**: The last three schemas (`pg_catalog`, `information_schema`, `pg_toast`) are already blocked by Lotus's built-in security, but including them explicitly in your configuration makes the intent clear.
+The last three are already blocked by the built-in denies; listing them
+makes the intent explicit.
 
 ## Column-Level Visibility
 
-Column visibility provides fine-grained control over individual columns within tables. You can hide sensitive data, mask personally identifiable information (PII), or prevent certain columns from being queried entirely.
+Column visibility controls individual columns inside an allowed table:
+hide sensitive fields, mask personally identifiable information, or
+reject a query that selects a forbidden column.
 
 ### Configuration
-
-Add column visibility rules to your configuration:
 
 ```elixir
 config :lotus,
@@ -414,40 +592,36 @@ config :lotus,
 
 ### Actions
 
-Column policies support four actions:
-
-- **`:allow`** - Show column values normally (default behavior)
-- **`:omit`** - Remove column entirely from query results
-- **`:mask`** - Transform/redact column values using a masking strategy
-- **`:error`** - Fail the query if this column is selected
+- **`:allow`** — show the values normally (default)
+- **`:omit`** — drop the column from the result
+- **`:mask`** — transform or redact the values
+- **`:error`** — fail the query when the column is selected
 
 ### Masking Strategies
 
-When using `:mask` action, choose from these strategies:
-
-#### `:null` - Replace with NULL
+#### `:null` — replace with NULL
 ```elixir
 {"users", "middle_name", [action: :mask, mask: :null]}
 ```
 
-#### `:sha256` - Replace with SHA256 hash
+#### `:sha256` — replace with a SHA256 hash
 ```elixir
 {"users", "ssn", [action: :mask, mask: :sha256]}
-# "123-45-6789" becomes "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
+# "123-45-6789" becomes "a665a459…"
 ```
 
-#### `{:fixed, value}` - Replace with fixed value
+#### `{:fixed, value}` — replace with a constant
 ```elixir
 {"users", "salary", [action: :mask, mask: {:fixed, "CONFIDENTIAL"}]}
 ```
 
-#### `{:partial, options}` - Partial masking
+#### `{:partial, options}` — keep the ends, mask the middle
 ```elixir
-# Keep last 4 characters, mask the rest
+# Keep the last 4 characters
 {"users", "phone", [action: :mask, mask: {:partial, keep_last: 4}]}
 # "555-123-4567" becomes "*******4567"
 
-# Keep first 2 and last 4, custom replacement
+# Keep the first 2 and last 4, custom replacement character
 {"users", "email", [action: :mask, mask: {:partial, keep_first: 2, keep_last: 4, replacement: "#"}]}
 # "john@example.com" becomes "jo#######.com"
 ```
@@ -468,68 +642,114 @@ Partial masking never lets a value through untouched:
 Values that are neither text nor binary — a `jsonb` column, for example —
 are rendered the way the UI and exports render them, then masked as text.
 
-### Schema Introspection Control
+### Builder functions
 
-Control whether columns appear in schema introspection:
+`Lotus.Visibility.Policy` builds the same policies in code:
+
+```elixir
+alias Lotus.Visibility.Policy
+
+column_visibility: %{
+  default: [
+    {"ssn", Policy.column_mask(:sha256)},
+    {"debug_info", Policy.column_omit(show_in_schema?: false)},
+    {"password", Policy.column_error()}
+  ]
+}
+```
+
+### Schema introspection control
+
+`show_in_schema?` decides whether the column appears in the output of
+`Lotus.describe_table/3`:
 
 ```elixir
 column_visibility: %{
   default: [
-    # Column is masked but visible in schema
+    # Masked, but still listed in the description
     {"password_hash", [action: :mask, mask: :sha256, show_in_schema?: true]},
 
-    # Column is omitted and hidden from schema
+    # Omitted and hidden from the description
     {"internal_notes", [action: :omit, show_in_schema?: false]}
   ]
 }
 ```
 
-### Pattern Matching
+A column that stays visible in the description carries its policy with
+it, so a UI can label it before anyone runs a query:
 
-Use regex patterns for flexible column matching:
+```elixir
+{:ok, columns} = Lotus.describe_table("postgres", "users")
+
+Enum.find(columns, &(&1.name == "ssn"))
+# %{name: "ssn", type: "text", ..., visibility: %{action: :mask, mask: :sha256}}
+```
+
+### Pattern matching
 
 ```elixir
 column_visibility: %{
   postgres: [
-    # Hide all columns ending in _secret
+    # Every column ending in _secret
     {~r/_secret$/, :error},
 
-    # Mask all PII columns across specific tables
+    # PII columns of the users table, in any schema
     {"users", ~r/(ssn|phone|email)/, [action: :mask, mask: :sha256]},
 
-    # Hash all audit columns in analytics schema
+    # Audit columns in the analytics schema
     {"analytics", ~r/.*/, ~r/^audit_/, [action: :mask, mask: :sha256]}
   ]
 }
 ```
 
-### Simple Syntax
+`"*"` works as a wildcard wherever a pattern is accepted.
 
-For common cases, use atom shortcuts:
+### Simple syntax
 
 ```elixir
 column_visibility: %{
   default: [
-    {"password", :error},        # Same as [action: :error]
-    {"temp_data", :omit},        # Same as [action: :omit]
-    {"user_agent", :mask}        # Same as [action: :mask, mask: :null]
+    {"password", :error},        # same as [action: :error]
+    {"temp_data", :omit},        # same as [action: :omit]
+    {"user_agent", :mask}        # same as [action: :mask, mask: :null]
   ]
 }
 ```
 
-### Precedence Rules
+### Precedence rules
 
-Column rules are evaluated in this order (most to least specific):
+Column rules are evaluated from most to least specific:
 
-1. **Schema + Table + Column** - `{"public", "users", "email", policy}`
-2. **Table + Column** - `{"users", "email", policy}`
-3. **Column Only** - `{"email", policy}`
+1. **Schema + table + column** — `{"public", "users", "email", policy}`
+2. **Table + column** — `{"users", "email", policy}`
+3. **Column only** — `{"email", policy}`
 
-The most specific matching rule wins.
+The most specific match wins.
+
+### Column rules and preflight
+
+The first two forms need to know which tables the result came from.
+Lotus takes that list from execution preflight, so a statement that
+**skipped** preflight — an adapter whose `needs_preflight?/2` returned
+`false`, or a source opted into `:allow_unrestricted_resources` — has no
+relation list, and only **column-only** rules can match.
+
+Write the rule that must always hold in the column-only form:
+
+```elixir
+column_visibility: %{
+  default: [
+    {"ssn", [action: :mask, mask: :sha256]}   # applies everywhere
+  ],
+  postgres: [
+    {"public", "users", "email", :omit}       # needs preflight relations
+  ]
+}
+```
 
 ### Examples
 
-#### PII Protection
+#### PII protection
 ```elixir
 column_visibility: %{
   default: [
@@ -541,9 +761,8 @@ column_visibility: %{
 }
 ```
 
-#### Development vs Production
+#### Development vs production
 ```elixir
-# Different rules per environment
 column_visibility: %{
   default: [
     {"password", if(Mix.env() == :prod, do: :error, else: :allow)},
@@ -552,15 +771,21 @@ column_visibility: %{
 }
 ```
 
-#### Multi-tenant Data
+#### Multi-tenant data
 ```elixir
 column_visibility: %{
   postgres: [
     # Hide tenant isolation columns
     {~r/^tenant_\d+/, ~r/.*/, "tenant_id", :omit},
 
-    # Mask cross-tenant data
+    # Mask cross-tenant references
     {"shared_data", "user_reference", [action: :mask, mask: :sha256]}
   ]
 }
 ```
+
+## Next Steps
+
+- [Schema Introspection](schema-introspection.md) — the discovery API these rules filter
+- [Custom Resolvers](custom-resolvers.md) — scoped and dynamic rule sources
+- [Configuration](configuration.md) — every config key in one place

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -853,23 +853,8 @@ defmodule Lotus do
     end
   end
 
-  defp build_cache_options(cache_opts, tags) do
-    base_options = [tags: tags]
-
-    if is_list(cache_opts) do
-      cache_options =
-        cache_opts
-        |> Enum.filter(fn
-          {_key, _value} -> true
-          _atom -> false
-        end)
-        |> Keyword.take([:max_bytes, :compress])
-
-      Keyword.merge(cache_options, base_options)
-    else
-      base_options
-    end
-  end
+  defp build_cache_options(cache_opts, tags),
+    do: Lotus.Cache.build_options(cache_opts, tags)
 
   defp result_key(body, bound_vars_map, repo_name, search_path, scope) do
     Key.result(

--- a/lib/lotus/cache.ex
+++ b/lib/lotus/cache.ex
@@ -14,6 +14,29 @@ defmodule Lotus.Cache do
   @spec enabled?() :: boolean()
   def enabled?, do: match?({:ok, _}, adapter())
 
+  @doc """
+  Builds the per-entry options for a cache write.
+
+  Layers the caller's `:cache` option over the entry options set in
+  application config, then adds the invalidation tags. A caller that passes
+  no `:cache` option, or an atom such as `:bypass`, still gets the
+  configured defaults.
+  """
+  @spec build_options(term(), [String.t()]) :: opts()
+  def build_options(cache_opts, tags) do
+    Config.cache_entry_options()
+    |> Keyword.merge(per_call_options(cache_opts))
+    |> Keyword.put(:tags, tags)
+  end
+
+  defp per_call_options(cache_opts) when is_list(cache_opts) do
+    cache_opts
+    |> Enum.filter(&match?({_key, _value}, &1))
+    |> Keyword.take([:max_bytes, :compress, :lock_timeout])
+  end
+
+  defp per_call_options(_cache_opts), do: []
+
   @spec get(key) :: {:ok, value} | :miss
   def get(key) do
     case adapter() do

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -601,6 +601,35 @@ defmodule Lotus.Config do
   @spec cache_config() :: cache_config() | nil
   def cache_config, do: load!()[:cache]
 
+  @entry_option_keys [:max_bytes, :compress, :lock_timeout]
+
+  @doc """
+  Returns the cache entry options the operator set in `:cache` config.
+
+  These apply to every cached entry unless a caller overrides them in a
+  per-call `:cache` option:
+
+    * `:max_bytes` - skip writing an entry whose encoded size exceeds this
+    * `:compress` - store the entry compressed
+    * `:lock_timeout` - how long a caller waits for whichever process is
+      already computing the same key, before computing it itself
+
+  Only keys that are actually configured are returned, so the cache adapter
+  keeps deciding the default for anything left unset.
+  """
+  @spec cache_entry_options() :: keyword()
+  def cache_entry_options do
+    case cache_config() do
+      config when is_map(config) ->
+        for key <- @entry_option_keys,
+            Map.has_key?(config, key),
+            do: {key, Map.fetch!(config, key)}
+
+      _ ->
+        []
+    end
+  end
+
   @doc """
   Returns cache settings for a specific profile.
 

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -383,8 +383,39 @@ defmodule Lotus.Config do
     Lotus.Source.Adapter in behaviours
   end
 
+  # v1 renamed three config keys. Without this check the old key is simply not
+  # in the allowlist below, so an upgrading app is told that :storage_repo is
+  # missing rather than that :ecto_repo moved — the error points at the wrong
+  # problem on the one path v1 most needs to be clear about.
+  @renamed_keys [
+    {:ecto_repo, :storage_repo},
+    {:data_repos, :data_sources},
+    {:default_repo, :default_source}
+  ]
+
+  defp check_renamed_keys!(env) do
+    case Enum.filter(@renamed_keys, fn {old, _new} -> Keyword.has_key?(env, old) end) do
+      [] ->
+        env
+
+      found ->
+        renames =
+          Enum.map_join(found, "\n", fn {old, new} -> "  #{inspect(old)} -> #{inspect(new)}" end)
+
+        raise ArgumentError, """
+        Invalid :lotus config: found configuration keys that were renamed in Lotus v1.0.
+
+        #{renames}
+
+        Rename them in your `config :lotus` block. There is no compatibility
+        shim; see the "Upgrading to v1.0" guide for the full migration.
+        """
+    end
+  end
+
   defp get_lotus_config do
     Application.get_all_env(:lotus)
+    |> check_renamed_keys!()
     |> Keyword.take([
       :storage_repo,
       :read_only,
@@ -441,7 +472,7 @@ defmodule Lotus.Config do
   `false` on a single source while running a permissive global default
   should be able to trust that the source stays locked down.
 
-  Used by `Lotus.Preflight.authorize/3` to gate non-SQL adapters whose
+  Used by `Lotus.Preflight.authorize/4` to gate non-SQL adapters whose
   engines enforce visibility at a layer Lotus can't introspect.
   """
   @spec allow_unrestricted_resources?(String.t()) :: boolean()

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -19,7 +19,7 @@ defmodule Lotus.Middleware do
 
   | Event | Triggered | Payload keys |
   |-------|-----------|--------------|
-  | `:before_query` | After preflight visibility check, before execution | `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
+  | `:before_query` | First, before sanitization, preflight and execution | `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
   | `:after_query` | After execution, before result returned to caller | `:result`, `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
   | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
   | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |

--- a/lib/lotus/preflight.ex
+++ b/lib/lotus/preflight.ex
@@ -11,7 +11,8 @@ defmodule Lotus.Preflight do
 
   When an adapter returns `{:unrestricted, reason}` the statement is allowed
   through only if the host application has opted in via
-  `config :lotus, :allow_unrestricted_resources`; otherwise preflight raises.
+  `config :lotus, :allow_unrestricted_resources`; otherwise preflight returns
+  an error.
   """
 
   alias Lotus.Config

--- a/lib/lotus/schema.ex
+++ b/lib/lotus/schema.ex
@@ -797,23 +797,8 @@ defmodule Lotus.Schema do
     end
   end
 
-  defp build_cache_options(cache_opts, tags) do
-    base = [tags: tags]
-
-    if is_list(cache_opts) do
-      pass =
-        cache_opts
-        |> Enum.filter(fn
-          {_k, _v} -> true
-          _atom -> false
-        end)
-        |> Keyword.take([:max_bytes, :compress])
-
-      Keyword.merge(pass, base)
-    else
-      base
-    end
-  end
+  defp build_cache_options(cache_opts, tags),
+    do: Lotus.Cache.build_options(cache_opts, tags)
 
   defp schema_key(kind, repo_name, scope) do
     key_builder().discovery_key(

--- a/lib/lotus/schema.ex
+++ b/lib/lotus/schema.ex
@@ -424,6 +424,8 @@ defmodule Lotus.Schema do
   - `:schema` - Look for table in specific schema
   - `:schemas` - Search for table in multiple schemas (first match wins)
   - `:search_path` - Use PostgreSQL search_path to resolve table location
+  - `:scope` - Opaque value passed to the visibility resolver and hashed into
+    the cache key
   - `:cache` - Cache options (profile, ttl_ms, etc.)
 
   ## Examples

--- a/lib/lotus/source/adapter.ex
+++ b/lib/lotus/source/adapter.ex
@@ -609,8 +609,13 @@ defmodule Lotus.Source.Adapter do
   Examples:
 
     * `"sql:postgres"`, `"sql:mysql"`, `"sql:sqlite"` for SQL-prepared adapters
-    * `"elasticsearch:json"` for an Elasticsearch DSL adapter
-    * `"mongo:aggregation"` for a MongoDB aggregation pipeline adapter
+    * `"json:elasticsearch"` for an Elasticsearch DSL adapter
+    * `"json:mongo"` for a MongoDB aggregation pipeline adapter
+
+  The part before the colon is the language family. It selects the editor
+  mode and the fenced-code label the AI layer asks the model to emit, so it
+  must name the syntax of the statement body (`sql`, `json`, ...), not the
+  engine.
   """
   @callback query_language(state :: term()) :: String.t()
 

--- a/lib/lotus/source/adapters/ecto/dialects/default.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/default.ex
@@ -14,8 +14,8 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.Default do
       the database level.
     * `set_statement_timeout/2` is a no-op, so user-configured statement
       timeouts have no effect.
-    * `extract_accessed_resources/4` is not implemented, so
-      `Lotus.Preflight.authorize/3` short-circuits to `:ok` — visibility rules
+    * `extract_accessed_resources/2` is not implemented, so
+      `Lotus.Preflight.authorize/4` short-circuits to `:ok` — visibility rules
       are **not** checked against the tables the query touches.
     * `list_schemas/1`, `list_tables/3`, and `describe_table/3` return
       empty lists — the schema browser will be blank.

--- a/lib/lotus/storage/query.ex
+++ b/lib/lotus/storage/query.ex
@@ -74,6 +74,7 @@ defmodule Lotus.Storage.Query do
   def changeset(query, attrs) do
     query
     |> cast(attrs, @permitted)
+    |> reject_renamed_attrs(attrs)
     |> cast_embed(:variables, with: &QueryVariable.changeset/2)
     |> validate_required(@required)
     |> validate_length(:name, min: 1, max: 255)
@@ -83,6 +84,25 @@ defmodule Lotus.Storage.Query do
     |> validate_query_language()
     |> maybe_add_unique_constraint()
   end
+
+  # `data_repo` was renamed to `data_source` in v1. `cast/3` drops an
+  # unpermitted key, and `data_source` is not required, so a stale attribute
+  # map used to save with `data_source: nil` and resolve to the default source
+  # at run time — a multi-source host would silently query the wrong database.
+  # Fail the changeset instead.
+  defp reject_renamed_attrs(changeset, attrs) when is_map(attrs) do
+    if Map.has_key?(attrs, :data_repo) or Map.has_key?(attrs, "data_repo") do
+      add_error(
+        changeset,
+        :data_source,
+        "was given as `data_repo`, which was renamed to `data_source` in Lotus v1.0"
+      )
+    else
+      changeset
+    end
+  end
+
+  defp reject_renamed_attrs(changeset, _attrs), do: changeset
 
   @doc """
   Compiles a stored query into an executable `Lotus.Query.Statement`.

--- a/lib/lotus/telemetry.ex
+++ b/lib/lotus/telemetry.ex
@@ -109,7 +109,7 @@ defmodule Lotus.Telemetry do
 
     * `:operation` - The introspection operation (e.g., `:list_schemas`, `:list_tables`,
       `:describe_table`, `:get_table_stats`, `:list_relations`)
-    * `:repo` - The repo name
+    * `:source` - The data source name
 
   ### `[:lotus, :schema, :introspection, :stop]`
 
@@ -122,7 +122,7 @@ defmodule Lotus.Telemetry do
   **Metadata:**
 
     * `:operation` - The introspection operation
-    * `:repo` - The repo name
+    * `:source` - The data source name
     * `:result` - `:ok` or `:error`
 
   ## Example
@@ -236,24 +236,24 @@ defmodule Lotus.Telemetry do
   end
 
   @doc false
-  def schema_introspection_start(operation, repo) do
+  def schema_introspection_start(operation, source) do
     start_time = System.monotonic_time()
 
     :telemetry.execute(@schema_start, %{system_time: System.system_time()}, %{
       operation: operation,
-      repo: repo
+      source: source
     })
 
     start_time
   end
 
   @doc false
-  def schema_introspection_stop(start_time, operation, repo, result_status) do
+  def schema_introspection_stop(start_time, operation, source, result_status) do
     duration = System.monotonic_time() - start_time
 
     :telemetry.execute(@schema_stop, %{duration: duration}, %{
       operation: operation,
-      repo: repo,
+      source: source,
       result: result_status
     })
   end

--- a/lib/lotus/visibility.ex
+++ b/lib/lotus/visibility.ex
@@ -1,10 +1,15 @@
 defmodule Lotus.Visibility do
   @moduledoc """
-  Schema and table visibility filtering for Lotus.
+  Schema, table and column visibility filtering for Lotus.
 
-  Implements a two-level visibility system where **schema visibility takes precedence**:
-  1. **Schema visibility** is checked first - if a schema is denied, all its tables are blocked
+  Implements a three-level visibility system where the outer level takes
+  precedence:
+
+  1. **Schema visibility** is checked first — if a schema is denied, every
+     table in it is blocked
   2. **Table visibility** is only checked if the schema is allowed
+  3. **Column visibility** applies to the columns of an allowed table, and
+     can hide a column from discovery or mask its values in results
 
   This ensures security by default while providing fine-grained control.
 

--- a/mix.exs
+++ b/mix.exs
@@ -115,7 +115,7 @@ defmodule Lotus.MixProject do
         "OTP Application": [Lotus.Application, Lotus.Supervisor],
         AI: [
           Lotus.AI,
-          Lotus.AI.SQLGenerator,
+          Lotus.AI.QueryGenerator,
           Lotus.AI.QueryExplainer,
           Lotus.AI.QueryOptimizer,
           Lotus.AI.Conversation,
@@ -124,7 +124,6 @@ defmodule Lotus.MixProject do
           Lotus.AI.Tool,
           ~r/Lotus\.AI\.Actions\..+/
         ],
-        "SQL Processing": [Lotus.SQL.Transformer],
         Utilities: [Lotus.JSON]
       ]
     ]
@@ -142,6 +141,7 @@ defmodule Lotus.MixProject do
       "guides/ai_query_generation.md",
       "guides/configuration.md",
       "guides/middleware.md",
+      "guides/schema-introspection.md",
       "guides/visibility.md",
       "guides/source-adapters.md",
       "guides/custom-resolvers.md",
@@ -154,7 +154,7 @@ defmodule Lotus.MixProject do
 
   defp description do
     """
-    Embeddable business intelligence engine for Elixir — run SQL queries, build dashboards, and manage analytics directly in your Phoenix app with Ecto.
+    Embeddable business intelligence engine for Elixir — run queries against SQL and non-SQL data sources, build dashboards, and manage analytics directly in your Phoenix app.
     """
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-lotus/lotus"
-  @version "1.0.0-rc.1"
+  @version "1.0.0"
 
   def project do
     [

--- a/test/lotus/cache/build_options_test.exs
+++ b/test/lotus/cache/build_options_test.exs
@@ -1,0 +1,77 @@
+defmodule Lotus.Cache.BuildOptionsTest do
+  @moduledoc """
+  `:max_bytes`, `:compress` and `:lock_timeout` are deployment policy, so they
+  are read from `:cache` config. A per-call `:cache` option overrides them.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Lotus.Cache
+
+  setup do
+    original = Application.get_env(:lotus, :cache)
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:lotus, :cache)
+        config -> Application.put_env(:lotus, :cache, config)
+      end
+
+      Lotus.Config.reload!()
+    end)
+
+    :ok
+  end
+
+  defp put_cache_config(extra) do
+    base = Application.get_env(:lotus, :cache) || %{}
+    Application.put_env(:lotus, :cache, Map.merge(base, extra))
+    Lotus.Config.reload!()
+  end
+
+  test "entry options set in config reach the adapter" do
+    put_cache_config(%{max_bytes: 1_000, compress: false, lock_timeout: 250})
+
+    opts = Cache.build_options(nil, ["source:postgres"])
+
+    assert opts[:max_bytes] == 1_000
+    assert opts[:compress] == false
+    assert opts[:lock_timeout] == 250
+    assert opts[:tags] == ["source:postgres"]
+  end
+
+  test "a per-call cache option overrides config" do
+    put_cache_config(%{max_bytes: 1_000, compress: false})
+
+    opts = Cache.build_options([max_bytes: 50_000], [])
+
+    assert opts[:max_bytes] == 50_000
+    assert opts[:compress] == false
+  end
+
+  test "an unset key is left out, so the adapter default applies" do
+    put_cache_config(%{max_bytes: 1_000})
+
+    opts = Cache.build_options([], [])
+
+    assert opts[:max_bytes] == 1_000
+    refute Keyword.has_key?(opts, :compress)
+    refute Keyword.has_key?(opts, :lock_timeout)
+  end
+
+  test "an atom cache option still picks up the configured defaults" do
+    put_cache_config(%{compress: false})
+
+    opts = Cache.build_options(:bypass, ["query:1"])
+
+    assert opts[:compress] == false
+    assert opts[:tags] == ["query:1"]
+  end
+
+  test "with no cache config at all the options carry only the tags" do
+    Application.delete_env(:lotus, :cache)
+    Lotus.Config.reload!()
+
+    assert Cache.build_options(nil, ["source:x"]) == [tags: ["source:x"]]
+  end
+end

--- a/test/lotus/config_renamed_keys_test.exs
+++ b/test/lotus/config_renamed_keys_test.exs
@@ -1,0 +1,38 @@
+defmodule Lotus.ConfigRenamedKeysTest do
+  @moduledoc """
+  A v0.x config must fail with an error that names the rename, not with a
+  "required :storage_repo option not found" that points at the wrong problem.
+  """
+
+  use ExUnit.Case, async: false
+
+  setup do
+    original = Application.get_all_env(:lotus)
+
+    on_exit(fn ->
+      for {k, _} <- Application.get_all_env(:lotus), do: Application.delete_env(:lotus, k)
+      for {k, v} <- original, do: Application.put_env(:lotus, k, v)
+      Lotus.Config.reload!()
+    end)
+
+    :ok
+  end
+
+  test "a renamed key raises and names both the old and the new key" do
+    Application.put_env(:lotus, :ecto_repo, Lotus.Test.Repo)
+
+    assert_raise ArgumentError, ~r/renamed in Lotus v1\.0.*:ecto_repo -> :storage_repo/s, fn ->
+      Lotus.Config.reload!()
+    end
+  end
+
+  test "every renamed key present is listed, not just the first" do
+    Application.put_env(:lotus, :data_repos, %{})
+    Application.put_env(:lotus, :default_repo, "main")
+
+    error = assert_raise(ArgumentError, fn -> Lotus.Config.reload!() end)
+
+    assert error.message =~ ":data_repos -> :data_sources"
+    assert error.message =~ ":default_repo -> :default_source"
+  end
+end

--- a/test/lotus/storage/renamed_attrs_test.exs
+++ b/test/lotus/storage/renamed_attrs_test.exs
@@ -1,0 +1,35 @@
+defmodule Lotus.Storage.RenamedAttrsTest do
+  @moduledoc """
+  A stale `data_repo` attribute must fail the changeset rather than save a
+  query with no source, which would silently run against the default database.
+  """
+
+  use Lotus.Case, async: true
+
+  alias Lotus.Storage.Query
+
+  @base %{name: "Stale", statement: "SELECT 1"}
+
+  test "an atom-keyed data_repo attribute is rejected" do
+    changeset = Query.changeset(%Query{}, Map.put(@base, :data_repo, "analytics"))
+
+    refute changeset.valid?
+    assert {msg, _} = changeset.errors[:data_source]
+    assert msg =~ "renamed to `data_source`"
+  end
+
+  test "a string-keyed data_repo attribute is rejected" do
+    attrs = %{"name" => "Stale", "statement" => "SELECT 1", "data_repo" => "analytics"}
+    changeset = Query.changeset(%Query{}, attrs)
+
+    refute changeset.valid?
+    assert changeset.errors[:data_source]
+  end
+
+  test "data_source is accepted" do
+    changeset = Query.changeset(%Query{}, Map.put(@base, :data_source, "postgres"))
+
+    assert changeset.valid?
+    assert Ecto.Changeset.get_field(changeset, :data_source) == "postgres"
+  end
+end

--- a/test/lotus/telemetry_test.exs
+++ b/test/lotus/telemetry_test.exs
@@ -171,11 +171,11 @@ defmodule Lotus.TelemetryTest do
       {:ok, _tables} = Lotus.Schema.list_tables("sqlite")
 
       assert_received {:telemetry, [:lotus, :schema, :introspection, :start], %{system_time: _},
-                       %{operation: :list_tables, repo: "sqlite"}}
+                       %{operation: :list_tables, source: "sqlite"}}
 
       assert_received {:telemetry, [:lotus, :schema, :introspection, :stop],
                        %{duration: duration},
-                       %{operation: :list_tables, repo: "sqlite", result: :ok}}
+                       %{operation: :list_tables, source: "sqlite", result: :ok}}
 
       assert is_integer(duration)
       assert duration >= 0
@@ -203,10 +203,10 @@ defmodule Lotus.TelemetryTest do
       {:ok, _schema} = Lotus.Schema.describe_table("sqlite", "products")
 
       assert_received {:telemetry, [:lotus, :schema, :introspection, :start], _,
-                       %{operation: :describe_table, repo: "sqlite"}}
+                       %{operation: :describe_table, source: "sqlite"}}
 
       assert_received {:telemetry, [:lotus, :schema, :introspection, :stop], %{duration: _},
-                       %{operation: :describe_table, repo: "sqlite", result: :ok}}
+                       %{operation: :describe_table, source: "sqlite", result: :ok}}
 
       :telemetry.detach("#{inspect(ref)}")
     end
@@ -231,7 +231,7 @@ defmodule Lotus.TelemetryTest do
       {:ok, _schemas} = Lotus.Schema.list_schemas("sqlite")
 
       assert_received {:telemetry, [:lotus, :schema, :introspection, :start], _,
-                       %{operation: :list_schemas, repo: "sqlite"}}
+                       %{operation: :list_schemas, source: "sqlite"}}
 
       assert_received {:telemetry, [:lotus, :schema, :introspection, :stop], %{duration: _},
                        %{operation: :list_schemas, result: :ok}}


### PR DESCRIPTION
Cuts 1.0.0.

- `@version` 1.0.0-rc.1 → 1.0.0
- CHANGELOG: the `[1.0.0-rc.1]` entry becomes `[1.0.0] - 2026-09-12`, with the two `[Unreleased]` items folded into its Added section, so the v1 story reads as one entry
- README and `guides/installation.md` install snippets: `~> 1.0.0-rc.1` → `~> 1.0`

No rc references left in the README, guides or mix.exs.

After merge: `git tag v1.0.0 && git push origin v1.0.0`, `mix hex.publish`, `gh release create v1.0.0`. lotus_web 1.0.0 follows once this is on Hex.