### PR TITLE
fix(normalizer): detect the Decimal.to_string arity instead of pinning a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-### Fixed
-
-- **Normalizing a `Decimal` no longer depends on which Decimal an
-  application resolved.** `Lotus.Normalizer` rendered one with
-  `Decimal.to_string/3` and `max_digits: :infinity`, so a numeric wider than
-  Decimal's default output cap renders in full instead of raising. That arity
-  arrived in Decimal 2.4.0, and Lotus pins no Decimal of its own, so an
-  application on an older one got an `UndefinedFunctionError` the moment a
-  query returned a numeric column. The impl now picks its arity at compile
-  time, the way `Lotus.JSON` picks its JSON library. Both branches render the
-  same output, since the versions without the option have no cap to lift.
-
 ## [1.0.0] - 2026-09-12
 
 > **v1.0 is a large rewrite and not a drop-in upgrade from the v0.16.x
@@ -742,6 +728,16 @@
   `:schema` keys). Documentation now matches the code (#173).
 
 ### Fixed
+
+- **Normalizing a `Decimal` no longer depends on which Decimal an
+  application resolved.** `Lotus.Normalizer` rendered one with
+  `Decimal.to_string/3` and `max_digits: :infinity`, so a numeric wider than
+  Decimal's default output cap renders in full instead of raising. That arity
+  arrived in Decimal 2.4.0, and Lotus pins no Decimal of its own, so an
+  application on an older one got an `UndefinedFunctionError` the moment a
+  query returned a numeric column. The impl now picks its arity at compile
+  time, the way `Lotus.JSON` picks its JSON library. Both branches render the
+  same output, since the versions without the option have no cap to lift.
 
 - `Lotus.Result.Statistics` normalizes string values through
   `Lotus.Value.to_display_string/1` before measuring them. Columns whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Declare the `decimal` requirement.** `Lotus.Normalizer` renders a
+  `Decimal` with `Decimal.to_string/3` and `max_digits: :infinity`, so that a
+  numeric wider than Decimal's default output cap renders in full instead of
+  raising. That arity arrived in decimal 2.4.0, but Lotus declared no
+  requirement of its own and Ecto's allows `~> 2.0`, so an application could
+  resolve decimal 2.0 to 2.3 and get an `UndefinedFunctionError` the moment a
+  query returned a numeric column. Lotus now requires
+  `~> 2.4 or ~> 3.0`.
+
 ## [1.0.0] - 2026-09-12
 
 > **v1.0 is a large rewrite and not a drop-in upgrade from the v0.16.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@
 
 ### Fixed
 
-- **Declare the `decimal` requirement.** `Lotus.Normalizer` renders a
-  `Decimal` with `Decimal.to_string/3` and `max_digits: :infinity`, so that a
-  numeric wider than Decimal's default output cap renders in full instead of
-  raising. That arity arrived in decimal 2.4.0, but Lotus declared no
-  requirement of its own and Ecto's allows `~> 2.0`, so an application could
-  resolve decimal 2.0 to 2.3 and get an `UndefinedFunctionError` the moment a
-  query returned a numeric column. Lotus now requires
-  `~> 2.4 or ~> 3.0`.
+- **Normalizing a `Decimal` no longer depends on which Decimal an
+  application resolved.** `Lotus.Normalizer` rendered one with
+  `Decimal.to_string/3` and `max_digits: :infinity`, so a numeric wider than
+  Decimal's default output cap renders in full instead of raising. That arity
+  arrived in Decimal 2.4.0, and Lotus pins no Decimal of its own, so an
+  application on an older one got an `UndefinedFunctionError` the moment a
+  query returned a numeric column. The impl now picks its arity at compile
+  time, the way `Lotus.JSON` picks its JSON library. Both branches render the
+  same output, since the versions without the option have no cap to lift.
 
 ## [1.0.0] - 2026-09-12
 

--- a/lib/lotus/normalizer.ex
+++ b/lib/lotus/normalizer.ex
@@ -97,7 +97,17 @@ defimpl Lotus.Normalizer, for: Decimal do
   # Query results may hold numerics far wider than Decimal's default output cap
   # (an unconstrained Postgres numeric allows 131072 integer digits), so render
   # them in full rather than raising ArgumentError.
-  def normalize(value), do: Decimal.to_string(value, :scientific, max_digits: :infinity)
+  #
+  # The cap, and the `max_digits` option that lifts it, arrived in Decimal
+  # 2.4.0. Lotus does not pin Decimal — Ecto owns that requirement, and which
+  # major an application is on is its call — so pick the arity at compile time
+  # the way `Lotus.JSON` picks its JSON library. Versions without the cap
+  # render in full anyway, so both branches agree on the output.
+  if Code.ensure_loaded?(Decimal) and function_exported?(Decimal, :to_string, 3) do
+    def normalize(value), do: Decimal.to_string(value, :scientific, max_digits: :infinity)
+  else
+    def normalize(value), do: Decimal.to_string(value, :scientific)
+  end
 end
 
 defimpl Lotus.Normalizer, for: URI do

--- a/mix.exs
+++ b/mix.exs
@@ -41,11 +41,6 @@ defmodule Lotus.MixProject do
   defp deps do
     [
       {:cachex, "~> 4.0", optional: true},
-      # Lotus.Normalizer renders Decimal results with `max_digits: :infinity`,
-      # which Decimal.to_string/3 only accepts from 2.4.0 on. Ecto's own
-      # requirement allows 2.0, so without this an app can resolve a Decimal
-      # that raises the moment a query returns a numeric column.
-      {:decimal, "~> 2.4 or ~> 3.0"},
       {:ecto, "~> 3.10"},
       {:ecto_sql, "~> 3.10"},
       {:ecto_sqlite3, "~> 0.21", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,11 @@ defmodule Lotus.MixProject do
   defp deps do
     [
       {:cachex, "~> 4.0", optional: true},
+      # Lotus.Normalizer renders Decimal results with `max_digits: :infinity`,
+      # which Decimal.to_string/3 only accepts from 2.4.0 on. Ecto's own
+      # requirement allows 2.0, so without this an app can resolve a Decimal
+      # that raises the moment a query returns a numeric column.
+      {:decimal, "~> 2.4 or ~> 3.0"},
       {:ecto, "~> 3.10"},
       {:ecto_sql, "~> 3.10"},
       {:ecto_sqlite3, "~> 0.21", optional: true},

--- a/test/lotus/normalizer_decimal_test.exs
+++ b/test/lotus/normalizer_decimal_test.exs
@@ -1,0 +1,40 @@
+defmodule Lotus.NormalizerDecimalTest do
+  @moduledoc """
+  A numeric column is the most ordinary thing a query can return, so
+  normalizing a Decimal must not depend on which Decimal an application
+  happened to resolve.
+  """
+
+  use ExUnit.Case, async: true
+
+  test "the Decimal in use exports the arity the normalizer calls" do
+    {:module, Decimal} = Code.ensure_loaded(Decimal)
+
+    assert function_exported?(Decimal, :to_string, 3),
+           """
+           Decimal #{Application.spec(:decimal, :vsn)} has no to_string/3.
+           Lotus.Normalizer needs it for `max_digits: :infinity`; the mix.exs
+           requirement is what keeps an application off those versions.
+           """
+  end
+
+  test "renders an ordinary decimal" do
+    assert Lotus.Normalizer.normalize(Decimal.new("123.45")) == "123.45"
+  end
+
+  test "renders a numeric wider than Decimal's default output cap" do
+    # An unconstrained Postgres numeric allows far more digits than Decimal
+    # prints by default, which is why the normalizer passes max_digits.
+    wide = Decimal.new(1, String.duplicate("9", 2_000) |> String.to_integer(), 0)
+
+    rendered = Lotus.Normalizer.normalize(wide)
+
+    assert is_binary(rendered)
+    assert String.length(rendered) >= 2_000
+  end
+
+  test "renders the values a numeric column can also hold" do
+    assert Lotus.Normalizer.normalize(Decimal.new("0")) == "0"
+    assert Lotus.Normalizer.normalize(Decimal.new("-1.5")) == "-1.5"
+  end
+end

--- a/test/lotus/normalizer_decimal_test.exs
+++ b/test/lotus/normalizer_decimal_test.exs
@@ -7,15 +7,13 @@ defmodule Lotus.NormalizerDecimalTest do
 
   use ExUnit.Case, async: true
 
-  test "the Decimal in use exports the arity the normalizer calls" do
+  test "normalizing works whichever to_string arity the resolved Decimal has" do
     {:module, Decimal} = Code.ensure_loaded(Decimal)
 
-    assert function_exported?(Decimal, :to_string, 3),
-           """
-           Decimal #{Application.spec(:decimal, :vsn)} has no to_string/3.
-           Lotus.Normalizer needs it for `max_digits: :infinity`; the mix.exs
-           requirement is what keeps an application off those versions.
-           """
+    # The impl picks its arity at compile time, so this asserts the branch
+    # taken here is a real one rather than asserting a particular version.
+    assert function_exported?(Decimal, :to_string, 2)
+    assert is_binary(Lotus.Normalizer.normalize(Decimal.new("1.0")))
   end
 
   test "renders an ordinary decimal" do


### PR DESCRIPTION
`Lotus.Normalizer` renders a `Decimal` with `Decimal.to_string/3` and `max_digits: :infinity`, so a numeric wider than Decimal's default output cap renders in full rather than raising `ArgumentError`. That arity arrived in Decimal 2.4.0.

Lotus pins no Decimal of its own, so an application resolving an older one — ecto 3.13 allows `~> 2.0` — hits this the moment a query returns a numeric column, which is about as ordinary as a query result gets:

```
** (UndefinedFunctionError) function Decimal.to_string/3 is undefined or private
    (lotus 1.0.0) lib/lotus/normalizer.ex:100: Lotus.Normalizer.Decimal.normalize/1
```

Reproduced against decimal 2.3.0.

## Why not pin a version

The first commit here added `{:decimal, "~> 2.4 or ~> 3.0"}`. That was the wrong lever, and the second commit replaces it.

A requirement would either re-admit the 2.x line an application may have deliberately left, or, at `~> 3.0` only, quietly raise the ecto floor to 3.14, since that is the first ecto line requiring Decimal 3. Which Decimal an application runs is Ecto's call and the application's, not this library's.

## What it does instead

Detects the arity, the way `Lotus.JSON` picks between the built-in `JSON` module and `Jason`:

```elixir
if Code.ensure_loaded?(Decimal) and function_exported?(Decimal, :to_string, 3) do
  def normalize(value), do: Decimal.to_string(value, :scientific, max_digits: :infinity)
else
  def normalize(value), do: Decimal.to_string(value, :scientific)
end
```

The check runs at compile time, not per call: the answer cannot change at runtime, and result normalization runs once per cell. Both branches render the same output, because the versions without the `max_digits` option have no cap to lift in the first place.

## Verification

Compiles clean against decimal 2.3.0 and 3.1.1, and normalizes correctly on both. 13 doctests, 1944 tests, 0 failures.

Found while preparing the Elasticsearch adapter release, whose lock had resolved decimal 2.3.0.
