### PR TITLE
fix(middleware): run :before_query and :after_query outside the result cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@
 
 ### Fixed
 
+- **`:before_query` and `:after_query` are no longer skipped on a result cache
+  hit.** Both events ran inside the cache callback, so a plug saw only the call
+  that filled the cache: a `:before_query` plug that halts for one user let the
+  same statement through for the next one while the entry was warm, and an audit
+  plug on `:after_query` recorded one execution in place of many. `:context` is
+  not part of the cache key, so two callers with different contexts and the same
+  scope shared one entry. The query middleware now runs outside the callback, as
+  discovery middleware already did: `:before_query` runs before the cache key is
+  built — so a statement it rewrites keys its own entry — only the raw execution
+  is stored, and `:after_query` runs on the result whether it came from the cache
+  or from the source, without writing what it returns back to the cache.
+  `:before_execute` stays inside the callback, next to the preflight whose
+  relations it carries. `Lotus.Runner` exposes the three phases as
+  `before_query/3`, `execute_statement/3` and `after_query/4`;
+  `run_statement/3` composes them and behaves as before, except that
+  `[:lotus, :query, *]` telemetry now brackets the execution phase alone, so a
+  middleware halt emits no query events.
+
 - **A failed statement no longer hands its tables to the next statement in
   the same process.** Preflight records the relations it authorised in the
   process dictionary, and `Lotus.Runner` consumed them only on the success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,27 +16,39 @@
   preflight, and `{:unrestricted, reason}` when the adapter cannot name the
   relations a statement touches; both mean "unknown", not "touches nothing",
   and a plug that gates on the list must refuse rather than read them as an
-  empty set.
+  empty set. The event fires on a result served from the result cache too: the
+  relations are stored with the result, so a plug that authorizes a statement
+  against its tables is not skipped once the cache is warm.
 
 ### Fixed
 
-- **`:before_query` and `:after_query` are no longer skipped on a result cache
-  hit.** Both events ran inside the cache callback, so a plug saw only the call
-  that filled the cache: a `:before_query` plug that halts for one user let the
-  same statement through for the next one while the entry was warm, and an audit
-  plug on `:after_query` recorded one execution in place of many. `:context` is
-  not part of the cache key, so two callers with different contexts and the same
-  scope shared one entry. The query middleware now runs outside the callback, as
-  discovery middleware already did: `:before_query` runs before the cache key is
-  built — so a statement it rewrites keys its own entry — only the raw execution
-  is stored, and `:after_query` runs on the result whether it came from the cache
-  or from the source, without writing what it returns back to the cache.
-  `:before_execute` stays inside the callback, next to the preflight whose
-  relations it carries. `Lotus.Runner` exposes the three phases as
-  `before_query/3`, `execute_statement/3` and `after_query/4`;
-  `run_statement/3` composes them and behaves as before, except that
-  `[:lotus, :query, *]` telemetry now brackets the execution phase alone, so a
-  middleware halt emits no query events.
+- **Middleware is no longer skipped on a result cache hit.** The query events
+  ran inside the cache callback, so a plug saw only the call that filled the
+  cache: a `:before_query` plug that halts for one user let the same statement
+  through for the next one while the entry was warm, and an audit plug on
+  `:after_query` recorded one execution in place of many. `:context` is not part
+  of the cache key, so two callers with different contexts and the same scope
+  shared one entry. All three query events now fire on a hit. Only the execution
+  is cached, and it is stored together with the relations preflight found, so
+  `:before_execute` gates on those relations whether the rows came from the
+  source or from the store. What `:after_query` returns is not written back; a
+  halt there withholds the result from that caller.
+
+  `Lotus.Runner` exposes the pipeline as `before_query/3`, `before_execute/4`,
+  `execute_statement/3` and `after_query/4`; `run_statement/3` composes them and
+  behaves as before, except that `[:lotus, :query, *]` telemetry now brackets the
+  execution phase alone, so a middleware halt emits no query events. Result cache
+  entries carry the relations, so entries written by an earlier version are
+  replaced the first time each key is read.
+
+- **A `:before_query` plug now sees the query the caller wrote, not a `LIMIT`
+  wrapper around it, and what it returns is what gets paginated, keyed and
+  counted.** Pagination ran before the event, so a plug adding a tenant predicate
+  to a windowed query was handed the wrapper, and `meta.total_count` counted the
+  rows of the statement the plug had replaced. The bound parameters were captured
+  before the event as well, so a plug that filters through a parameter rather
+  than through the statement text did not change the cache key at all and two
+  callers shared one entry.
 
 - **A failed statement no longer hands its tables to the next statement in
   the same process.** Preflight records the relations it authorised in the

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -204,6 +204,14 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
+│ Lotus.Runner.before_query/3                                          │
+│  • Middleware.run(:before_query, _) — may rewrite the statement      │
+│  • Outside the cache, so it runs on a hit too; the statement it      │
+│    returns is the one the cache key is built from                    │
+└─────────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
 │ Lotus.Cache.get_or_store/4                                           │
 │  • Key: from the configured Lotus.Cache.KeyBuilder                   │
 │  • Tags: ["query:<id>", "source:<name>", "scope:<digest>", ...]      │
@@ -213,16 +221,22 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
                                │ miss / :bypass / :refresh
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│ Lotus.Runner.run_statement(%Adapter{}, %Statement{}, opts)           │
+│ Lotus.Runner.execute_statement(%Adapter{}, %Statement{}, opts)       │
 │  1. Telemetry.query_start                                            │
-│  2. Middleware.run(:before_query, _) — may rewrite the statement     │
-│  3. Adapter.sanitize_query (single statement + deny list)            │
-│  4. Adapter.needs_preflight? → Lotus.Preflight.authorize             │
-│  5. Middleware.run(:before_execute, _) — carries the relations       │
-│  6. Adapter.transaction (read-only) → Adapter.execute_query          │
-│  7. Column policy enforcement (omit / mask / error)                  │
-│  8. Middleware.run(:after_query, _)                                  │
-│  9. Telemetry.query_stop / query_exception                           │
+│  2. Adapter.sanitize_query (single statement + deny list)            │
+│  3. Adapter.needs_preflight? → Lotus.Preflight.authorize             │
+│  4. Middleware.run(:before_execute, _) — carries the relations       │
+│  5. Adapter.transaction (read-only) → Adapter.execute_query          │
+│  6. Column policy enforcement (omit / mask / error)                  │
+│  7. Telemetry.query_stop / query_exception                           │
+└─────────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ Lotus.Runner.after_query/4                                           │
+│  • Middleware.run(:after_query, _) — on the result, hit or miss      │
+│  • Outside the cache, so a plug that changes the result changes      │
+│    what this caller gets, not what is stored                         │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
@@ -234,9 +248,9 @@ A few notes on the pipeline:
 - **Variable binding** happens inside `Lotus.Storage.Query.compile/2`, which also consults `Lotus.Storage.SchemaCache` for type-aware casting of user-supplied values. Substitution itself is adapter-owned: prepared-statement adapters push a placeholder into `statement.body` and the value into `statement.params`, while JSON/DSL adapters inline a properly escaped literal. **Those adapters are the injection boundary** — escape through the target language's own encoder, never by string concatenation.
 - **Filters and sorts** are injected through the adapter, not concatenated naively — see `Lotus.Source.Adapters.Ecto.SQL.FilterInjector` and `SortInjector`. An adapter must declare the operators it handles via `supported_filter_operators/1`; anything else raises `Lotus.UnsupportedOperatorError`.
 - **Pagination** has two strategies for `count: :exact`. An engine that returns the total as a side-effect of the main query puts it in `execute_query/4`'s `:total_count` key; everything else places a count spec in `statement.meta[:count_spec]` and Lotus core runs it. The inline count wins when both are present.
-- **Caching** is optional. When no cache adapter is configured, `Lotus.Cache` is a pass-through and the fetcher always runs.
+- **Caching** is optional. When no cache adapter is configured, `Lotus.Cache` is a pass-through and the fetcher always runs. The cache wraps the execution phase only, so `:before_query` and `:after_query` run on a cache hit; `Lotus.Runner.run_statement/3` composes the same three phases with no cache between them.
 - **Preflight** is skipped when `needs_preflight?/2` returns false (the Ecto adapter keeps the `EXPLAIN` / `SHOW` / `PRAGMA` heuristic internally). The relations it discovers are stashed in `Lotus.Preflight.Relations`, from where the runner reads them once and carries them down the pipeline — to `:before_execute` middleware, and to column visibility policy lookup, without re-parsing the statement. An adapter that cannot enumerate resources returns `{:unrestricted, reason}`, which is blocked unless the operator opts in with `:allow_unrestricted_resources`.
-- **Middleware runs first**, before sanitization and preflight, because a `:before_query` plug may rewrite the statement — row-level security and tenant predicates are the point of the hook. Sanitization and preflight then apply to whatever will actually execute. Halting from a `:before_query` plug yields `{:error, reason}` to the caller. A plug that needs the table list instead of the chance to rewrite registers `:before_execute`, which runs once preflight has named the relations.
+- **Middleware runs first**, outside the cache and before sanitization and preflight, because a `:before_query` plug may rewrite the statement — row-level security and tenant predicates are the point of the hook. Sanitization and preflight then apply to whatever will actually execute. Halting from a `:before_query` plug yields `{:error, reason}` to the caller. A plug that needs the table list instead of the chance to rewrite registers `:before_execute`, which runs once preflight has named the relations.
 
 ### Schema Introspection Flow
 

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -199,23 +199,30 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
 │ Statement shaping (per-adapter, %Statement{} in / %Statement{} out)  │
 │  • apply_filters/3 (Lotus.Query.Filter)                              │
 │  • apply_sorts/3   (Lotus.Query.Sort)                                │
