### PR TITLE
fix(runner): clear preflight relations on every exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **A failed statement no longer hands its tables to the next statement in
+  the same process.** Preflight records the relations it authorised in the
+  process dictionary, and `Lotus.Runner` consumed them only on the success
+  path. A statement that passed preflight and then failed during execution
+  left its relations behind, and a later statement that skips preflight
+  (`EXPLAIN`, `SHOW`, `PRAGMA`) resolved its column policies against the
+  failed statement's tables — masking a column no rule covers, or returning
+  one a rule masks. A long-lived process, such as a LiveView session, carried
+  the stale value for every query that followed. `run_statement/3` now clears
+  the relations on every exit, raises included.
+
 ## [1.0.0] - 2026-09-12
 
 > **v1.0 is a large rewrite and not a drop-in upgrade from the v0.16.x
@@ -728,17 +743,6 @@
   `:schema` keys). Documentation now matches the code (#173).
 
 ### Fixed
-
-- **A failed statement no longer hands its tables to the next statement in
-  the same process.** Preflight records the relations it authorised in the
-  process dictionary, and `Lotus.Runner` consumed them only on the success
-  path. A statement that passed preflight and then failed during execution
-  left its relations behind, and a later statement that skips preflight
-  (`EXPLAIN`, `SHOW`, `PRAGMA`) resolved its column policies against the
-  failed statement's tables — masking a column no rule covers, or returning
-  one a rule masks. A long-lived process, such as a LiveView session, carried
-  the stale value for every query that followed. `run_statement/3` now clears
-  the relations on every exit, raises included.
 
 - **Normalizing a `Decimal` no longer depends on which Decimal an
   application resolved.** `Lotus.Normalizer` rendered one with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -729,6 +729,17 @@
 
 ### Fixed
 
+- **A failed statement no longer hands its tables to the next statement in
+  the same process.** Preflight records the relations it authorised in the
+  process dictionary, and `Lotus.Runner` consumed them only on the success
+  path. A statement that passed preflight and then failed during execution
+  left its relations behind, and a later statement that skips preflight
+  (`EXPLAIN`, `SHOW`, `PRAGMA`) resolved its column policies against the
+  failed statement's tables — masking a column no rule covers, or returning
+  one a rule masks. A long-lived process, such as a LiveView session, carried
+  the stale value for every query that followed. `run_statement/3` now clears
+  the relations on every exit, raises included.
+
 - **Normalizing a `Decimal` no longer depends on which Decimal an
   application resolved.** `Lotus.Normalizer` rendered one with
   `Decimal.to_string/3` and `max_digits: :infinity`, so a numeric wider than

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -40,14 +40,23 @@ defmodule Lotus.Runner do
     # that is the point of the hook, for row-level security and tenant
     # predicates. Sanitization and preflight then apply to what will actually
     # execute, rather than to the text the caller originally supplied.
+    #
+    # Preflight records its relations in the process dictionary, and only the
+    # success path consumes them. The `after` clause clears them on every other
+    # exit, so a failed statement cannot hand its tables to the next statement
+    # in the same process.
     result =
-      with {:ok, %Statement{} = statement} <-
-             run_before_query(adapter, statement, context, vars),
-           :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
-           :ok <- preflight_visibility(adapter, statement, opts),
-           {:ok, %Result{} = res} <- exec_read_only(adapter, statement, opts),
-           {:ok, %Result{} = res} <- run_after_query(adapter, statement, res, context, vars) do
-        {:ok, res}
+      try do
+        with {:ok, %Statement{} = statement} <-
+               run_before_query(adapter, statement, context, vars),
+             :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
+             :ok <- preflight_visibility(adapter, statement, opts),
+             {:ok, %Result{} = res} <- exec_read_only(adapter, statement, opts),
+             {:ok, %Result{} = res} <- run_after_query(adapter, statement, res, context, vars) do
+          {:ok, res}
+        end
+      after
+        Relations.clear()
       end
 
     case result do

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -42,11 +42,15 @@ defmodule Lotus.Runner do
     # execute, rather than to the text the caller originally supplied.
     #
     # Preflight records its relations in the process dictionary, and only the
-    # success path consumes them. The `after` clause clears them on every other
-    # exit, so a failed statement cannot hand its tables to the next statement
-    # in the same process.
+    # success path consumes them. Clearing on both sides of the pipeline keeps
+    # them from crossing a statement boundary: on entry, because
+    # `Preflight.authorize/4` is public and a caller may have left its own
+    # behind, and in `after` on every exit, raises included, so a statement
+    # that fails cannot hand its tables to the next one in the same process.
     result =
       try do
+        Relations.clear()
+
         with {:ok, %Statement{} = statement} <-
                run_before_query(adapter, statement, context, vars),
              :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -1224,39 +1224,68 @@ defmodule Lotus.RunnerTest do
   describe "preflight relations between statements" do
     setup do
       Mimic.copy(Lotus.Config)
-      on_exit(&Lotus.Preflight.Relations.clear/0)
+      Mimic.copy(Lotus.Middleware)
+      Mimic.copy(Lotus.Source.Adapter)
       :ok
     end
 
+    # `CAST(email AS integer)` plans fine and fails only once a row is
+    # evaluated, so preflight passes and records its relations first. The
+    # issue's `1 / 0` cannot stand in for it: constant folding makes that fail
+    # inside preflight's own EXPLAIN, so it never reaches the path covered here.
+    @failing_statement "SELECT CAST(email AS integer) AS boom FROM test_users"
+
     test "clears the relations of a statement that fails during execution" do
-      assert {:error, _} =
-               Runner.run_statement(
-                 @pg_adapter,
-                 Statement.new("SELECT CAST(email AS integer) AS boom FROM test_users")
-               )
+      assert {:error, _} = Runner.run_statement(@pg_adapter, Statement.new(@failing_statement))
 
       assert Lotus.Preflight.Relations.get() == []
     end
 
     test "a failed statement does not lend its tables to the next statement" do
+      show = Statement.new("SHOW search_path")
+
+      assert {:ok, %{rows: [[unmasked_path]]}} = Runner.run_statement(@pg_adapter, show)
+
       Lotus.Config
       |> stub(:column_rules_for_source_name, fn _source ->
         [{"test_users", "search_path", [mask: {:fixed, "REDACTED"}]}]
       end)
 
-      assert {:error, _} =
-               Runner.run_statement(
-                 @pg_adapter,
-                 Statement.new("SELECT CAST(email AS integer) AS boom FROM test_users")
-               )
+      assert {:error, _} = Runner.run_statement(@pg_adapter, Statement.new(@failing_statement))
 
-      # `SHOW` skips preflight, so it never overwrites the relations the failed
-      # statement left behind. Its column must not take the rule for a table it
-      # does not read.
+      # `SHOW` skips preflight — see `EctoAdapter.do_needs_preflight?/2` — so it
+      # never overwrites what the failed statement left behind. Its column must
+      # not take the rule written for `test_users`.
       assert {:ok, %{columns: ["search_path"], rows: [[path]]}} =
-               Runner.run_statement(@pg_adapter, Statement.new("SHOW search_path"))
+               Runner.run_statement(@pg_adapter, show)
 
-      refute path == "REDACTED"
+      assert path == unmasked_path
+    end
+
+    # `exec_read_only/3` rescues, and `Middleware.run/2` turns a raising plug
+    # into `{:halt, _}`, so no exception escapes `run_statement/3` as the code
+    # stands — the `try/after` is defence in depth. Stubbing both boundaries
+    # forces the raise this pins: whatever else changes, an exception must not
+    # strand relations for the next statement.
+    test "a raise does not strand relations for the next statement" do
+      Lotus.Middleware
+      |> stub(:run, fn
+        :before_query, payload ->
+          Lotus.Preflight.Relations.put([{"public", "test_users"}])
+          {:cont, payload}
+
+        _event, payload ->
+          {:cont, payload}
+      end)
+
+      Lotus.Source.Adapter
+      |> stub(:sanitize_query, fn _adapter, _statement, _opts -> raise "boom" end)
+
+      assert_raise RuntimeError, "boom", fn ->
+        Runner.run_statement(@pg_adapter, Statement.new("SELECT 1"))
+      end
+
+      assert Lotus.Preflight.Relations.get() == []
     end
   end
 end

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -3,6 +3,7 @@ defmodule Lotus.RunnerTest do
   use Mimic
 
   alias Lotus.Fixtures
+  alias Lotus.Preflight.Relations
   alias Lotus.Query.Statement
   alias Lotus.Runner
   alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
@@ -1238,7 +1239,7 @@ defmodule Lotus.RunnerTest do
     test "clears the relations of a statement that fails during execution" do
       assert {:error, _} = Runner.run_statement(@pg_adapter, Statement.new(@failing_statement))
 
-      assert Lotus.Preflight.Relations.get() == []
+      assert Relations.get() == []
     end
 
     test "a failed statement does not lend its tables to the next statement" do
@@ -1271,7 +1272,7 @@ defmodule Lotus.RunnerTest do
       Lotus.Middleware
       |> stub(:run, fn
         :before_query, payload ->
-          Lotus.Preflight.Relations.put([{"public", "test_users"}])
+          Relations.put([{"public", "test_users"}])
           {:cont, payload}
 
         _event, payload ->
@@ -1285,7 +1286,7 @@ defmodule Lotus.RunnerTest do
         Runner.run_statement(@pg_adapter, Statement.new("SELECT 1"))
       end
 
-      assert Lotus.Preflight.Relations.get() == []
+      assert Relations.get() == []
     end
   end
 end

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -1220,4 +1220,43 @@ defmodule Lotus.RunnerTest do
   # exercise the *runtime* guard, which is what real (dynamic) callers hit.
   @spec runtime_term(term()) :: term()
   defp runtime_term(value), do: value
+
+  describe "preflight relations between statements" do
+    setup do
+      Mimic.copy(Lotus.Config)
+      on_exit(&Lotus.Preflight.Relations.clear/0)
+      :ok
+    end
+
+    test "clears the relations of a statement that fails during execution" do
+      assert {:error, _} =
+               Runner.run_statement(
+                 @pg_adapter,
+                 Statement.new("SELECT CAST(email AS integer) AS boom FROM test_users")
+               )
+
+      assert Lotus.Preflight.Relations.get() == []
+    end
+
+    test "a failed statement does not lend its tables to the next statement" do
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"test_users", "search_path", [mask: {:fixed, "REDACTED"}]}]
+      end)
+
+      assert {:error, _} =
+               Runner.run_statement(
+                 @pg_adapter,
+                 Statement.new("SELECT CAST(email AS integer) AS boom FROM test_users")
+               )
+
+      # `SHOW` skips preflight, so it never overwrites the relations the failed
+      # statement left behind. Its column must not take the rule for a table it
+      # does not read.
+      assert {:ok, %{columns: ["search_path"], rows: [[path]]}} =
+               Runner.run_statement(@pg_adapter, Statement.new("SHOW search_path"))
+
+      refute path == "REDACTED"
+    end
+  end
 end


