### PR TITLE
feat(middleware): add a :before_execute event carrying preflight relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`:before_execute` middleware event.** A plug that must authorise a
+  statement against the tables it touches had no way to learn them:
+  `:before_query` runs before the statement is analysed, on purpose, so a
+  rewriting plug can still change what gets analysed. The new event fires
+  after sanitization and preflight pass and before the statement executes,
+  and its payload carries `:relations` — the `{schema, table}` pairs preflight
+  proved the statement touches — alongside `:statement`, `:source`,
+  `:context` and `:vars`. A halt returns `{:error, reason}` to the caller, as
+  the other events do. `:relations` is `[]` when the adapter needs no
+  preflight, and `{:unrestricted, reason}` when the adapter cannot name the
+  relations a statement touches; both mean "unknown", not "touches nothing",
+  and a plug that gates on the list must refuse rather than read them as an
+  empty set.
+
 ### Fixed
 
 - **A failed statement no longer hands its tables to the next statement in

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ For the complete setup guide (caching, multiple databases, visibility controls),
 - **AI query optimization** — get actionable optimization suggestions (indexes, rewrites, schema changes) powered by query-plan analysis
 - **Adapter-driven AI** — each adapter describes its own query language, example query, syntax notes, and error patterns through `ai_context/1`, so the assistant speaks the engine's dialect instead of assuming SQL. Free-form adapter text only reaches the prompt for adapters you list in `:trusted_source_adapters`
 - **Three-level visibility** — schema, table, and column rules, with schema taking precedence over table and per-column `:omit` / `{:mask, _}` / `:error` policies applied to result rows
-- **Middleware** — a plug-style pipeline with `:before_query`, `:after_query`, and `:after_list_*` hooks for auditing, access control, and per-tenant statement rewriting
+- **Middleware** — a plug-style pipeline with `:before_query`, `:before_execute`, `:after_query`, and `:after_list_*` hooks for auditing, access control, per-tenant statement rewriting, and authorizing on the tables a statement provably touches
 - **Telemetry** — `[:lotus, ...]` events for query execution, schema introspection, and cache hits and misses
 - **Read-only by default** — all queries run in read-only transactions with automatic timeout controls and session state management (opt out per-query with `read_only: false`)
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -486,9 +486,9 @@ config :lotus,
 **Type**: `map()` or `nil` — `%{event => [{Module, opts}]}`
 **Default**: `nil`
 
-**Events**: `:before_query`, `:after_query`, `:after_list_schemas`, `:after_list_tables`, `:after_describe_table`, `:after_list_relations`, `:after_discover`.
+**Events**: `:before_query`, `:before_execute`, `:after_query`, `:after_list_schemas`, `:after_list_tables`, `:after_describe_table`, `:after_list_relations`, `:after_discover`.
 
-In v1.0 the payload key for the data source is `:source` (it was `:repo`), and `:before_query` / `:after_query` carry a `%Lotus.Query.Statement{}` under `:statement` instead of separate `:sql` and `:params` keys. A `:before_query` plug that returns `{:cont, %{payload | statement: rewritten}}` changes what actually executes, and the rewritten statement is the one that sanitization and preflight then check. See the [Middleware Guide](middleware.md).
+In v1.0 the payload key for the data source is `:source` (it was `:repo`), and `:before_query` / `:after_query` carry a `%Lotus.Query.Statement{}` under `:statement` instead of separate `:sql` and `:params` keys. A `:before_query` plug that returns `{:cont, %{payload | statement: rewritten}}` changes what actually executes, and the rewritten statement is the one that sanitization and preflight then check. `:before_execute` runs after preflight and adds a `:relations` key — the `{schema, table}` pairs preflight proved the statement touches — for plugs that authorize on tables rather than rewrite. See the [Middleware Guide](middleware.md).
 
 #### `ai`
 

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -116,10 +116,10 @@ Everything lives under `lib/lotus/`. The library is roughly split into a public 
 **Query pipeline**
 
 - [`Lotus.Query.Statement`](../lib/lotus/query/statement.ex) — The opaque carrier threaded through the whole pipeline: `:adapter`, `:body` (adapter-native term — SQL text, a JSON map, a DSL AST), `:params` (list for positional binds, map for named binds), and `:meta`.