-│  • apply_pagination/3 → statement.meta[:count_spec]                  │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │ Lotus.Runner.before_query/3                                          │
 │  • Middleware.run(:before_query, _) — may rewrite the statement      │
-│  • Outside the cache, so it runs on a hit too; the statement it      │
-│    returns is the one the cache key is built from                    │
+│  • Outside the cache, so it runs on a hit too, and before pagination │
+│    so a plug is handed the query the caller wrote                    │
+└─────────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ apply_pagination/3 → statement.meta[:count_spec]                     │
+│  • Built from the statement the plug returned, so the page and its   │
+│    count describe the same rows                                      │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │ Lotus.Cache.get_or_store/4                                           │
-│  • Key: from the configured Lotus.Cache.KeyBuilder                   │
+│  • Key: from the configured Lotus.Cache.KeyBuilder, over the body,   │
+│    bound values and window of the statement that will execute        │
 │  • Tags: ["query:<id>", "source:<name>", "scope:<digest>", ...]      │
-│  • Hit  → return cached Result                                       │
+│  • Hit  → the stored %{result:, relations:}, then :before_execute    │
 │  • Miss → run the fetcher below                                      │
 └─────────────────────────────────────────────────────────────────────┘
                                │ miss / :bypass / :refresh
@@ -229,6 +236,7 @@ When you call `Lotus.run_query(query, opts)` the request flows through roughly t
 │  5. Adapter.transaction (read-only) → Adapter.execute_query          │
 │  6. Column policy enforcement (omit / mask / error)                  │
 │  7. Telemetry.query_stop / query_exception                           │
+│  → {:ok, %{result:, relations:}}, which is what the cache stores     │
 └─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
@@ -248,9 +256,9 @@ A few notes on the pipeline:
 - **Variable binding** happens inside `Lotus.Storage.Query.compile/2`, which also consults `Lotus.Storage.SchemaCache` for type-aware casting of user-supplied values. Substitution itself is adapter-owned: prepared-statement adapters push a placeholder into `statement.body` and the value into `statement.params`, while JSON/DSL adapters inline a properly escaped literal. **Those adapters are the injection boundary** — escape through the target language's own encoder, never by string concatenation.
 - **Filters and sorts** are injected through the adapter, not concatenated naively — see `Lotus.Source.Adapters.Ecto.SQL.FilterInjector` and `SortInjector`. An adapter must declare the operators it handles via `supported_filter_operators/1`; anything else raises `Lotus.UnsupportedOperatorError`.
 - **Pagination** has two strategies for `count: :exact`. An engine that returns the total as a side-effect of the main query puts it in `execute_query/4`'s `:total_count` key; everything else places a count spec in `statement.meta[:count_spec]` and Lotus core runs it. The inline count wins when both are present.
-- **Caching** is optional. When no cache adapter is configured, `Lotus.Cache` is a pass-through and the fetcher always runs. The cache wraps the execution phase only, so `:before_query` and `:after_query` run on a cache hit; `Lotus.Runner.run_statement/3` composes the same three phases with no cache between them.
+- **Caching** is optional. When no cache adapter is configured, `Lotus.Cache` is a pass-through and the fetcher always runs. The cache wraps the execution phase only, and stores the relations preflight found alongside the result, so all three query events fire on a hit — `:before_execute` gates on the stored relations. `Lotus.Runner.run_statement/3` composes the same phases with no cache between them. What a hit skips is sanitization, preflight and column visibility, all of which read `:scope`, which is in the key.
 - **Preflight** is skipped when `needs_preflight?/2` returns false (the Ecto adapter keeps the `EXPLAIN` / `SHOW` / `PRAGMA` heuristic internally). The relations it discovers are stashed in `Lotus.Preflight.Relations`, from where the runner reads them once and carries them down the pipeline — to `:before_execute` middleware, and to column visibility policy lookup, without re-parsing the statement. An adapter that cannot enumerate resources returns `{:unrestricted, reason}`, which is blocked unless the operator opts in with `:allow_unrestricted_resources`.
-- **Middleware runs first**, outside the cache and before sanitization and preflight, because a `:before_query` plug may rewrite the statement — row-level security and tenant predicates are the point of the hook. Sanitization and preflight then apply to whatever will actually execute. Halting from a `:before_query` plug yields `{:error, reason}` to the caller. A plug that needs the table list instead of the chance to rewrite registers `:before_execute`, which runs once preflight has named the relations.
+- **Middleware runs first**, outside the cache and before pagination, sanitization and preflight, because a `:before_query` plug may rewrite the statement — row-level security and tenant predicates are the point of the hook. Sanitization and preflight then apply to whatever will actually execute. Halting from a `:before_query` plug yields `{:error, reason}` to the caller. A plug that needs the table list instead of the chance to rewrite registers `:before_execute`, which runs once preflight has named the relations.
 
 ### Schema Introspection Flow
 

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -190,10 +190,13 @@ Lotus.run_statement("SELECT * FROM orders", [],
 )
 ```
 
-> **The result cache key includes `:scope` but never `:context`.** A plug that
-> masks or filters results per actor must have the caller pass a `:scope` that
-> identifies that actor. If the actor is only carried in `:context`, two callers
-> share one cache key and one caller's masked result is served to the other.
+> **The result cache key includes `:scope` but never `:context`.** Query
+> middleware runs outside the cache callback, so a plug that masks or filters
+> results per actor works from `:context` alone — it sees every call, hit or
+> miss. What `:scope` buys is a separate stored entry: the visibility resolver
+> runs inside the cache callback, so a resolver that hides tables or masks
+> columns per actor needs the caller to pass a `:scope` identifying that actor,
+> or one actor's stored result is served to the next.
 > `Lotus.invalidate_scope/1` clears both the discovery and result cache entries
 > for a given scope.
 
@@ -215,8 +218,8 @@ end
 
 ### Audit Logging
 
-Log each query execution with the user who ran it. Note that `:before_query`
-runs inside the result cache, so this records cache misses only — see
+Log each query execution with the user who ran it. `:before_query` runs outside
+the result cache, so this records every call, cached or not — see
 [Caching](#caching) below.
 
 ```elixir
@@ -380,20 +383,30 @@ end
 
 ## Caching
 
-Query middleware and discovery middleware sit on opposite sides of their caches.
+Query middleware and discovery middleware both sit outside their caches. Only
+the raw work an adapter does is stored.
 
-### Query middleware runs inside the result cache
+### Query middleware runs outside the result cache
 
-`:before_query` and `:after_query` run inside the result cache callback, so on a
-cache **hit** neither event fires — the cached rows are returned as they were
-stored. This matters in two ways:
+`:before_query` and `:after_query` run outside the result cache callback, so both
+events fire on a cache **hit** as well:
 
-- **Side-effecting plugs skip cached runs.** An audit plug on `:before_query`
-  records misses, not hits. Log from the caller if you need every attempt.
-- **Per-actor filtering needs `:scope`, not `:context`.** The result cache key
-  hashes `:scope` and ignores `:context`, so a plug that redacts rows per user
-  must have the caller pass a `:scope` identifying that user — otherwise every
-  caller shares one key and one user's redacted rows are served to the next.
+- **Side-effecting plugs see every call.** An audit plug on `:before_query`
+  records hits and misses alike, and a plug that halts for one caller halts
+  whether or not the cache is warm.
+- **Context-sensitive plugs are safe.** `:context` is not part of the cache key,
+  and it does not need to be: two callers with different `:context` values each
+  get their own middleware decision on the same stored rows.
+- **The stored entry keeps the raw result.** `:after_query` runs on the way out,
+  so what a plug makes of the result is returned to that caller and never
+  written back to the cache.
+- **`:before_execute` runs inside the callback.** It carries the relations
+  preflight named, and preflight is what the cache stores, so a cache hit
+  skips both. A plug that must run on every call belongs on `:before_query`.
+
+A `:before_query` plug that rewrites the statement keys its own cache entry —
+the rewritten statement is what builds the key, so two plugs that rewrite
+differently do not share an entry.
 
 Pass `cache: :bypass` on a call that must never be served from the cache, or
 `cache: :refresh` to re-run and re-seed it.

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -190,15 +190,14 @@ Lotus.run_statement("SELECT * FROM orders", [],
 )
 ```
 
-> **The result cache key includes `:scope` but never `:context`.** Query
-> middleware runs outside the cache callback, so a plug that masks or filters
-> results per actor works from `:context` alone — it sees every call, hit or
-> miss. What `:scope` buys is a separate stored entry: the visibility resolver
-> runs inside the cache callback, so a resolver that hides tables or masks
-> columns per actor needs the caller to pass a `:scope` identifying that actor,
-> or one actor's stored result is served to the next.
-> `Lotus.invalidate_scope/1` clears both the discovery and result cache entries
-> for a given scope.
+> **The result cache key includes `:scope` but never `:context`.** Middleware
+> runs outside the cache callback, so a plug that masks or filters results per
+> actor works from `:context` alone — it sees every call, hit or miss. The
+> visibility resolver does not: it runs inside the callback, so a resolver that
+> hides tables or masks columns per actor needs the caller to pass a `:scope`
+> identifying that actor, or one actor's stored result is served to the next.
+> See [Caching](#caching). `Lotus.invalidate_scope/1` clears both the discovery
+> and result cache entries for a given scope.
 
 ```elixir
 defmodule MyApp.AccessControlMiddleware do