### PR DESCRIPTION
Closes #258.

## Problem

`Lotus.Preflight` records the relations it authorises in the process
dictionary. `Lotus.Runner.handle_query_result/4` consumed them with
`Relations.take/0` only in the `{:ok, _}` clause — the `{:error, _}`
clause and the `rescue` in `exec_read_only/3` both returned without
clearing.

A statement that passed preflight and then failed during execution left
its relations behind. A later statement in the same process that skips
preflight (`EXPLAIN`, `SHOW`, `PRAGMA`) never overwrote them, so
`Visibility.column_policy_for/4` resolved its column policies against the
failed statement's tables. A column a rule masks could come back
unmasked; a column no rule covers could come back masked. A long-lived
process, such as a LiveView session, carried the stale value for every
query that followed.

## Change

`run_statement/3` wraps its pipeline in `try/after` and clears the
relations there. That is the second of the two options the issue lists —
it covers every exit, a raise a caller catches higher up included, and
does not depend on finding each new error path a later change adds.

## Tests

Two new tests in `test/lotus/runner_test.exs`, both of which fail on
`main`:

- the relations are empty after a statement that fails during execution
- the issue's reproduction end to end: a statement touching `test_users`
  fails during execution, then a `SHOW` — which skips preflight — must
  not take the column rule written for `test_users`

`mix compile --warnings-as-errors`, `mix format --check-formatted` and
the full suite (1959 tests) pass.

## Note on the issue's "Related" section

`Lotus.Middleware`'s event table already reads "First, before
sanitization, preflight and execution" for `:before_query`, so the
documentation correction the issue asks for is already in place. No
change was needed there.