-- [`Lotus.Runner`](../lib/lotus/runner.ex) — Execution engine. Runs `:before_query` middleware, asks the adapter to sanitize the statement, invokes preflight, executes inside a read-only transaction, and applies column-level visibility policies to the result.
+- [`Lotus.Runner`](../lib/lotus/runner.ex) — Execution engine. Runs `:before_query` middleware, asks the adapter to sanitize the statement, invokes preflight, runs `:before_execute` middleware with the relations preflight found, executes inside a read-only transaction, and applies column-level visibility policies to the result.
 - [`Lotus.Preflight`](../lib/lotus/preflight.ex) — Asks the adapter which relations a statement will touch before executing it (`EXPLAIN` for the Ecto adapter) and checks them against visibility rules.
 - [`Lotus.Preflight.Relations`](../lib/lotus/preflight/relations.ex) — Process-local staging for relations discovered during preflight so the runner can reuse them when applying column policies.
-- [`Lotus.Middleware`](../lib/lotus/middleware.ex) — Plug-style pipeline compiled into `:persistent_term`. Supports `:before_query`, `:after_query`, `:after_list_schemas`, `:after_list_tables`, `:after_describe_table`, `:after_list_relations`, and `:after_discover`.
+- [`Lotus.Middleware`](../lib/lotus/middleware.ex) — Plug-style pipeline compiled into `:persistent_term`. Supports `:before_query`, `:before_execute`, `:after_query`, `:after_list_schemas`, `:after_list_tables`, `:after_describe_table`, `:after_list_relations`, and `:after_discover`.
 - [`Lotus.Result`](../lib/lotus/result.ex) / [`Lotus.Result.Statistics`](../lib/lotus/result/statistics.ex) — The struct returned from query execution.
 - [`Lotus.UnsupportedOperatorError`](../lib/lotus/unsupported_operator_error.ex) — Raised when a filter asks for an operator the adapter did not declare in `supported_filter_operators/1`. Silent degradation is not an option.
 
@@ -218,10 +218,11 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
 │  2. Middleware.run(:before_query, _) — may rewrite the statement     │
 │  3. Adapter.sanitize_query (single statement + deny list)            │
 │  4. Adapter.needs_preflight? → Lotus.Preflight.authorize             │
-│  5. Adapter.transaction (read-only) → Adapter.execute_query          │
-│  6. Column policy enforcement (omit / mask / error)                  │
-│  7. Middleware.run(:after_query, _)                                  │
-│  8. Telemetry.query_stop / query_exception                           │
+│  5. Middleware.run(:before_execute, _) — carries the relations       │
+│  6. Adapter.transaction (read-only) → Adapter.execute_query          │
+│  7. Column policy enforcement (omit / mask / error)                  │
+│  8. Middleware.run(:after_query, _)                                  │
+│  9. Telemetry.query_stop / query_exception                           │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
@@ -234,8 +235,8 @@ A few notes on the pipeline:
 - **Filters and sorts** are injected through the adapter, not concatenated naively — see `Lotus.Source.Adapters.Ecto.SQL.FilterInjector` and `SortInjector`. An adapter must declare the operators it handles via `supported_filter_operators/1`; anything else raises `Lotus.UnsupportedOperatorError`.
 - **Pagination** has two strategies for `count: :exact`. An engine that returns the total as a side-effect of the main query puts it in `execute_query/4`'s `:total_count` key; everything else places a count spec in `statement.meta[:count_spec]` and Lotus core runs it. The inline count wins when both are present.
 - **Caching** is optional. When no cache adapter is configured, `Lotus.Cache` is a pass-through and the fetcher always runs.
-- **Preflight** is skipped when `needs_preflight?/2` returns false (the Ecto adapter keeps the `EXPLAIN` / `SHOW` / `PRAGMA` heuristic internally). The relations it discovers are stashed in `Lotus.Preflight.Relations` so the runner can look up column visibility policies without re-parsing the statement. An adapter that cannot enumerate resources returns `{:unrestricted, reason}`, which is blocked unless the operator opts in with `:allow_unrestricted_resources`.
-- **Middleware runs first**, before sanitization and preflight, because a `:before_query` plug may rewrite the statement — row-level security and tenant predicates are the point of the hook. Sanitization and preflight then apply to whatever will actually execute. Halting from a `:before_query` plug yields `{:error, reason}` to the caller.
+- **Preflight** is skipped when `needs_preflight?/2` returns false (the Ecto adapter keeps the `EXPLAIN` / `SHOW` / `PRAGMA` heuristic internally). The relations it discovers are stashed in `Lotus.Preflight.Relations`, from where the runner reads them once and carries them down the pipeline — to `:before_execute` middleware, and to column visibility policy lookup, without re-parsing the statement. An adapter that cannot enumerate resources returns `{:unrestricted, reason}`, which is blocked unless the operator opts in with `:allow_unrestricted_resources`.
+- **Middleware runs first**, before sanitization and preflight, because a `:before_query` plug may rewrite the statement — row-level security and tenant predicates are the point of the hook. Sanitization and preflight then apply to whatever will actually execute. Halting from a `:before_query` plug yields `{:error, reason}` to the caller. A plug that needs the table list instead of the chance to rewrite registers `:before_execute`, which runs once preflight has named the relations.
 
 ### Schema Introspection Flow
 

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -26,6 +26,7 @@ Each middleware receives a payload map whose contents depend on the pipeline eve
 | Event | Triggered | Payload keys |
 |-------|-----------|--------------|
 | `:before_query` | Before sanitization, preflight and execution | `:statement`, `:source`, `:context`, `:vars` |