@@ -386,30 +385,52 @@ end
 Query middleware and discovery middleware both sit outside their caches. Only
 the raw work an adapter does is stored.
 
-### Query middleware runs outside the result cache
+### Every query event fires on a cache hit
 
-`:before_query` and `:after_query` run outside the result cache callback, so both
-events fire on a cache **hit** as well:
+`:before_query`, `:before_execute` and `:after_query` all run on a call served
+from the cache:
 
-- **Side-effecting plugs see every call.** An audit plug on `:before_query`
-  records hits and misses alike, and a plug that halts for one caller halts
-  whether or not the cache is warm.
+- **Side-effecting plugs see every call.** An audit plug records hits and misses
+  alike, and a plug that halts for one caller halts whether or not the cache is
+  warm.
 - **Context-sensitive plugs are safe.** `:context` is not part of the cache key,
-  and it does not need to be: two callers with different `:context` values each
-  get their own middleware decision on the same stored rows.
+  and for middleware it does not need to be: two callers with different
+  `:context` values each get their own middleware decision on the same stored
+  rows.
+- **`:before_execute` gets its relations either way.** The relations preflight
+  named are stored with the result, so the event carries them on a hit as well
+  as on a miss — a plug that authorizes a statement against its tables is an
+  access control, and one a warm cache skips would be no control at all.
 - **The stored entry keeps the raw result.** `:after_query` runs on the way out,
   so what a plug makes of the result is returned to that caller and never
-  written back to the cache.
-- **`:before_execute` runs inside the callback.** It carries the relations
-  preflight named, and preflight is what the cache stores, so a cache hit
-  skips both. A plug that must run on every call belongs on `:before_query`.
+  written back. A halt there withholds the result from that caller; the rows
+  themselves stay in the cache for a caller whose own plugs let them through.
 
-A `:before_query` plug that rewrites the statement keys its own cache entry —
-the rewritten statement is what builds the key, so two plugs that rewrite
-differently do not share an entry.
+A `:before_query` plug that rewrites the statement keys its own cache entry.
+`:before_query` runs before pagination, so the plug is handed the query the
+caller wrote rather than a `LIMIT` wrapper around it, and everything that keys
+the entry — the body, the bound values, the window — describes the statement the
+plug returned. A plug that filters through a bound parameter rather than through
+the statement text is keyed just the same.
 
 Pass `cache: :bypass` on a call that must never be served from the cache, or
 `cache: :refresh` to re-run and re-seed it.
