### PR TITLE
fix(sqlite): drop the compile-time reference to the optional Exqlite.Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@
   the stale value for every query that followed. `run_statement/3` now clears
   the relations on every exit, raises included.
 
+- **Lotus compiles without an `Exqlite.Error is undefined` warning in projects
+  that do not use `ecto_sqlite3`.** The SQLite dialect rescued
+  `Exqlite.Error` by name, which made a compile-time reference to an optional
+  dependency. The dialect now matches the error struct by an atom that makes no
+  compile-time reference. SQLite behavior does not change.
+
 ## [1.0.0] - 2026-09-12
 
 > **v1.0 is a large rewrite and not a drop-in upgrade from the v0.16.x

--- a/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
+++ b/lib/lotus/source/adapters/ecto/dialects/sqlite.ex
@@ -48,20 +48,32 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
     e -> {:error, Exception.message(e)}
   end
 
+  # ecto_sqlite3 is optional. A `rescue ... in [Exqlite.Error]` clause or a
+  # `%Exqlite.Error{}` pattern makes a compile-time reference, which warns in
+  # projects without exqlite. Module.concat/1 gives the same atom without it.
+  @exqlite_error Module.concat(["Exqlite", "Error"])
+
   defp setup_read_only_pragma(_repo, false), do: {false, nil}
 
   defp setup_read_only_pragma(repo, true) do
     check_and_set_pragma(repo)
   rescue
-    error in [Exqlite.Error] ->
-      msg = error.message || Exception.message(error)
-
-      if msg =~ "no such pragma" or msg =~ "unknown pragma" do
+    error ->
+      if exqlite_error?(error) and pragma_unsupported?(exqlite_message(error)) do
         log_pragma_warning()
         {false, nil}
       else
         reraise error, __STACKTRACE__
       end
+  end
+
+  defp exqlite_error?(%{__struct__: @exqlite_error}), do: true
+  defp exqlite_error?(_), do: false
+
+  defp exqlite_message(error), do: Map.get(error, :message) || Exception.message(error)
+
+  defp pragma_unsupported?(message) do
+    message =~ "no such pragma" or message =~ "unknown pragma"
   end
 
   defp check_and_set_pragma(repo) do
@@ -93,8 +105,8 @@ defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3 do
   end
 
   @impl true
-  def format_error(%{__struct__: mod} = e) when mod == Exqlite.Error do
-    "SQLite Error: " <> (Map.get(e, :message) || Exception.message(e))
+  def format_error(%{__struct__: @exqlite_error} = error) do
+    "SQLite Error: " <> exqlite_message(error)
   end
 
   def format_error(other), do: Default.format_error(other)

--- a/test/lotus/source/adapters/ecto/dialects/sqlite_test.exs
+++ b/test/lotus/source/adapters/ecto/dialects/sqlite_test.exs
@@ -1,0 +1,55 @@
+defmodule Lotus.Source.Adapters.Ecto.Dialects.SQLite3Test do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Lotus.Source.Adapters.Ecto.Dialects.Default
+  alias Lotus.Source.Adapters.Ecto.Dialects.SQLite3
+
+  defmodule PragmaRaisingRepo do
+    def checkout(fun), do: fun.()
+
+    def query("PRAGMA query_only"), do: raise(Process.get(:pragma_error))
+
+    def transaction(fun, _opts), do: {:ok, fun.()}
+  end
+
+  describe "execute_in_transaction/3 when PRAGMA query_only raises" do
+    test "runs the transaction without the pragma when SQLite does not know it" do
+      Process.put(:pragma_error, %Exqlite.Error{message: "no such pragma: query_only"})
+
+      log =
+        capture_log(fn ->
+          assert {:ok, :ran} =
+                   SQLite3.execute_in_transaction(PragmaRaisingRepo, fn -> :ran end, [])
+        end)
+
+      assert log =~ "does not support PRAGMA query_only"
+    end
+
+    test "returns the error for any other Exqlite error" do
+      Process.put(:pragma_error, %Exqlite.Error{message: "database is locked"})
+
+      assert {:error, "database is locked"} =
+               SQLite3.execute_in_transaction(PragmaRaisingRepo, fn -> :ran end, [])
+    end
+
+    test "returns the error for a non-Exqlite exception with a pragma message" do
+      Process.put(:pragma_error, %RuntimeError{message: "no such pragma: query_only"})
+
+      assert {:error, "no such pragma: query_only"} =
+               SQLite3.execute_in_transaction(PragmaRaisingRepo, fn -> :ran end, [])
+    end
+  end
+
+  describe "format_error/1" do
+    test "prefixes an Exqlite error message" do
+      assert SQLite3.format_error(%Exqlite.Error{message: "no such table: missing"}) ==
+               "SQLite Error: no such table: missing"
+    end
+
+    test "delegates other errors to the default dialect" do
+      assert SQLite3.format_error("boom") == Default.format_error("boom")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Projects that do not use `ecto_sqlite3` got this warning when they compiled Lotus:

```
warning: struct Exqlite.Error is undefined (module Exqlite.Error is not available or is yet to be defined)
  └─ lib/lotus/source/adapters/ecto/dialects/sqlite.ex:56
```

The cause is `rescue error in [Exqlite.Error]`. That clause expands to a struct check, which makes a compile-time reference to an optional dependency.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes made

- `Lotus.Source.Adapters.Ecto.Dialects.SQLite3` gets the error module as an attribute from `Module.concat(["Exqlite", "Error"])`. This atom makes no compile-time reference.
- `setup_read_only_pragma/2` rescues all exceptions. It handles only an Exqlite error with a "no such pragma" or "unknown pragma" message. It re-raises all other exceptions, as before.
- `format_error/1` matches on the same attribute, for consistency.
- CHANGELOG entry under Unreleased → Fixed.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

New `test/lotus/source/adapters/ecto/dialects/sqlite_test.exs` uses a fake repo whose `PRAGMA query_only` raises. It covers:
- an unsupported pragma: the transaction runs and a warning is logged
- a different Exqlite error: an error is returned
- a non-Exqlite exception with a pragma message: an error is returned
- `format_error/1` for an Exqlite error and for other errors

Manual check: I compiled the old clause and the new clause with `elixirc`, with no exqlite on the code path. The old clause gives the warning. The new clause gives no warning.

Full suite: 1991 passed. `mix compile --warnings-as-errors`, `mix format --check-formatted` and `mix credo --strict` pass.

## Environment (if applicable)

**Elixir & OTP versions:** Elixir 1.20.1, OTP 29

**Dependencies:** None

## Breaking changes

None.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that this change doesn't introduce security vulnerabilities

## Related issues

Fixes #265