+| `:before_execute` | After sanitization and preflight pass, before execution | `:statement`, `:relations`, `:source`, `:context`, `:vars` |
 | `:after_query` | After execution, before result returned to caller | `:result`, `:statement`, `:source`, `:context`, `:vars` |
 | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
 | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |
@@ -89,6 +90,54 @@ in force.
 Returning the payload unchanged leaves the original statement in place, so
 existing audit and access-control plugs need no changes.
 
+## Authorizing on the Tables a Statement Touches
+
+`:before_query` runs before the statement is analysed, so at that point Lotus
+does not yet know which tables it reads. `:before_execute` runs after
+sanitization and preflight have passed and before the statement executes, and
+its payload carries `:relations` — the `{schema, table}` pairs preflight proved
+the statement touches, for the statement a `:before_query` plug rewrote:
+
+```elixir
+defmodule MyApp.TableAuthz do
+  def init(opts), do: opts
+
+  def call(%{relations: relations, context: %{user: user}} = payload, _opts)
+      when is_list(relations) and relations != [] do
+    if Enum.all?(relations, &MyApp.Authz.may_read?(user, &1)) do
+      {:cont, payload}
+    else
+      {:halt, "not authorized for one of the tables this query reads"}
+    end
+  end
+
+  # `[]` and `{:unrestricted, reason}` both mean Lotus could not name the
+  # tables, not that the statement touches none. A plug that gates on the
+  # list must refuse rather than read either as an empty set.
+  def call(_payload, _opts), do: {:halt, "cannot determine which tables this query reads"}
+end
+```
+
+Halting returns `{:error, reason}` to the caller and the statement never runs.
+
+`:relations` is `[]` when the adapter's `needs_preflight?/2` returns false for
+the statement — no analysis ran. It is `{:unrestricted, reason}` when the
+adapter cannot name the relations a statement touches (Elasticsearch, for one)
+and the host opted in via `:allow_unrestricted_resources`. The two forms are
+distinct so a plug can log which case it hit.
+
+The two query hooks answer different questions, and both can be registered:
+
+| Hook | Question |
+|------|----------|
+| `:before_query` | May this caller run a statement, and what statement should run? |
+| `:before_execute` | Given what this statement provably touches, may it proceed? |
+
+A row-level-security plug that rewrites the statement uses the first. An
+authorization plug that gates on tables uses the second. A `:before_execute`
+plug may not rewrite the statement: preflight has already authorized the one in
+the payload, and that is the one that executes.
+
 ## Configuration
 
 Register middleware in your Lotus config. Each entry is a `{module, opts}` tuple — `opts` is passed to `init/1` at compile time:
@@ -99,6 +148,9 @@ config :lotus,
     before_query: [
       {MyApp.AccessControlMiddleware, []},
       {MyApp.QueryAuditMiddleware, [repo: MyApp.AuditRepo]}
+    ],
+    before_execute: [
+      {MyApp.TableAuthz, []}
     ],
     after_query: [
       {MyApp.ResultRedactionMiddleware, [fields: ~w(email phone ssn)]}
@@ -128,7 +180,7 @@ payload.
 `:scope` identifies *who is asking*. Lotus hashes it into cache keys and passes
 it to the visibility resolver, so a resolver can hide tables or mask columns per
 tenant or per role. It is present on the discovery event payloads
-(`:after_list_*`, `:after_discover`), not on `:before_query` / `:after_query`.
+(`:after_list_*`, `:after_discover`), not on the query events.
 
 ```elixir
 # Pass both when running a query

--- a/lib/lotus/config.ex
+++ b/lib/lotus/config.ex
@@ -265,8 +265,8 @@ defmodule Lotus.Config do
 
       Format: %{event => [{Module, opts}]}
 
-      Events: :before_query, :after_query, :after_list_schemas, :after_list_tables,
-      :after_describe_table, :after_list_relations, :after_discover
+      Events: :before_query, :before_execute, :after_query, :after_list_schemas,
+      :after_list_tables, :after_describe_table, :after_list_relations, :after_discover
 
       ## Example
 

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -20,12 +20,42 @@ defmodule Lotus.Middleware do
   | Event | Triggered | Payload keys |
   |-------|-----------|--------------|
   | `:before_query` | First, before sanitization, preflight and execution | `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
+  | `:before_execute` | After sanitization and preflight pass, before execution | `:statement` (`%Lotus.Query.Statement{}`), `:relations`, `:source`, `:context`, `:vars` |
   | `:after_query` | After execution, before result returned to caller | `:result`, `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
   | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
   | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |
   | `:after_describe_table` | After table schema introspection and column visibility | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
   | `:after_list_relations` | After relation discovery and visibility filtering | `:relations`, `:source`, `:scope`, `:context` |
   | `:after_discover` | After any discovery call, following the kind-specific `:after_list_*` event | `:kind`, `:result`, `:source`, `:scope`, `:context` |
+
+  ### Query event ordering
+
+  `:before_query` fires first, before sanitization and preflight, because a
+  plug may rewrite the statement — row-level security and tenant predicates
+  are the point of the hook. Sanitization and preflight then apply to what
+  will actually execute.
+
+  `:before_execute` fires after sanitization and preflight pass and before the
+  statement executes. Its `:statement` is the rewritten one, and its
+  `:relations` is what preflight proved the statement touches. The two hooks
+  answer different questions: `:before_query` asks which statement should run,
+  `:before_execute` asks whether the statement may proceed given what it
+  provably touches.
+
+  #### The `:relations` payload
+
+  `:relations` is a list of `{schema, table}` tuples, where `schema` is `nil`
+  for a source that has no schemas. Two values mean "Lotus cannot name the
+  tables", not "the statement touches none":
+
+    * `[]` — the adapter's `needs_preflight?/2` returned false for this
+      statement, so no analysis ran.
+    * `{:unrestricted, reason}` — the adapter cannot name the relations a
+      statement touches (Elasticsearch, for one), and the host opted in via
+      `:allow_unrestricted_resources`.
+
+  A plug that authorizes on the table list must treat both as unknown and
+  halt, rather than read them as an empty set of tables.
 
   `:vars` is the map of bound query variables, by name, after defaults and
   caller-supplied values are merged (`%{"start_date" => "2026-01-01"}`).
@@ -74,6 +104,7 @@ defmodule Lotus.Middleware do
 
   @type event ::
           :before_query
+          | :before_execute
           | :after_query
           | :after_list_schemas
           | :after_list_tables

--- a/lib/lotus/preflight.ex
+++ b/lib/lotus/preflight.ex
@@ -12,7 +12,9 @@ defmodule Lotus.Preflight do
   When an adapter returns `{:unrestricted, reason}` the statement is allowed
   through only if the host application has opted in via
   `config :lotus, :allow_unrestricted_resources`; otherwise preflight returns
-  an error.
+  an error. The opted-in case records `{:unrestricted, reason}` rather than a
+  relation list, so a later consumer can tell "touches no table" apart from
+  "this adapter cannot name its tables".
   """
 
   alias Lotus.Config
@@ -56,6 +58,7 @@ defmodule Lotus.Preflight do
 
   defp handle_unrestricted(%Adapter{name: name}, reason) do
     if Config.allow_unrestricted_resources?(name) do
+      Relations.put({:unrestricted, reason})
       :ok
     else
       {:error,

--- a/lib/lotus/preflight/relations.ex
+++ b/lib/lotus/preflight/relations.ex
@@ -1,51 +1,74 @@
 defmodule Lotus.Preflight.Relations do
   @moduledoc """
-  Manages preflight relations stored in the process dictionary.
+  Manages the preflight outcome stored in the process dictionary.
 
   This module provides a clean interface for storing and retrieving
-  relations discovered during SQL preflight authorization, which are
-  later used for column-level visibility policies.
+  the relations discovered during SQL preflight authorization, which are
+  later used for column-level visibility policies and handed to
+  `:before_execute` middleware.
+
+  The stored value is either a list of `{schema, table}` relations or
+  `{:unrestricted, reason}` for an adapter that cannot name the relations a
+  statement touches. The second form lets a caller tell "this statement
+  touches no table" apart from "this adapter cannot say".
   """
 
   @process_key :lotus_preflight_relations
 
-  @doc """
-  Stores the list of relations in the process dictionary.
+  @type relation :: {String.t() | nil, String.t()}
+  @type outcome :: [relation()] | {:unrestricted, String.t()}
 
-  These relations are discovered during preflight authorization
-  and will be used later for column visibility checks.
+  @doc """
+  Stores the preflight outcome in the process dictionary.
+
+  Accepts the list of relations discovered during preflight authorization,
+  or `{:unrestricted, reason}` when the adapter cannot name them.
   """
-  @spec put([{String.t(), String.t()}]) :: :ok
-  def put(relations) when is_list(relations) do
-    Process.put(@process_key, relations)
+  @spec put(outcome()) :: :ok
+  def put(relations) when is_list(relations), do: store(relations)
+  def put({:unrestricted, reason} = outcome) when is_binary(reason), do: store(outcome)
+
+  defp store(outcome) do
+    Process.put(@process_key, outcome)
     :ok
   end
 
   @doc """
-  Retrieves the list of relations from the process dictionary.
+  Retrieves the preflight outcome from the process dictionary.
 
-  Returns an empty list if no relations have been stored.
+  Returns an empty list if no outcome has been stored.
   """
-  @spec get() :: [{String.t(), String.t()}]
+  @spec get() :: outcome()
   def get do
     Process.get(@process_key) || []
   end
 
   @doc """
-  Retrieves and clears the list of relations from the process dictionary.
+  Retrieves and clears the preflight outcome from the process dictionary.
 
-  This is typically called after the relations have been consumed
-  to ensure they don't leak to subsequent operations.
+  This is typically called after the outcome has been consumed
+  to ensure it doesn't leak to subsequent operations.
   """
-  @spec take() :: [{String.t(), String.t()}]
+  @spec take() :: outcome()
   def take do
-    relations = get()
+    outcome = get()
     clear()
-    relations
+    outcome
   end
 
   @doc """
-  Clears the stored relations from the process dictionary.
+  Narrows a preflight outcome to the list of relations it names.
+
+  An `{:unrestricted, reason}` outcome names none, so it narrows to `[]`.
+  Column visibility policies use this: a relation Lotus cannot name is a
+  relation it cannot write a policy for.
+  """
+  @spec to_list(outcome()) :: [relation()]
+  def to_list(relations) when is_list(relations), do: relations
+  def to_list({:unrestricted, _reason}), do: []
+
+  @doc """
+  Clears the stored outcome from the process dictionary.
   """
   @spec clear() :: :ok
   def clear do

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -41,12 +41,13 @@ defmodule Lotus.Runner do
     # predicates. Sanitization and preflight then apply to what will actually
     # execute, rather than to the text the caller originally supplied.
     #
-    # Preflight records its relations in the process dictionary, and only the
-    # success path consumes them. Clearing on both sides of the pipeline keeps
-    # them from crossing a statement boundary: on entry, because
-    # `Preflight.authorize/4` is public and a caller may have left its own
-    # behind, and in `after` on every exit, raises included, so a statement
-    # that fails cannot hand its tables to the next one in the same process.
+    # Preflight records its relations in the process dictionary, and
+    # `preflight_visibility/3` reads them out once and carries them down the
+    # pipeline explicitly. Clearing on both sides keeps them from crossing a
+    # statement boundary: on entry, because `Preflight.authorize/4` is public
+    # and a caller may have left its own behind, and in `after` on every exit,
+    # raises included, so a statement that fails cannot hand its tables to the
+    # next one in the same process.
     result =
       try do
         Relations.clear()
@@ -54,8 +55,9 @@ defmodule Lotus.Runner do
         with {:ok, %Statement{} = statement} <-
                run_before_query(adapter, statement, context, vars),
              :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
-             :ok <- preflight_visibility(adapter, statement, opts),
-             {:ok, %Result{} = res} <- exec_read_only(adapter, statement, opts),
+             {:ok, relations} <- preflight_visibility(adapter, statement, opts),
+             :ok <- run_before_execute(adapter, statement, relations, context, vars),
+             {:ok, %Result{} = res} <- exec_read_only(adapter, statement, relations, opts),
              {:ok, %Result{} = res} <- run_after_query(adapter, statement, res, context, vars) do
           {:ok, res}
         end
@@ -78,7 +80,12 @@ defmodule Lotus.Runner do
     end
   end
 
-  defp exec_read_only(%Adapter{} = adapter, %Statement{body: body, params: params}, opts) do
+  defp exec_read_only(
+         %Adapter{} = adapter,
+         %Statement{body: body, params: params},
+         relations,
+         opts
+       ) do
     Adapter.transaction(
       adapter,
       fn _state ->
@@ -89,7 +96,7 @@ defmodule Lotus.Runner do
             Adapter.execute_query(adapter, body, params, opts ++ [timeout: timeout])
           end)
 
-        handle_query_result(res, elapsed_us, adapter, Keyword.get(opts, :scope))
+        handle_query_result(res, elapsed_us, adapter, relations, Keyword.get(opts, :scope))
       end,
       opts
     )
@@ -105,13 +112,14 @@ defmodule Lotus.Runner do
          {:ok, %{columns: cols, rows: rows} = raw},
          elapsed_us,
          %Adapter{} = adapter,
+         relations,
          scope
        ) do
     num_rows = Map.get(raw, :num_rows, length(rows || []))
     command = normalize_command(Map.get(raw, :command))
     duration_ms = System.convert_time_unit(elapsed_us, :microsecond, :millisecond)
 
-    rels = Relations.take()
+    rels = Relations.to_list(relations)
 
     policies =
       Enum.map(cols || [], fn c ->
@@ -138,11 +146,11 @@ defmodule Lotus.Runner do
     end
   end
 
-  defp handle_query_result({:error, err}, _elapsed_us, _adapter, _scope) do
+  defp handle_query_result({:error, err}, _elapsed_us, _adapter, _relations, _scope) do
     {:error, err}
   end
 
-  defp handle_query_result(other, _elapsed_us, _adapter, _scope) do
+  defp handle_query_result(other, _elapsed_us, _adapter, _relations, _scope) do
     other
   end
 
@@ -273,6 +281,31 @@ defmodule Lotus.Runner do
     end
   end
 
+  # Fires once sanitization and preflight have passed, with the relations
+  # preflight proved the statement touches. A plug may inspect but not rewrite
+  # here — the statement has already been authorized, so the one that executes
+  # must be the one preflight saw.
+  defp run_before_execute(
+         %Adapter{} = adapter,
+         %Statement{} = statement,
+         relations,
+         context,
+         vars
+       ) do
+    payload = %{
+      source: adapter.name,
+      statement: statement,
+      relations: relations,
+      context: context,
+      vars: vars
+    }
+
+    case Middleware.run(:before_execute, payload) do
+      {:cont, _payload} -> :ok
+      {:halt, reason} -> {:error, reason}
+    end
+  end
+
   defp run_after_query(
          %Adapter{} = adapter,
          %Statement{} = statement,
@@ -294,17 +327,21 @@ defmodule Lotus.Runner do
     end
   end
 
+  # Returns what preflight proved the statement touches: a list of
+  # `{schema, table}`, or `{:unrestricted, reason}` for an adapter that cannot
+  # name them. An adapter that needs no preflight yields `[]` — nothing was
+  # analysed, so nothing is known.
   defp preflight_visibility(%Adapter{} = adapter, %Statement{} = statement, opts) do
     if Adapter.needs_preflight?(adapter, statement) do
       search_path = Keyword.get(opts, :search_path)
       scope = Keyword.get(opts, :scope)
 
       case Preflight.authorize(adapter, statement, search_path, scope) do
-        :ok -> :ok
+        :ok -> {:ok, Relations.get()}
         {:error, msg} -> {:error, msg}
       end
     else
-      :ok
+      {:ok, []}
     end
   rescue
     e -> {:error, Exception.message(e)}

--- a/test/lotus/middleware_before_execute_test.exs
+++ b/test/lotus/middleware_before_execute_test.exs
@@ -1,0 +1,137 @@
+defmodule Lotus.MiddlewareBeforeExecuteTest do
+  @moduledoc """
+  `:before_execute` fires after sanitization and preflight pass and before the
+  statement runs, carrying the relations preflight proved the statement
+  touches.
+
+  This is what an authorization plug that gates on tables needs. `:before_query`
+  cannot serve it: it runs before the statement is analysed, on purpose, so a
+  rewriting plug can still change what gets analysed.
+  """
+
+  use Lotus.Case
+
+  alias Lotus.Middleware
+  alias Lotus.Test.Schemas.User
+
+  defmodule CapturePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, _opts) do
+      send(self(), {:before_execute, payload})
+      {:cont, payload}
+    end
+  end
+
+  defmodule HaltPlug do
+    @moduledoc false
+    def init(opts), do: opts
+    def call(_payload, _opts), do: {:halt, "denied by table authz"}
+  end
+
+  defmodule OrderPlug do
+    @moduledoc false
+    def init(event), do: event
+
+    def call(payload, event) do
+      send(self(), {:fired, event})
+      {:cont, payload}
+    end
+  end
+
+  defmodule RewritePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{statement: statement} = payload, _opts) do
+      {:cont,
+       %{payload | statement: %{statement | body: "SELECT id FROM test_users WHERE id = 1"}}}
+    end
+  end
+
+  setup do
+    on_exit(fn -> :persistent_term.erase({Lotus.Middleware, :compiled}) end)
+
+    Repo.insert!(%User{id: 1, name: "Ada", email: "ada@example.test"})
+    Repo.insert!(%User{id: 2, name: "Grace", email: "grace@example.test"})
+
+    :ok
+  end
+
+  test "the payload carries the relations preflight found" do
+    Middleware.compile(%{before_execute: [{CapturePlug, []}]})
+
+    assert {:ok, _result} =
+             Lotus.run_statement("SELECT id FROM test_users", [], repo: "postgres")
+
+    assert_received {:before_execute, payload}
+    assert payload.relations == [{"public", "test_users"}]
+  end
+
+  test "the payload carries the statement, source, context and vars" do
+    Middleware.compile(%{before_execute: [{CapturePlug, []}]})
+
+    assert {:ok, _result} =
+             Lotus.run_statement("SELECT id FROM test_users", [],
+               repo: "postgres",
+               context: %{user_id: 7}
+             )
+
+    assert_received {:before_execute, payload}
+    assert payload.source == "postgres"
+    assert payload.context == %{user_id: 7}
+    assert payload.vars == %{}
+    assert payload.statement.body == "SELECT id FROM test_users"
+  end
+
+  test "a halt returns {:error, reason} and the statement never runs" do
+    Middleware.compile(%{before_execute: [{HaltPlug, []}]})
+
+    assert {:error, "denied by table authz"} =
+             Lotus.run_statement("SELECT id FROM test_users", [], repo: "postgres")
+  end
+
+  test "relations describe the statement a :before_query plug rewrote" do
+    Middleware.compile(%{
+      before_query: [{RewritePlug, []}],
+      before_execute: [{CapturePlug, []}]
+    })
+
+    assert {:ok, result} =
+             Lotus.run_statement("SELECT id FROM test_users", [], repo: "postgres")
+
+    assert result.rows == [[1]]
+
+    assert_received {:before_execute, payload}
+    assert payload.statement.body == "SELECT id FROM test_users WHERE id = 1"
+    assert payload.relations == [{"public", "test_users"}]
+  end
+
+  test "fires after :before_query and before :after_query" do
+    Middleware.compile(%{
+      before_query: [{OrderPlug, :before_query}],
+      before_execute: [{OrderPlug, :before_execute}],
+      after_query: [{OrderPlug, :after_query}]
+    })
+
+    assert {:ok, _result} =
+             Lotus.run_statement("SELECT id FROM test_users", [], repo: "postgres")
+
+    # Bound patterns, so the mailbox order is the assertion.
+    assert_received {:fired, first}
+    assert_received {:fired, second}
+    assert_received {:fired, third}
+    assert [first, second, third] == [:before_query, :before_execute, :after_query]
+  end
+
+  test "a statement blocked by preflight never reaches :before_execute" do
+    Middleware.compile(%{before_execute: [{CapturePlug, []}]})
+
+    assert {:error, msg} =
+             Lotus.run_statement("SELECT * FROM lotus_queries", [], repo: "postgres")
+
+    assert msg =~ "blocked table"
+    refute_received {:before_execute, _payload}
+  end
+end

--- a/test/lotus/middleware_before_execute_unrestricted_test.exs
+++ b/test/lotus/middleware_before_execute_unrestricted_test.exs
@@ -1,0 +1,73 @@
+defmodule Lotus.MiddlewareBeforeExecuteUnrestrictedTest do
+  @moduledoc """
+  An adapter that cannot name the relations a statement touches reaches
+  `:before_execute` as `{:unrestricted, reason}`, not as `[]`.
+
+  The distinction is the point: `[]` and `{:unrestricted, _}` both mean "Lotus
+  cannot name the tables", but only the tuple says why, so a plug can log the
+  adapter's own reason rather than guessing.
+  """
+
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Lotus.Middleware
+  alias Lotus.Query.Statement
+  alias Lotus.Runner
+  alias Lotus.Test.InMemoryAdapter
+
+  @dataset_tables %{
+    "users" => %{
+      columns: ["id", "name"],
+      rows: [[1, "Ada"]],
+      types: %{"id" => "integer", "name" => "text"}
+    }
+  }
+
+  defmodule CapturePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, _opts) do
+      send(self(), {:before_execute, payload})
+      {:cont, payload}
+    end
+  end
+
+  setup :set_mimic_from_context
+
+  setup do
+    Mimic.copy(Lotus.Config)
+    on_exit(fn -> :persistent_term.erase({Lotus.Middleware, :compiled}) end)
+    :ok
+  end
+
+  defp adapter do
+    InMemoryAdapter.adapter("mem", InMemoryAdapter.dataset(tables: @dataset_tables))
+  end
+
+  defp stmt(body), do: %Statement{adapter: InMemoryAdapter, body: body}
+
+  test "an adapter that can name its relations yields the list" do
+    stub(Lotus.Config, :allow_unrestricted_resources?, fn _name -> false end)
+    Middleware.compile(%{before_execute: [{CapturePlug, []}]})
+
+    assert {:ok, _result} = Runner.run_statement(adapter(), stmt(%{from: "users"}))
+
+    assert_received {:before_execute, payload}
+    assert payload.relations == [{nil, "users"}]
+  end
+
+  test "an adapter that cannot name its relations yields {:unrestricted, reason}" do
+    stub(Lotus.Config, :allow_unrestricted_resources?, fn "mem" -> true end)
+    Middleware.compile(%{before_execute: [{CapturePlug, []}]})
+
+    # A DSL body with no `:from` is one the in-memory adapter cannot analyse,
+    # so `extract_accessed_resources/2` returns `{:unrestricted, reason}`.
+    Runner.run_statement(adapter(), stmt(%{select: ["id"]}))
+
+    assert_received {:before_execute, payload}
+    assert {:unrestricted, reason} = payload.relations
+    assert reason =~ "missing :from"
+  end
+end

--- a/test/lotus/preflight/relations_test.exs
+++ b/test/lotus/preflight/relations_test.exs
@@ -25,6 +25,24 @@ defmodule Lotus.Preflight.RelationsTest do
       assert :ok = Relations.put([])
       assert Process.get(:lotus_preflight_relations) == []
     end
+
+    test "stores an unrestricted outcome" do
+      assert :ok = Relations.put({:unrestricted, "adapter cannot name its tables"})
+
+      assert Process.get(:lotus_preflight_relations) ==
+               {:unrestricted, "adapter cannot name its tables"}
+    end
+  end
+
+  describe "to_list/1" do
+    test "returns a relation list unchanged" do
+      assert Relations.to_list([{"public", "users"}]) == [{"public", "users"}]
+      assert Relations.to_list([]) == []
+    end
+
+    test "narrows an unrestricted outcome to no relations" do
+      assert Relations.to_list({:unrestricted, "cannot name its tables"}) == []
+    end
   end
 
   describe "get/0" do


### PR DESCRIPTION
Closes #259.

## Problem

A middleware plug that must authorise a statement against the tables it touches has no good way to learn those tables. `:before_query` runs before preflight — deliberately, so a rewriting plug can still change what gets analysed — so at that point the statement has not been analysed yet.

## Change

A new `:before_execute` event. It fires after `sanitize_query/3` and `preflight_visibility/3` pass, and before `exec_read_only/3`.

| Key | Value |
|-----|-------|
| `:statement` | the `%Lotus.Query.Statement{}` that will execute, after any `:before_query` rewrite |
| `:relations` | what preflight found, as a list of `{schema, table}` |
| `:source` | the source name |
| `:context` | the caller's opaque context |
| `:vars` | the bound variables |

A halt returns `{:error, reason}` to the caller, as the other events do.

`:relations` is `[]` when `Adapter.needs_preflight?/2` returns false, and `{:unrestricted, reason}` when the adapter cannot name the relations a statement touches (Elasticsearch is the case that matters). Both mean "unknown", not "touches nothing" — documented on `Lotus.Middleware`, in the guide, and in the worked plug example.

## Notes

- `Lotus.Preflight.Relations` now stores either a relation list or `{:unrestricted, reason}`, with `to_list/1` narrowing the second form to `[]` for column-policy lookup. `Preflight` records the marker on the opted-in unrestricted path, where it previously recorded nothing.
- `Lotus.Runner` reads the preflight outcome out of the process dictionary once, in `preflight_visibility/3`, and carries it down the pipeline explicitly. The result path no longer reads the process dictionary at all.
- `Lotus.Preflight.authorize/4` keeps its `:ok | {:error, reason}` return — no public API changed.

## Verification

`mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` and `mix test` (1971 tests) all pass.