+
+### What a cache hit does skip
+
+Everything between sanitization and the returned rows is what the entry stores,
+so a hit skips it: the adapter's statement sanitization, preflight table
+authorization, and column visibility — `mask`, `omit`, and the hidden-column
+error. Those controls read `:scope`, and `:scope` is part of the cache key, so
+two scopes never share an entry.
+
+**`:scope` is the only caller identity the result cache separates on.** A
+visibility resolver must therefore decide from `(source, relations, column,
+scope)` alone. A resolver that varies its rules by anything else — a user read
+out of `:context`, process state, or the current request — masks the warming
+caller's result and then serves it unchanged to the next caller. Carry the actor
+in `:scope` when visibility depends on it, and keep per-actor logic that cannot
+be expressed that way in middleware, which runs on every call.
 
 ### Discovery middleware runs outside the schema cache
 

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -46,7 +46,9 @@ from cache emits no `[:lotus, :query, *]` events at all; `[:lotus, :cache, :hit]
 is the event to count for those. The `:before_query` and `:after_query`
 middleware run outside that phase, on every call: a plug that halts there yields
 `{:error, reason}` to the caller without emitting query events, because no
-statement ran.
+statement ran. For the same reason `:stop` carries the result as the source
+returned it — an `:after_query` plug that redacts rows has not run yet, so a
+handler that logs `metadata.result` logs the unredacted rows.
 
 ### Cache Operations
 

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -31,19 +31,22 @@ OpenTelemetry span contexts for trace correlation. The `:scope` option is **not*
 in the metadata — it is caller identity used for cache keys and visibility, not
 instrumentation.
 
-The events bracket the whole `Lotus.Runner` pipeline, so `:start` fires before
-middleware, sanitization and preflight run. Any failure among those — a halted
-`:before_query` plug, a denied table, a driver error — ends the run at
-`:exception`, not `:stop`.
+The events bracket statement execution — sanitization, preflight,
+`:before_execute` and the query itself — so `:start` fires before any of those
+run. Any failure among them — a denied table, a halted `:before_execute` plug, a
+driver error — ends the run at `:exception`, not `:stop`.
 
 Because Lotus turns those failures into `{:error, reason}` rather than letting
 them raise, the `:exception` metadata is uniform: `kind` is always `:error`,
 `reason` is the `{:error, reason}` tuple the caller receives, and `stacktrace`
 is `[]`. Match on `reason` rather than expecting an exception struct.
 
-Query telemetry is emitted from the runner, which sits **inside** the result
-cache. A query served from cache emits no `[:lotus, :query, *]` events at all;
-`[:lotus, :cache, :hit]` is the event to count for those.
+Query telemetry brackets the phase the result cache stores, so a query served
+from cache emits no `[:lotus, :query, *]` events at all; `[:lotus, :cache, :hit]`
+is the event to count for those. The `:before_query` and `:after_query`
+middleware run outside that phase, on every call: a plug that halts there yields
+`{:error, reason}` to the caller without emitting query events, because no
+statement ran.
 
 ### Cache Operations
 

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -496,16 +496,37 @@ defmodule Lotus do
     {statement, pagination_meta, cache_bound} =
       maybe_paginate(statement, adapter, search_path, Keyword.get(opts, :window))
 
+    # The query middleware runs outside the cache callback, as discovery does:
+    # a plug that varies on `:context` — access control, audit — must see every
+    # call, not only the one that fills the cache, and `:context` is not part of
+    # the cache key. `:before_query` therefore runs before the key is built,
+    # because it may rewrite the statement, and only the raw execution is
+    # stored: what `:after_query` makes of the result is not written back.
+    with {:ok, %Statement{} = statement} <- Runner.before_query(adapter, statement, runner_opts),
+         {:ok, %Result{} = res} <-
+           exec_cached_statement(adapter, statement, runner_opts, %{
+             opts: opts,
+             search_path: search_path,
+             pagination_meta: pagination_meta,
+             cache_identity: cache_bound || cache_identity,
+             query_id: query_id
+           }) do
+      Runner.after_query(adapter, statement, res, runner_opts)
+    end
+  end
+
+  defp exec_cached_statement(adapter, statement, runner_opts, ctx) do
+    %{opts: opts, pagination_meta: pagination_meta} = ctx
     scope = Keyword.get(opts, :scope)
 
     key =
-      result_key(statement.body, cache_bound || cache_identity, adapter.name, search_path, scope)
+      result_key(statement.body, ctx.cache_identity, adapter.name, ctx.search_path, scope)
 
-    tags = build_cache_tags(query_id, adapter.name, opts)
+    tags = build_cache_tags(ctx.query_id, adapter.name, opts)
     profile = determine_cache_profile(opts)
 
     exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      with {:ok, %Result{} = res} <- Runner.run_statement(adapter, statement, runner_opts) do
+      with {:ok, %Result{} = res} <- Runner.execute_statement(adapter, statement, runner_opts) do
         {:ok, merge_pagination_meta(res, pagination_meta)}
       end
     end)

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -493,43 +493,102 @@ defmodule Lotus do
     :ok = validate_sort_columns!(adapter, sorts)
     statement = Adapter.apply_sorts(adapter, statement, sorts)
 
-    {statement, pagination_meta, cache_bound} =
-      maybe_paginate(statement, adapter, search_path, Keyword.get(opts, :window))
-
-    # The query middleware runs outside the cache callback, as discovery does:
-    # a plug that varies on `:context` — access control, audit — must see every
-    # call, not only the one that fills the cache, and `:context` is not part of
-    # the cache key. `:before_query` therefore runs before the key is built,
-    # because it may rewrite the statement, and only the raw execution is
-    # stored: what `:after_query` makes of the result is not written back.
+    # The middleware runs outside the cache callback, as discovery middleware
+    # does: a plug that varies on `:context` — access control, audit — must see
+    # every call, not only the one that fills the cache, and `:context` is not
+    # part of the cache key. Only the raw execution is stored: what
+    # `:after_query` makes of the result is not written back.
+    #
+    # `:before_query` runs before pagination, so a plug is handed the query the
+    # caller wrote rather than a `LIMIT` wrapper around it, and the page and its
+    # count are both built from the statement the plug returned. Everything that
+    # keys the entry — the body, the bound values, the window — therefore
+    # describes what will actually execute.
     with {:ok, %Statement{} = statement} <- Runner.before_query(adapter, statement, runner_opts),
+         {statement, pagination_meta, cache_bound} =
+           maybe_paginate(statement, adapter, search_path, Keyword.get(opts, :window)),
          {:ok, %Result{} = res} <-
-           exec_cached_statement(adapter, statement, runner_opts, %{
-             opts: opts,
-             search_path: search_path,
-             pagination_meta: pagination_meta,
-             cache_identity: cache_bound || cache_identity,
-             query_id: query_id
-           }) do
+           exec_cached_statement(
+             adapter,
+             statement,
+             runner_opts,
+             [
+               mode: opts[:cache],
+               key:
+                 result_key(
+                   statement.body,
+                   bound_identity(cache_bound || cache_identity, statement.params),
+                   adapter.name,
+                   search_path,
+                   Keyword.get(opts, :scope)
+                 ),
+               tags: build_cache_tags(query_id, adapter.name, opts),
+               profile: determine_cache_profile(opts)
+             ],
+             pagination_meta
+           ) do
       Runner.after_query(adapter, statement, res, runner_opts)
     end
   end
 
-  defp exec_cached_statement(adapter, statement, runner_opts, ctx) do
-    %{opts: opts, pagination_meta: pagination_meta} = ctx
-    scope = Keyword.get(opts, :scope)
+  # The bound values in the key come from the statement that will execute. A
+  # plug that filters rows through a parameter rather than through the statement
+  # text leaves the body alone, and two callers would otherwise share an entry.
+  defp bound_identity(identity, params) when is_map(identity),
+    do: Map.put(identity, :__params__, params)
 
-    key =
-      result_key(statement.body, ctx.cache_identity, adapter.name, ctx.search_path, scope)
+  defp bound_identity(_identity, params), do: %{__params__: params}
 
-    tags = build_cache_tags(ctx.query_id, adapter.name, opts)
-    profile = determine_cache_profile(opts)
-
-    exec_with_cache(opts[:cache], profile, key, tags, fn ->
-      with {:ok, %Result{} = res} <- Runner.execute_statement(adapter, statement, runner_opts) do
-        {:ok, merge_pagination_meta(res, pagination_meta)}
+  # Only the execution is cached, and it is stored with the relations preflight
+  # found, so `:before_execute` can run on a hit as well. On a miss it runs
+  # inside the callback, where it still gates execution.
+  defp exec_cached_statement(adapter, statement, runner_opts, cache, pagination_meta) do
+    fetch = fn ->
+      with {:ok, %{result: res, relations: relations}} <-
+             Runner.execute_statement(adapter, statement, runner_opts) do
+        {:ok, %{result: merge_pagination_meta(res, pagination_meta), relations: relations}}
       end
-    end)
+    end
+
+    case exec_with_cache_origin(cache, fetch) do
+      {:ok, %{result: %Result{} = res, relations: relations}, :hit} ->
+        with :ok <- Runner.before_execute(adapter, statement, relations, runner_opts) do
+          {:ok, res}
+        end
+
+      {:ok, %{result: %Result{} = res}, _executed} ->
+        {:ok, res}
+
+      # An entry stored before results carried their relations. `:before_execute`
+      # has nothing to gate on, so the entry is of no use: execute, and replace
+      # it with one that carries them.
+      {:ok, _stale, :hit} ->
+        with {:ok, %{result: %Result{} = res}} = fresh <- fetch.() do
+          put_cache_entry(cache, elem(fresh, 1))
+          {:ok, res}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp exec_with_cache_origin(cache, fetch) do
+    exec_with_cache_origin(
+      Keyword.get(cache, :mode),
+      Keyword.fetch!(cache, :profile),
+      Keyword.fetch!(cache, :key),
+      Keyword.fetch!(cache, :tags),
+      fetch
+    )
+  end
+
+  defp put_cache_entry(cache, val) do
+    mode = Keyword.get(cache, :mode)
+    ttl = choose_ttl(mode, Keyword.fetch!(cache, :profile))
+    options = build_cache_options(mode, Keyword.fetch!(cache, :tags))
+
+    Lotus.Cache.put(Keyword.fetch!(cache, :key), val, ttl, options)
   end
 
   defp prepare_final_opts(opts, nil),
@@ -827,24 +886,21 @@ defmodule Lotus do
     end
   end
 
-  defp exec_with_cache(cache_opts, ttl_default_profile, key, tags, fun) do
+  # Reports where the value came from: `:hit` for one the store already held,
+  # `:executed` for one `fun` produced. The query path needs the distinction,
+  # because a value from the store skipped the checks inside `fun` and its
+  # caller has to make up for them.
+  defp exec_with_cache_origin(cache_opts, ttl_default_profile, key, tags, fun) do
     case cache_mode(cache_opts) do
-      :off ->
-        fun.()
-
-      :bypass ->
-        fun.()
+      mode when mode in [:off, :bypass] ->
+        executed(fun)
 
       :refresh ->
-        case fun.() do
-          {:ok, val} ->
-            ttl = choose_ttl(cache_opts, ttl_default_profile)
-            cache_options = build_cache_options(cache_opts, tags)
-            :ok = Lotus.Cache.put(key, val, ttl, cache_options)
-            {:ok, val}
-
-          error ->
-            error
+        with {:ok, val} <- fun.() do
+          ttl = choose_ttl(cache_opts, ttl_default_profile)
+          cache_options = build_cache_options(cache_opts, tags)
+          :ok = Lotus.Cache.put(key, val, ttl, cache_options)
+          {:ok, val, :executed}
         end
 
       :use ->
@@ -859,12 +915,17 @@ defmodule Lotus do
       cache_options = build_cache_options(cache_opts, tags)
 
       case Lotus.Cache.get_or_store(key, ttl, fn -> cache_value_or_throw(fun) end, cache_options) do
-        {:ok, val, _} -> {:ok, val}
-        {:error, _} -> fun.()
+        {:ok, val, :hit} -> {:ok, val, :hit}
+        {:ok, val, _stored} -> {:ok, val, :executed}
+        {:error, _} -> executed(fun)
       end
     catch
       {:lotus_cache_error, e} -> {:error, e}
     end
+  end
+
+  defp executed(fun) do
+    with {:ok, val} <- fun.(), do: {:ok, val, :executed}
   end
 
   defp cache_value_or_throw(fun) do

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -63,6 +63,20 @@ defmodule Lotus.Middleware do
   can enforce rules on the values a caller picked (date-range limits, tenant
   checks) without parsing the statement.
 
+  ### Caching
+
+  `:before_query` and `:after_query` run **outside** the result cache callback —
+  only the raw execution is cached. Both events therefore fire on a cache hit,
+  and context-dependent middleware (per-user access control, audit) is safe to
+  use without keying the cache on `:context`. A `:before_query` plug that
+  rewrites the statement keys its own entry, because the rewritten statement is
+  what builds the key. What an `:after_query` plug makes of the result goes to
+  that caller and is not written back to the cache.
+
+  `:before_execute` runs **inside** the callback, alongside the preflight whose
+  relations it carries, so a cache hit skips it. A plug that must run on every
+  call belongs on `:before_query`.
+
   ### Discovery event ordering
 
   Discovery calls (`Lotus.list_schemas/2`, `list_tables/2`, `describe_table/3`,

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -37,7 +37,8 @@ defmodule Lotus.Middleware do
 
   `:before_execute` fires after sanitization and preflight pass and before the
   statement executes. Its `:statement` is the rewritten one, and its
-  `:relations` is what preflight proved the statement touches. The two hooks
+  `:relations` is what preflight proved the statement touches — read back from
+  the cache entry when the result is served from the cache. The two hooks
   answer different questions: `:before_query` asks which statement should run,
   `:before_execute` asks whether the statement may proceed given what it
   provably touches.
@@ -65,17 +66,24 @@ defmodule Lotus.Middleware do
 
   ### Caching
 
-  `:before_query` and `:after_query` run **outside** the result cache callback —
-  only the raw execution is cached. Both events therefore fire on a cache hit,
-  and context-dependent middleware (per-user access control, audit) is safe to
-  use without keying the cache on `:context`. A `:before_query` plug that
-  rewrites the statement keys its own entry, because the rewritten statement is
-  what builds the key. What an `:after_query` plug makes of the result goes to
-  that caller and is not written back to the cache.
+  Every query event fires on a cache hit. Only the raw execution is cached, and
+  the relations preflight found are stored with it, so `:before_execute` carries
+  them whether the result came from the source or from the cache. Middleware is
+  therefore safe to make context-dependent — per-user access control, audit —
+  without keying the cache on `:context`.
 
-  `:before_execute` runs **inside** the callback, alongside the preflight whose
-  relations it carries, so a cache hit skips it. A plug that must run on every
-  call belongs on `:before_query`.
+  A `:before_query` plug that rewrites the statement keys its own entry: the
+  event runs before pagination and before the key is built, so the body, the
+  bound values and the window all describe what will execute. What an
+  `:after_query` plug makes of the result goes to that caller and is not written
+  back; a halt there withholds the result from that caller, and the rows stay
+  cached for one whose plugs let them through.
+
+  What a hit does skip is the work between sanitization and the rows: statement
+  sanitization, preflight table authorization, and column visibility. Those read
+  `:scope`, which is part of the cache key — so a visibility resolver must
+  decide from `(source, relations, column, scope)` alone. Per-actor logic that
+  cannot be expressed that way belongs in middleware.
 
   ### Discovery event ordering
 

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -62,6 +62,13 @@ defmodule Lotus.Runner do
   @spec before_query(Adapter.t(), Statement.t(), opts()) ::
           {:ok, Statement.t()} | {:error, term()}
   def before_query(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
+    # The first phase of a run clears the relations, so a plug cannot read a
+    # value another statement left in the process dictionary. `Preflight.
+    # authorize/4` is public, and `execute_statement/3` clears on entry and on
+    # every exit — but on a cache hit it never runs at all, and it is the phases
+    # around it that would then carry a stale value forward.
+    Relations.clear()
+
     payload = %{
       source: adapter.name,
       statement: statement,

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -28,19 +28,99 @@ defmodule Lotus.Runner do
           vars: map()
         ]
 
+  @doc """
+  Runs a statement through the full pipeline: `:before_query`, sanitization,
+  preflight, `:before_execute`, execution, column policy enforcement and
+  `:after_query`.
+
+  A caller that wraps execution in the result cache composes the three phases
+  itself — `before_query/3`, `execute_statement/3`, `after_query/4` — so that
+  the query middleware runs on a cache hit as well.
+  """
   @spec run_statement(Adapter.t(), Statement.t(), opts()) ::
           {:ok, query_result()} | {:error, term()}
   def run_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
+    with {:ok, %Statement{} = statement} <- before_query(adapter, statement, opts),
+         {:ok, %Result{} = res} <- execute_statement(adapter, statement, opts) do
+      after_query(adapter, statement, res, opts)
+    end
+  end
+
+  @doc """
+  Runs the `:before_query` pipeline and returns the statement to execute.
+
+  `:before_query` runs first because a plug may rewrite the statement — that is
+  the point of the hook, for row-level security and tenant predicates.
+  Sanitization and preflight then apply to what will actually execute, rather
+  than to the text the caller originally supplied.
+
+  A caller that caches the execution runs this phase outside the cache
+  callback, and builds the cache key from the statement returned here: a plug
+  that varies on `:context` must see every call, not only the one that fills
+  the cache, and two plugs that rewrite differently must not share an entry.
+  """
+  @spec before_query(Adapter.t(), Statement.t(), opts()) ::
+          {:ok, Statement.t()} | {:error, term()}
+  def before_query(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
+    payload = %{
+      source: adapter.name,
+      statement: statement,
+      context: Keyword.get(opts, :context),
+      vars: vars(opts)
+    }
+
+    # A plug that rewrites `:statement` in the payload has its version carried
+    # forward; one that returns the payload untouched leaves the original in
+    # place. Anything that is not a statement is ignored rather than trusted.
+    case Middleware.run(:before_query, payload) do
+      {:cont, %{statement: %Statement{} = rewritten}} -> {:ok, rewritten}
+      {:cont, _} -> {:ok, statement}
+      {:halt, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Runs the `:after_query` pipeline on a result and returns what it yields.
+
+  A caller that caches the execution runs this phase on the returned result,
+  whether that result came from the cache or from the source. A plug that
+  changes the result changes what this call returns; the stored entry keeps the
+  raw execution.
+  """
+  @spec after_query(Adapter.t(), Statement.t(), query_result(), opts()) ::
+          {:ok, query_result()} | {:error, term()}
+  def after_query(%Adapter{} = adapter, %Statement{} = statement, %Result{} = result, opts \\ []) do
+    payload = %{
+      source: adapter.name,
+      statement: statement,
+      result: result,
+      context: Keyword.get(opts, :context),
+      vars: vars(opts)
+    }
+
+    case Middleware.run(:after_query, payload) do
+      {:cont, %{result: %Result{} = res}} -> {:ok, res}
+      {:cont, _} -> {:ok, result}
+      {:halt, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Executes a statement: sanitization, preflight, `:before_execute`, the query
+  itself and column policy enforcement.
+
+  This is the phase the result cache stores. The query middleware around it
+  lives in `before_query/3` and `after_query/4`, and `[:lotus, :query, *]`
+  telemetry covers this phase only — a statement served from the cache emits
+  no query events.
+  """
+  @spec execute_statement(Adapter.t(), Statement.t(), opts()) ::
+          {:ok, query_result()} | {:error, term()}
+  def execute_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
     context = Keyword.get(opts, :context)
-    vars = Keyword.get(opts, :vars) || %{}
     telemetry_meta = %{source: adapter.name, statement: statement, context: context}
     start_time = Telemetry.query_start(telemetry_meta)
 
-    # `:before_query` runs first because a plug may rewrite the statement —
-    # that is the point of the hook, for row-level security and tenant
-    # predicates. Sanitization and preflight then apply to what will actually
-    # execute, rather than to the text the caller originally supplied.
-    #
     # Preflight records its relations in the process dictionary, and
     # `preflight_visibility/3` reads them out once and carries them down the
     # pipeline explicitly. Clearing on both sides keeps them from crossing a
@@ -52,13 +132,10 @@ defmodule Lotus.Runner do
       try do
         Relations.clear()
 
-        with {:ok, %Statement{} = statement} <-
-               run_before_query(adapter, statement, context, vars),
-             :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
+        with :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
              {:ok, relations} <- preflight_visibility(adapter, statement, opts),
-             :ok <- run_before_execute(adapter, statement, relations, context, vars),
-             {:ok, %Result{} = res} <- exec_read_only(adapter, statement, relations, opts),
-             {:ok, %Result{} = res} <- run_after_query(adapter, statement, res, context, vars) do
+             :ok <- run_before_execute(adapter, statement, relations, context, vars(opts)),
+             {:ok, %Result{} = res} <- exec_read_only(adapter, statement, relations, opts) do
           {:ok, res}
         end
       after
@@ -79,6 +156,8 @@ defmodule Lotus.Runner do
         error
     end
   end
+
+  defp vars(opts), do: Keyword.get(opts, :vars) || %{}
 
   defp exec_read_only(
          %Adapter{} = adapter,
@@ -267,20 +346,6 @@ defmodule Lotus.Runner do
     Keyword.take(opts, [:read_only])
   end
 
-  # Returns the statement to execute. A plug that rewrites `:statement` in the
-  # payload has its version carried forward; one that returns the payload
-  # untouched leaves the original in place. Anything that is not a statement
-  # is ignored rather than trusted.
-  defp run_before_query(%Adapter{} = adapter, %Statement{} = statement, context, vars) do
-    payload = %{source: adapter.name, statement: statement, context: context, vars: vars}
-
-    case Middleware.run(:before_query, payload) do
-      {:cont, %{statement: %Statement{} = rewritten}} -> {:ok, rewritten}
-      {:cont, _} -> {:ok, statement}
-      {:halt, reason} -> {:error, reason}
-    end
-  end
-
   # Fires once sanitization and preflight have passed, with the relations
   # preflight proved the statement touches. A plug may inspect but not rewrite
   # here — the statement has already been authorized, so the one that executes
@@ -302,27 +367,6 @@ defmodule Lotus.Runner do
 
     case Middleware.run(:before_execute, payload) do
       {:cont, _payload} -> :ok
-      {:halt, reason} -> {:error, reason}
-    end
-  end
-
-  defp run_after_query(
-         %Adapter{} = adapter,
-         %Statement{} = statement,
-         %Result{} = result,
-         context,
-         vars
-       ) do
-    payload = %{
-      source: adapter.name,
-      statement: statement,
-      result: result,
-      context: context,
-      vars: vars
-    }
-
-    case Middleware.run(:after_query, payload) do
-      {:cont, %{result: res}} -> {:ok, res}
       {:halt, reason} -> {:error, reason}
     end
   end

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -28,20 +28,30 @@ defmodule Lotus.Runner do
           vars: map()
         ]
 
+  @typedoc """
+  What executing a statement produced: the result, and the relations preflight
+  proved the statement touches.
+
+  This is the unit the result cache stores, so that a caller serving a result
+  from the cache can still hand the relations to `:before_execute`.
+  """
+  @type execution :: %{result: query_result(), relations: term()}
+
   @doc """
   Runs a statement through the full pipeline: `:before_query`, sanitization,
   preflight, `:before_execute`, execution, column policy enforcement and
   `:after_query`.
 
-  A caller that wraps execution in the result cache composes the three phases
-  itself — `before_query/3`, `execute_statement/3`, `after_query/4` — so that
-  the query middleware runs on a cache hit as well.
+  A caller that wraps execution in the result cache composes the phases itself
+  — `before_query/3`, `execute_statement/3` or a cached result plus
+  `before_execute/4`, then `after_query/4` — so that the middleware runs on a
+  cache hit as well.
   """
   @spec run_statement(Adapter.t(), Statement.t(), opts()) ::
           {:ok, query_result()} | {:error, term()}
   def run_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
     with {:ok, %Statement{} = statement} <- before_query(adapter, statement, opts),
-         {:ok, %Result{} = res} <- execute_statement(adapter, statement, opts) do
+         {:ok, %{result: %Result{} = res}} <- execute_statement(adapter, statement, opts) do
       after_query(adapter, statement, res, opts)
     end
   end
@@ -105,9 +115,38 @@ defmodule Lotus.Runner do
       vars: vars(opts)
     }
 
+    # No fallback clause for a `:cont` without a `%Result{}` under `:result`: a
+    # plug whose whole job is to rewrite the result must fail loudly when it
+    # returns a shape that cannot be one, rather than have Lotus quietly serve
+    # the result the plug meant to replace.
     case Middleware.run(:after_query, payload) do
       {:cont, %{result: %Result{} = res}} -> {:ok, res}
-      {:cont, _} -> {:ok, result}
+      {:halt, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Runs the `:before_execute` pipeline for a statement and the relations it
+  touches.
+
+  `execute_statement/3` runs this itself, with the relations preflight just
+  found. A caller that serves a result from the cache runs it with the
+  relations stored alongside that result, so the gate fires on every call: a
+  plug that authorizes a statement against its tables is an access control,
+  and an access control that a warm cache skips is no control at all.
+  """
+  @spec before_execute(Adapter.t(), Statement.t(), term(), opts()) :: :ok | {:error, term()}
+  def before_execute(%Adapter{} = adapter, %Statement{} = statement, relations, opts \\ []) do
+    payload = %{
+      source: adapter.name,
+      statement: statement,
+      relations: relations,
+      context: Keyword.get(opts, :context),
+      vars: vars(opts)
+    }
+
+    case Middleware.run(:before_execute, payload) do
+      {:cont, _payload} -> :ok
       {:halt, reason} -> {:error, reason}
     end
   end
@@ -116,16 +155,21 @@ defmodule Lotus.Runner do
   Executes a statement: sanitization, preflight, `:before_execute`, the query
   itself and column policy enforcement.
 
-  This is the phase the result cache stores. The query middleware around it
-  lives in `before_query/3` and `after_query/4`, and `[:lotus, :query, *]`
-  telemetry covers this phase only — a statement served from the cache emits
-  no query events.
+  Returns the result together with the relations preflight proved the statement
+  touches, which is what the result cache stores — see `t:execution/0`. The
+  query middleware around this phase lives in `before_query/3` and
+  `after_query/4`, and `[:lotus, :query, *]` telemetry covers this phase only,
+  so a statement served from the cache emits no query events.
   """
   @spec execute_statement(Adapter.t(), Statement.t(), opts()) ::
-          {:ok, query_result()} | {:error, term()}
+          {:ok, execution()} | {:error, term()}
   def execute_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
-    context = Keyword.get(opts, :context)
-    telemetry_meta = %{source: adapter.name, statement: statement, context: context}
+    telemetry_meta = %{
+      source: adapter.name,
+      statement: statement,
+      context: Keyword.get(opts, :context)
+    }
+
     start_time = Telemetry.query_start(telemetry_meta)
 
     # Preflight records its relations in the process dictionary, and
@@ -141,22 +185,22 @@ defmodule Lotus.Runner do
 
         with :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
              {:ok, relations} <- preflight_visibility(adapter, statement, opts),
-             :ok <- run_before_execute(adapter, statement, relations, context, vars(opts)),
+             :ok <- before_execute(adapter, statement, relations, opts),
              {:ok, %Result{} = res} <- exec_read_only(adapter, statement, relations, opts) do
-          {:ok, res}
+          {:ok, %{result: res, relations: relations}}
         end
       after
         Relations.clear()
       end
 
     case result do
-      {:ok, %Result{} = res} ->
+      {:ok, %{result: %Result{} = res}} ->
         Telemetry.query_stop(
           start_time,
           Map.merge(telemetry_meta, %{row_count: res.num_rows, result: res})
         )
 
-        {:ok, res}
+        result
 
       {:error, _} = error ->
         Telemetry.query_exception(start_time, :error, error, [], telemetry_meta)
@@ -351,31 +395,6 @@ defmodule Lotus.Runner do
 
   defp sanitize_opts(opts) do
     Keyword.take(opts, [:read_only])
-  end
-
-  # Fires once sanitization and preflight have passed, with the relations
-  # preflight proved the statement touches. A plug may inspect but not rewrite
-  # here — the statement has already been authorized, so the one that executes
-  # must be the one preflight saw.
-  defp run_before_execute(
-         %Adapter{} = adapter,
-         %Statement{} = statement,
-         relations,
-         context,
-         vars
-       ) do
-    payload = %{
-      source: adapter.name,
-      statement: statement,
-      relations: relations,
-      context: context,
-      vars: vars
-    }
-
-    case Middleware.run(:before_execute, payload) do
-      {:cont, _payload} -> :ok
-      {:halt, reason} -> {:error, reason}
-    end
   end
 
   # Returns what preflight proved the statement touches: a list of

--- a/test/lotus/middleware_cache_hit_test.exs
+++ b/test/lotus/middleware_cache_hit_test.exs
@@ -10,6 +10,7 @@ defmodule Lotus.MiddlewareCacheHitTest do
 
   alias Lotus.Cache.ETS
   alias Lotus.{Config, Middleware}
+  alias Lotus.Preflight.Relations
   alias Lotus.Test.Schemas.User
 
   defmodule DenyUserPlug do
@@ -36,6 +37,26 @@ defmodule Lotus.MiddlewareCacheHitTest do
 
     def call(%{result: result} = payload, _opts) do
       {:cont, %{payload | result: %{result | rows: [["rewritten"]]}}}
+    end
+  end
+
+  defmodule CapturePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, event: event) do
+      send(self(), {event, payload})
+      {:cont, payload}
+    end
+  end
+
+  defmodule ReadRelationsPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, _opts) do
+      send(self(), {:relations_at_before_query, Relations.get()})
+      {:cont, payload}
     end
   end
 
@@ -134,5 +155,60 @@ defmodule Lotus.MiddlewareCacheHitTest do
 
     assert {:ok, grace} = run(%{name: "Grace"})
     assert grace.rows == [["Grace"]]
+  end
+
+  describe "the phases that stay inside the cache callback" do
+    test ":before_execute does not fire on a cache hit" do
+      Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
+
+      assert {:ok, _} = run(nil)
+      assert_received {:before_execute, payload}
+      assert payload.relations == [{"public", "test_users"}]
+
+      # `:before_execute` carries the relations preflight named, and preflight is
+      # what the cache stores, so a hit skips both. A plug that must run on every
+      # call belongs on `:before_query`.
+      assert {:ok, _} = run(nil)
+      refute_received {:before_execute, _payload}
+    end
+
+    test "a cache hit leaves no preflight relations behind" do
+      assert {:ok, _} = run(nil)
+      assert Relations.get() == []
+
+      assert {:ok, _} = run(nil)
+      assert Relations.get() == []
+    end
+
+    # `CAST(email AS integer)` plans fine and fails only once a row is
+    # evaluated, so preflight passes and records its relations before execution
+    # fails. `SHOW` skips preflight, so nothing overwrites those relations.
+    test "a failed statement does not lend its tables to a later cached statement" do
+      show = "SHOW search_path"
+      failing = "SELECT CAST(email AS integer) AS boom FROM test_users"
+
+      assert {:ok, %{rows: [[unmasked_path]]}} =
+               Lotus.run_statement(show, [], repo: "postgres")
+
+      stub(Config, :column_rules_for_source_name, fn _source ->
+        [{"test_users", "search_path", [mask: {:fixed, "REDACTED"}]}]
+      end)
+
+      assert {:error, _} = Lotus.run_statement(failing, [], repo: "postgres")
+
+      assert {:ok, %{columns: ["search_path"], rows: [[path]]}} =
+               Lotus.run_statement(show, [], repo: "postgres", cache: :refresh)
+
+      assert path == unmasked_path
+    end
+
+    test "a :before_query plug never sees relations another statement left behind" do
+      Middleware.compile(%{before_query: [{ReadRelationsPlug, []}]})
+
+      Relations.put([{"public", "test_users"}])
+
+      assert {:ok, _} = run(nil)
+      assert_received {:relations_at_before_query, []}
+    end
   end
 end

--- a/test/lotus/middleware_cache_hit_test.exs
+++ b/test/lotus/middleware_cache_hit_test.exs
@@ -1,0 +1,138 @@
+defmodule Lotus.MiddlewareCacheHitTest do
+  @moduledoc """
+  `:before_query` and `:after_query` run outside the result cache callback, so a
+  cache hit does not skip them. Middleware is the documented place for
+  context-dependent logic, and `:context` is not part of the cache key.
+  """
+
+  use Lotus.Case, async: false
+  use Mimic
+
+  alias Lotus.Cache.ETS
+  alias Lotus.{Config, Middleware}
+  alias Lotus.Test.Schemas.User
+
+  defmodule DenyUserPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{context: %{user: "b"}}, _opts), do: {:halt, "denied"}
+    def call(payload, _opts), do: {:cont, payload}
+  end
+
+  defmodule RecordRunPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, event: event) do
+      send(self(), {event, payload[:context]})
+      {:cont, payload}
+    end
+  end
+
+  defmodule RewriteResultPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{result: result} = payload, _opts) do
+      {:cont, %{payload | result: %{result | rows: [["rewritten"]]}}}
+    end
+  end
+
+  defmodule TenantPredicatePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{statement: statement, context: %{name: name}} = payload, _opts) do
+      body = "SELECT name FROM test_users WHERE name = '#{name}'"
+      {:cont, %{payload | statement: %{statement | body: body}}}
+    end
+
+    def call(payload, _opts), do: {:cont, payload}
+  end
+
+  @statement "SELECT name FROM test_users ORDER BY name"
+
+  setup do
+    Mimic.copy(Lotus.Config)
+
+    clear_cache_tables()
+
+    on_exit(fn ->
+      :persistent_term.erase({Lotus.Middleware, :compiled})
+      clear_cache_tables()
+    end)
+
+    Config
+    |> stub(:cache_adapter, fn -> {:ok, ETS} end)
+    |> stub(:cache_namespace, fn -> "middleware_cache_test" end)
+    |> stub(:default_cache_profile, fn -> :results end)
+    |> stub(:cache_profile_settings, fn _profile -> [ttl_ms: 30_000] end)
+
+    Repo.insert!(%User{id: 1, name: "Ada", email: "ada@example.test", age: 36})
+    Repo.insert!(%User{id: 2, name: "Grace", email: "grace@example.test", age: 85})
+
+    :ok
+  end
+
+  defp clear_cache_tables do
+    for table <- [:lotus_cache, :lotus_cache_tags] do
+      if :ets.whereis(table) != :undefined, do: :ets.delete_all_objects(table)
+    end
+
+    :ok
+  end
+
+  defp run(context) do
+    Lotus.run_statement(@statement, [], repo: "postgres", context: context)
+  end
+
+  test "a :before_query plug halts on a warm cache" do
+    Middleware.compile(%{before_query: [{DenyUserPlug, []}]})
+
+    assert {:ok, _result} = run(%{user: "a"})
+    assert {:error, "denied"} = run(%{user: "b"})
+  end
+
+  test ":before_query runs on every call, cached or not" do
+    Middleware.compile(%{before_query: [{RecordRunPlug, [event: :before]}]})
+
+    assert {:ok, _} = run(%{user: "a"})
+    assert {:ok, _} = run(%{user: "b"})
+
+    assert_received {:before, %{user: "a"}}
+    assert_received {:before, %{user: "b"}}
+  end
+
+  test ":after_query runs on every call, cached or not" do
+    Middleware.compile(%{after_query: [{RecordRunPlug, [event: :after]}]})
+
+    assert {:ok, _} = run(%{user: "a"})
+    assert {:ok, _} = run(%{user: "b"})
+
+    assert_received {:after, %{user: "a"}}
+    assert_received {:after, %{user: "b"}}
+  end
+
+  test "an :after_query plug that changes the result does not write it back to the cache" do
+    Middleware.compile(%{after_query: [{RewriteResultPlug, []}]})
+
+    assert {:ok, first} = run(nil)
+    assert first.rows == [["rewritten"]]
+
+    Middleware.compile(%{})
+
+    assert {:ok, second} = run(nil)
+    assert second.rows == [["Ada"], ["Grace"]]
+  end
+
+  test "a statement a :before_query plug rewrote keys its own cache entry" do
+    Middleware.compile(%{before_query: [{TenantPredicatePlug, []}]})
+
+    assert {:ok, ada} = run(%{name: "Ada"})
+    assert ada.rows == [["Ada"]]
+
+    assert {:ok, grace} = run(%{name: "Grace"})
+    assert grace.rows == [["Grace"]]
+  end
+end

--- a/test/lotus/middleware_cache_hit_test.exs
+++ b/test/lotus/middleware_cache_hit_test.exs
@@ -1,15 +1,19 @@
 defmodule Lotus.MiddlewareCacheHitTest do
   @moduledoc """
-  `:before_query` and `:after_query` run outside the result cache callback, so a
-  cache hit does not skip them. Middleware is the documented place for
-  context-dependent logic, and `:context` is not part of the cache key.
+  The query middleware runs outside the result cache callback, so a cache hit
+  does not skip it. `:context` is not part of the cache key, and middleware is
+  the documented place for context-dependent logic, so a plug that gates or
+  audits per caller has to see every call.
+
+  `:before_execute` gates on the relations preflight found, and those relations
+  are stored with the result, so it fires on a hit as well.
   """
 
   use Lotus.Case, async: false
   use Mimic
 
-  alias Lotus.Cache.ETS
-  alias Lotus.{Config, Middleware}
+  alias Lotus.Cache.{ETS, Key}
+  alias Lotus.{Config, Middleware, Result}
   alias Lotus.Preflight.Relations
   alias Lotus.Test.Schemas.User
 
@@ -31,6 +35,16 @@ defmodule Lotus.MiddlewareCacheHitTest do
     end
   end
 
+  defmodule CapturePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, event: event) do
+      send(self(), {event, payload})
+      {:cont, payload}
+    end
+  end
+
   defmodule RewriteResultPlug do
     @moduledoc false
     def init(opts), do: opts
@@ -40,14 +54,10 @@ defmodule Lotus.MiddlewareCacheHitTest do
     end
   end
 
-  defmodule CapturePlug do
+  defmodule HaltResultPlug do
     @moduledoc false
     def init(opts), do: opts
-
-    def call(payload, event: event) do
-      send(self(), {event, payload})
-      {:cont, payload}
-    end
+    def call(_payload, _opts), do: {:halt, "withheld"}
   end
 
   defmodule ReadRelationsPlug do
@@ -60,13 +70,41 @@ defmodule Lotus.MiddlewareCacheHitTest do
     end
   end
 
-  defmodule TenantPredicatePlug do
+  defmodule DenyRelationPlug do
     @moduledoc false
     def init(opts), do: opts
 
+    def call(%{relations: relations} = payload, denied: denied) do
+      if Enum.any?(relations, &match?({_schema, ^denied}, &1)) do
+        {:halt, "denied by table authz"}
+      else
+        {:cont, payload}
+      end
+    end
+  end
+
+  defmodule TenantBodyPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    # Replaces the whole statement, parameters included, the way a plug that
+    # substitutes its own query has to.
     def call(%{statement: statement, context: %{name: name}} = payload, _opts) do
       body = "SELECT name FROM test_users WHERE name = '#{name}'"
-      {:cont, %{payload | statement: %{statement | body: body}}}
+      {:cont, %{payload | statement: %{statement | body: body, params: []}}}
+    end
+
+    def call(payload, _opts), do: {:cont, payload}
+  end
+
+  defmodule TenantParamPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    # Filters through a bound parameter and leaves the statement text alone —
+    # the shape a plug takes when it does not splice values into SQL.
+    def call(%{statement: statement, context: %{name: name}} = payload, _opts) do
+      {:cont, %{payload | statement: %{statement | params: [name]}}}
     end
 
     def call(payload, _opts), do: {:cont, payload}
@@ -108,98 +146,216 @@ defmodule Lotus.MiddlewareCacheHitTest do
     Lotus.run_statement(@statement, [], repo: "postgres", context: context)
   end
 
-  test "a :before_query plug halts on a warm cache" do
-    Middleware.compile(%{before_query: [{DenyUserPlug, []}]})
+  # `[:lotus, :query, :stop]` brackets the phase the cache stores, so counting
+  # those events counts executions. Asserting that middleware ran twice proves
+  # nothing unless the second call was really served from the cache.
+  defp count_executions(fun) do
+    ref = make_ref()
+    pid = self()
+    handler = "#{inspect(ref)}"
 
-    assert {:ok, _result} = run(%{user: "a"})
-    assert {:error, "denied"} = run(%{user: "b"})
+    :telemetry.attach(
+      handler,
+      [:lotus, :query, :stop],
+      fn _event, _measurements, _metadata, _config -> send(pid, {ref, :executed}) end,
+      nil
+    )
+
+    try do
+      fun.()
+      count_messages(ref, 0)
+    after
+      :telemetry.detach(handler)
+    end
   end
 
-  test ":before_query runs on every call, cached or not" do
-    Middleware.compile(%{before_query: [{RecordRunPlug, [event: :before]}]})
-
-    assert {:ok, _} = run(%{user: "a"})
-    assert {:ok, _} = run(%{user: "b"})
-
-    assert_received {:before, %{user: "a"}}
-    assert_received {:before, %{user: "b"}}
+  defp count_messages(ref, count) do
+    receive do
+      {^ref, :executed} -> count_messages(ref, count + 1)
+    after
+      0 -> count
+    end
   end
 
-  test ":after_query runs on every call, cached or not" do
-    Middleware.compile(%{after_query: [{RecordRunPlug, [event: :after]}]})
+  describe "the middleware around the cache callback" do
+    test "a :before_query plug halts on a warm cache" do
+      Middleware.compile(%{before_query: [{DenyUserPlug, []}]})
 
-    assert {:ok, _} = run(%{user: "a"})
-    assert {:ok, _} = run(%{user: "b"})
+      assert {:ok, _result} = run(%{user: "a"})
+      assert {:error, "denied"} = run(%{user: "b"})
+    end
 
-    assert_received {:after, %{user: "a"}}
-    assert_received {:after, %{user: "b"}}
+    test ":before_query and :after_query run on a call served from the cache" do
+      Middleware.compile(%{
+        before_query: [{RecordRunPlug, [event: :before]}],
+        after_query: [{RecordRunPlug, [event: :after]}]
+      })
+
+      executions =
+        count_executions(fn ->
+          assert {:ok, _} = run(%{user: "a"})
+          assert {:ok, _} = run(%{user: "b"})
+        end)
+
+      assert executions == 1
+
+      assert_received {:before, %{user: "a"}}
+      assert_received {:before, %{user: "b"}}
+      assert_received {:after, %{user: "a"}}
+      assert_received {:after, %{user: "b"}}
+    end
+
+    test "a halt on :after_query withholds a cached result from that caller alone" do
+      assert {:ok, _} = run(nil)
+
+      Middleware.compile(%{after_query: [{HaltResultPlug, []}]})
+      assert {:error, "withheld"} = run(nil)
+
+      Middleware.compile(%{})
+      assert {:ok, result} = run(nil)
+      assert result.rows == [["Ada"], ["Grace"]]
+    end
+
+    test "an :after_query plug that changes the result does not write it back to the cache" do
+      Middleware.compile(%{after_query: [{RewriteResultPlug, []}]})
+
+      assert {:ok, first} = run(nil)
+      assert first.rows == [["rewritten"]]
+
+      # Emptying the table proves the second call was served from the store: a
+      # re-execution would return no rows at all.
+      Repo.delete_all(User)
+      Middleware.compile(%{})
+
+      assert {:ok, second} = run(nil)
+      assert second.rows == [["Ada"], ["Grace"]]
+    end
+
+    test "a statement a :before_query plug rewrote keys its own cache entry" do
+      Middleware.compile(%{before_query: [{TenantBodyPlug, []}]})
+
+      assert {:ok, ada} = run(%{name: "Ada"})
+      assert ada.rows == [["Ada"]]
+
+      assert {:ok, grace} = run(%{name: "Grace"})
+      assert grace.rows == [["Grace"]]
+    end
+
+    test "a plug that rewrites only the bound parameters keys its own entry too" do
+      Middleware.compile(%{before_query: [{TenantParamPlug, []}]})
+
+      statement = "SELECT name FROM test_users WHERE name = $1"
+
+      run = fn name ->
+        Lotus.run_statement(statement, ["unused"], repo: "postgres", context: %{name: name})
+      end
+
+      assert {:ok, ada} = run.("Ada")
+      assert ada.rows == [["Ada"]]
+
+      assert {:ok, grace} = run.("Grace")
+      assert grace.rows == [["Grace"]]
+    end
+
+    test "a stored query keys its entry on the rewritten statement as well" do
+      Middleware.compile(%{before_query: [{TenantBodyPlug, []}]})
+
+      {:ok, query} =
+        Lotus.create_query(%{
+          name: "Users by age",
+          statement: "SELECT name FROM test_users WHERE age >= {{min_age}}",
+          data_source: "postgres",
+          variables: [%{name: "min_age", type: :number, default: "18"}]
+        })
+
+      assert {:ok, ada} = Lotus.run_query(query, context: %{name: "Ada"})
+      assert ada.rows == [["Ada"]]
+
+      assert {:ok, grace} = Lotus.run_query(query, context: %{name: "Grace"})
+      assert grace.rows == [["Grace"]]
+    end
   end
 
-  test "an :after_query plug that changes the result does not write it back to the cache" do
-    Middleware.compile(%{after_query: [{RewriteResultPlug, []}]})
+  describe ":before_execute on a cached result" do
+    test "fires on a hit, with the relations stored alongside the result" do
+      Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
 
-    assert {:ok, first} = run(nil)
-    assert first.rows == [["rewritten"]]
+      executions =
+        count_executions(fn ->
+          assert {:ok, _} = run(nil)
+          assert {:ok, _} = run(nil)
+        end)
 
-    Middleware.compile(%{})
+      assert executions == 1
 
-    assert {:ok, second} = run(nil)
-    assert second.rows == [["Ada"], ["Grace"]]
-  end
+      assert_received {:before_execute, first}
+      assert_received {:before_execute, second}
+      assert first.relations == [{"public", "test_users"}]
+      assert second.relations == first.relations
+      assert second.statement.body == @statement
+    end
 
-  test "a statement a :before_query plug rewrote keys its own cache entry" do
-    Middleware.compile(%{before_query: [{TenantPredicatePlug, []}]})
+    test "a halt on a hit withholds the cached result" do
+      assert {:ok, _} = run(nil)
 
-    assert {:ok, ada} = run(%{name: "Ada"})
-    assert ada.rows == [["Ada"]]
+      Middleware.compile(%{before_execute: [{DenyRelationPlug, [denied: "test_users"]}]})
 
-    assert {:ok, grace} = run(%{name: "Grace"})
-    assert grace.rows == [["Grace"]]
-  end
+      assert {:error, "denied by table authz"} = run(nil)
+    end
 
-  describe "the phases that stay inside the cache callback" do
-    test ":before_execute does not fire on a cache hit" do
+    test "the relations a plug sees on a hit are not a leftover from another statement" do
       Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
 
       assert {:ok, _} = run(nil)
+      assert_received {:before_execute, _first}
+
+      Relations.put([{"public", "decoy"}])
+
+      assert {:ok, _} = run(nil)
+      assert_received {:before_execute, second}
+      assert second.relations == [{"public", "test_users"}]
+    end
+  end
+
+  describe "an entry stored before results carried their relations" do
+    test "is replaced, and :before_execute gates on the relations of the fresh run" do
+      key =
+        Key.result(
+          @statement,
+          %{__params__: []},
+          [data_source: "postgres", search_path: nil, lotus_version: Lotus.version()],
+          nil
+        )
+
+      stale = %Result{columns: ["name"], rows: [["stale"]], num_rows: 1}
+      :ok = Lotus.Cache.put(key, stale, 30_000, [])
+
+      Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
+
+      assert {:ok, result} = run(nil)
+      assert result.rows == [["Ada"], ["Grace"]]
+
       assert_received {:before_execute, payload}
       assert payload.relations == [{"public", "test_users"}]
 
-      # `:before_execute` carries the relations preflight named, and preflight is
-      # what the cache stores, so a hit skips both. A plug that must run on every
-      # call belongs on `:before_query`.
-      assert {:ok, _} = run(nil)
-      refute_received {:before_execute, _payload}
-    end
+      # The replacement carries the relations, so the next call is a hit that
+      # still has something to gate on.
+      executions = count_executions(fn -> assert {:ok, _} = run(nil) end)
+      assert executions == 0
 
-    test "a cache hit leaves no preflight relations behind" do
+      assert_received {:before_execute, from_cache}
+      assert from_cache.relations == [{"public", "test_users"}]
+    end
+  end
+
+  describe "preflight relations across a cached call" do
+    test "a call served from the cache leaves no relations behind" do
+      assert {:ok, _} = run(nil)
+
+      Relations.put([{"public", "decoy"}])
+
       assert {:ok, _} = run(nil)
       assert Relations.get() == []
-
-      assert {:ok, _} = run(nil)
-      assert Relations.get() == []
-    end
-
-    # `CAST(email AS integer)` plans fine and fails only once a row is
-    # evaluated, so preflight passes and records its relations before execution
-    # fails. `SHOW` skips preflight, so nothing overwrites those relations.
-    test "a failed statement does not lend its tables to a later cached statement" do
-      show = "SHOW search_path"
-      failing = "SELECT CAST(email AS integer) AS boom FROM test_users"
-
-      assert {:ok, %{rows: [[unmasked_path]]}} =
-               Lotus.run_statement(show, [], repo: "postgres")
-
-      stub(Config, :column_rules_for_source_name, fn _source ->
-        [{"test_users", "search_path", [mask: {:fixed, "REDACTED"}]}]
-      end)
-
-      assert {:error, _} = Lotus.run_statement(failing, [], repo: "postgres")
-
-      assert {:ok, %{columns: ["search_path"], rows: [[path]]}} =
-               Lotus.run_statement(show, [], repo: "postgres", cache: :refresh)
-
-      assert path == unmasked_path
     end
 
     test "a :before_query plug never sees relations another statement left behind" do
@@ -209,6 +365,32 @@ defmodule Lotus.MiddlewareCacheHitTest do
 
       assert {:ok, _} = run(nil)
       assert_received {:relations_at_before_query, []}
+    end
+
+    # `CAST(email AS integer)` plans fine and fails only once a row is
+    # evaluated, so preflight passes and records its relations before execution
+    # fails.
+    test "a statement that fails during execution clears its relations" do
+      failing = "SELECT CAST(email AS integer) AS boom FROM test_users"
+
+      assert {:error, _} = Lotus.run_statement(failing, [], repo: "postgres")
+      assert Relations.get() == []
+    end
+  end
+
+  describe "pagination" do
+    test "the page and its count are built from the rewritten statement" do
+      Middleware.compile(%{before_query: [{TenantBodyPlug, []}]})
+
+      assert {:ok, result} =
+               Lotus.run_statement(@statement, [],
+                 repo: "postgres",
+                 context: %{name: "Ada"},
+                 window: [limit: 10, count: :exact]
+               )
+
+      assert result.rows == [["Ada"]]
+      assert result.meta.total_count == 1
     end
   end
 end


### PR DESCRIPTION
Closes #257

## Problem

`:before_query` and `:after_query` ran inside the result cache callback, so a plug saw only the call that filled the cache:

- A `:before_query` plug that halts for one user let the same statement through for the next one while the entry was warm.
- An audit plug on `:after_query` recorded one execution in place of many.
- `:context` is not part of the cache key, so two callers with different contexts and the same scope shared one entry.

Middleware is the documented place for context-dependent logic, and discovery already runs its events outside the schema cache for that reason. The query path did not follow the same rule.

## Change

`Lotus.Runner` now exposes the pipeline as three phases:

- `before_query/3` — the `:before_query` middleware; returns the statement to execute.
- `execute_statement/3` — sanitization, preflight, `:before_execute`, execution, column policies. This is the phase the cache stores.
- `after_query/4` — the `:after_query` middleware, on the result.

`run_statement/3` composes the three and behaves as before. `Lotus.execute_with_options/7` runs `before_query` **before** the cache key is built — so a statement a plug rewrites keys its own entry — caches the raw execution only, and runs `after_query` on the returned result, hit or miss. What an `:after_query` plug makes of the result is not written back to the cache.

`:before_execute` stays inside the callback, next to the preflight whose relations it carries; `:scope` is in the key, so it stays consistent.

No public API removed, no change to the cache key.

## One behaviour note

`[:lotus, :query, *]` telemetry now brackets the execution phase alone, which is the phase the cache stores — the documented contract that "a query served from cache emits no query events" is unchanged. A middleware halt therefore emits no query events, because no statement ran. `guides/telemetry.md` says so.

## Tests

`test/lotus/middleware_cache_hit_test.exs` — five tests, each failing before the change:

- a `:before_query` plug halts on a warm cache;
- `:before_query` and `:after_query` each run on every call, cached or not;
- an `:after_query` plug that changes the result does not write it back to the cache;
- a statement a `:before_query` plug rewrote keys its own cache entry.

`mix test` — 1976 passing. `mix compile --warnings-as-errors`, `mix format --check-formatted` and `mix credo --strict` clean.

Docs updated: `Lotus.Middleware` moduledoc, `guides/middleware.md`, `guides/telemetry.md`, `guides/contributing.md` pipeline diagram, CHANGELOG.