### PR TITLE
fix(runner): run the exact-count statement with the caller's options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@
 
 ### Fixed
 
+- **The exact-count run now runs as the caller.** `window: [count: :exact]`
+  runs a second statement to compute `meta.total_count`, and that run dropped
+  the caller's options: preflight ran with no `:scope`, so a scoped table deny
+  that blocked the page did not apply to the count beside it, and middleware
+  saw `context: nil` and `vars: %{}`, so an audit plug recorded the count with
+  no caller and a plug that halts without a caller silently turned the total
+  into `nil`. The count run now carries `:context`, `:scope`, `:vars` and the
+  read-only setting. It fires `:before_execute`, as it touches the same tables
+  as the page, but not `:before_query` — it is derived from the statement that
+  hook already returned, so a rewriting plug would apply twice — and not
+  `:after_query`, because it has no result the caller reads. A halt on the
+  count run still leaves `meta.total_count` as `nil` with the page intact.
+
 - **Middleware is no longer skipped on a result cache hit.** The query events
   ran inside the cache callback, so a plug saw only the call that filled the
   cache: a `:before_query` plug that halts for one user let the same statement

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -36,6 +36,10 @@ Each middleware receives a payload map whose contents depend on the pipeline eve
 
 `:vars` is the map of bound query variables by name, after defaults and caller-supplied values are merged. It is `%{}` for a raw statement run through `Lotus.run_statement/3`.
 
+### The exact-count run
+
+`window: [count: :exact]` runs a second statement, derived from the page statement, to compute `meta.total_count`. That run carries the caller's `:context`, `:vars`, `:scope` and read-only setting. It fires `:before_execute` (it touches the same tables as the page and is authorised the same way) but not `:before_query` (it is derived from the statement that hook already returned, so a rewriting plug would apply twice) and not `:after_query` (it has no result the caller reads). A halt on the count run leaves `meta.total_count` as `nil` and the page result intact.
+
 ### Discovery event ordering
 
 Discovery calls (`Lotus.list_schemas/2`, `Lotus.list_tables/2`, `Lotus.describe_table/3`, `Lotus.list_relations/2`) fire **two** events per call:

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -506,7 +506,7 @@ defmodule Lotus do
     # describes what will actually execute.
     with {:ok, %Statement{} = statement} <- Runner.before_query(adapter, statement, runner_opts),
          {statement, pagination_meta, cache_bound} =
-           maybe_paginate(statement, adapter, search_path, Keyword.get(opts, :window)),
+           maybe_paginate(statement, adapter, runner_opts, Keyword.get(opts, :window)),
          {:ok, %Result{} = res} <-
            exec_cached_statement(
              adapter,
@@ -1016,19 +1016,20 @@ defmodule Lotus do
     :ok
   end
 
-  defp maybe_paginate(%Statement{} = statement, _adapter, _search_path, nil),
+  defp maybe_paginate(%Statement{} = statement, _adapter, _runner_opts, nil),
     do: {statement, nil, nil}
 
   defp maybe_paginate(
          %Statement{params: params} = statement,
          adapter,
-         search_path,
+         runner_opts,
          pagination_opts
        )
        when is_list(pagination_opts) do
     limit = resolve_window_limit(pagination_opts)
     offset = Keyword.get(pagination_opts, :offset, 0)
     count_mode = Keyword.get(pagination_opts, :count, :none)
+    search_path = Keyword.get(runner_opts, :search_path)
 
     callback_opts = [limit: limit, offset: offset, count: count_mode, search_path: search_path]
 
@@ -1039,12 +1040,14 @@ defmodule Lotus do
     # chose to fulfil it. Strategy A adapters (inline count via the main
     # query result) don't set :count_spec but still need :exact plumbed
     # through so merge_pagination_meta/2 surfaces the total.
+    # The count run is Lotus's own statement, derived from the caller's, and it
+    # must run as the caller: same context, scope, vars and read-only setting.
     pagination_meta = %{
       window: %{limit: limit, offset: offset},
       total_mode: count_mode,
       count_spec: count_spec,
       adapter: adapter,
-      search_path: search_path
+      runner_opts: runner_opts
     }
 
     cache_bound = %{
@@ -1092,33 +1095,31 @@ defmodule Lotus do
     }
   end
 
-  defp do_count(%{count_spec: %{query: q, params: ps}, adapter: adapter} = meta) do
-    runner_opts = build_runner_opts(meta)
+  # The count statement is derived from the statement `:before_query` already
+  # returned, so that hook does not run again: a rewriting plug would apply its
+  # predicate twice. `:after_query` does not run either: it shapes a result the
+  # caller reads, and the count has none. Sanitization, preflight and
+  # `:before_execute` do run, with the caller's options, because the count
+  # touches the same tables as the page and must be authorised the same way.
+  defp do_count(%{count_spec: %{query: q, params: ps}, adapter: adapter, runner_opts: opts}) do
     statement = %Statement{adapter: adapter.module, body: q, params: ps}
 
     adapter
-    |> Runner.run_statement(statement, runner_opts)
+    |> Runner.execute_statement(statement, opts)
     |> parse_count_result()
   end
 
-  defp build_runner_opts(meta) do
-    case Map.get(meta, :search_path) do
-      sp when is_binary(sp) and byte_size(sp) > 0 -> [search_path: sp]
-      _ -> []
-    end
-  end
-
-  defp parse_count_result({:ok, %Result{rows: [[n]]}} = _result) when is_integer(n) do
+  defp parse_count_result({:ok, %{result: %Result{rows: [[n]]}}}) when is_integer(n) do
     {:ok, n}
   end
 
-  defp parse_count_result({:ok, %Result{rows: [[n]]}} = _result) when is_binary(n) do
+  defp parse_count_result({:ok, %{result: %Result{rows: [[n]]}}}) when is_binary(n) do
     case Integer.parse(n) do
       {v, _} -> {:ok, v}
       _ -> {:error, :invalid_count}
     end
   end
 
-  defp parse_count_result({:ok, %Result{rows: _}}), do: {:error, :invalid_count}
+  defp parse_count_result({:ok, %{result: %Result{}}}), do: {:error, :invalid_count}
   defp parse_count_result(other), do: other
 end

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -58,6 +58,18 @@ defmodule Lotus.Middleware do
   A plug that authorizes on the table list must treat both as unknown and
   halt, rather than read them as an empty set of tables.
 
+  #### Derived statements
+
+  `window: [count: :exact]` runs a second statement, derived from the page
+  statement, to compute `meta.total_count`. That run carries the caller's
+  `:context`, `:vars`, `:scope` and read-only setting, and fires
+  `:before_execute` — it touches the same tables as the page and is
+  authorised the same way. It does not fire `:before_query`, because it is
+  derived from the statement that hook already returned and a rewriting plug
+  would apply twice. It does not fire `:after_query`, because it has no result
+  the caller reads. A halt on the count run leaves `meta.total_count` as `nil`
+  and the page result intact.
+
   `:vars` is the map of bound query variables, by name, after defaults and
   caller-supplied values are merged (`%{"start_date" => "2026-01-01"}`).
   It is `%{}` for a raw statement run through `Lotus.run_statement/3`. A plug

--- a/test/lotus/middleware_count_run_test.exs
+++ b/test/lotus/middleware_count_run_test.exs
@@ -1,0 +1,154 @@
+defmodule Lotus.MiddlewareCountRunTest do
+  @moduledoc """
+  `window: [count: :exact]` runs a second statement, derived from the page
+  statement, to compute `meta.total_count`. That run is Lotus's own and not
+  the caller's, so it must carry the caller's options into the pipeline and
+  fire only the events that make sense for a derived statement:
+
+    * `:before_query` fires once, for the page statement. The count statement
+      is derived from what that hook returned, so running it again would apply
+      a rewriting plug twice.
+    * `:before_execute` fires for the page and for the count, with the caller's
+      context and vars, because it authorises against relations and the count
+      touches the same tables.
+    * `:after_query` fires once, for the page result. The count has no
+      user-facing result to shape.
+    * Preflight sees the caller's scope on both runs.
+  """
+
+  use Lotus.Case
+  use Mimic
+
+  alias Lotus.Middleware
+  alias Lotus.Test.Schemas.User
+
+  defmodule CapturePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, event: event) do
+      send(self(), {event, payload})
+      {:cont, payload}
+    end
+  end
+
+  defmodule HaltCountPlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(%{statement: %{body: body}} = payload, _opts) do
+      if String.contains?(body, "COUNT("),
+        do: {:halt, "count refused"},
+        else: {:cont, payload}
+    end
+  end
+
+  defmodule RecordingResolver do
+    @moduledoc false
+    @behaviour Lotus.Visibility.Resolver
+
+    @impl true
+    def schema_rules_for(_source, _scope), do: []
+
+    @impl true
+    def table_rules_for(_source, scope) do
+      send(self(), {:table_rules_for, scope})
+      []
+    end
+
+    @impl true
+    def column_rules_for(_source, _scope), do: []
+  end
+
+  @statement "SELECT name FROM test_users ORDER BY name"
+  @window [limit: 1, count: :exact]
+
+  setup :set_mimic_from_context
+
+  setup do
+    Mimic.copy(Lotus.Config)
+    on_exit(fn -> :persistent_term.erase({Lotus.Middleware, :compiled}) end)
+
+    Repo.insert!(%User{id: 1, name: "Ada", email: "ada@example.test", age: 36})
+    Repo.insert!(%User{id: 2, name: "Grace", email: "grace@example.test", age: 85})
+
+    :ok
+  end
+
+  defp run(opts) do
+    Lotus.run_statement(@statement, [], Keyword.merge([repo: "postgres", window: @window], opts))
+  end
+
+  test ":before_query fires once per paginated call, with the caller's context" do
+    Middleware.compile(%{before_query: [{CapturePlug, [event: :before_query]}]})
+
+    assert {:ok, result} = run(context: %{user: "a"})
+    assert result.meta.total_count == 2
+
+    assert_received {:before_query, %{context: %{user: "a"}}}
+    refute_received {:before_query, _}
+  end
+
+  test ":before_execute fires for the page and for the count, both with the caller's context" do
+    Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
+
+    assert {:ok, result} = run(context: %{user: "a"})
+    assert result.meta.total_count == 2
+
+    assert_received {:before_execute, %{context: %{user: "a"}} = page}
+    assert_received {:before_execute, %{context: %{user: "a"}} = count}
+    refute_received {:before_execute, _}
+
+    assert page.relations == [{"public", "test_users"}]
+    assert count.relations == [{"public", "test_users"}]
+    assert String.contains?(count.statement.body, "COUNT(")
+  end
+
+  test ":before_execute for the count carries the caller's vars" do
+    {:ok, query} =
+      Lotus.create_query(%{
+        name: "Users by age",
+        statement: "SELECT name FROM test_users WHERE age >= {{min_age}}",
+        data_source: "postgres",
+        variables: [%{name: "min_age", type: :number, default: "18"}]
+      })
+
+    Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
+
+    assert {:ok, result} = Lotus.run_query(query, vars: %{"min_age" => 40}, window: @window)
+    assert result.meta.total_count == 1
+
+    assert_received {:before_execute, %{vars: %{"min_age" => 40}}}
+    assert_received {:before_execute, %{vars: %{"min_age" => 40}}}
+    refute_received {:before_execute, _}
+  end
+
+  test ":after_query fires once, for the page result only" do
+    Middleware.compile(%{after_query: [{CapturePlug, [event: :after_query]}]})
+
+    assert {:ok, result} = run(context: %{user: "a"})
+    assert result.meta.total_count == 2
+
+    assert_received {:after_query, %{context: %{user: "a"}}}
+    refute_received {:after_query, _}
+  end
+
+  test "preflight sees the caller's scope on the page run and on the count run" do
+    stub(Lotus.Config, :visibility_resolver, fn -> RecordingResolver end)
+
+    assert {:ok, result} = run(scope: %{tenant_id: 7})
+    assert result.meta.total_count == 2
+
+    assert_received {:table_rules_for, %{tenant_id: 7}}
+    assert_received {:table_rules_for, %{tenant_id: 7}}
+    refute_received {:table_rules_for, nil}
+  end
+
+  test "a plug that halts the count leaves total_count nil and the page intact" do
+    Middleware.compile(%{before_execute: [{HaltCountPlug, []}]})
+
+    assert {:ok, result} = run(context: %{user: "a"})
+    assert result.rows == [["Ada"]]
+    assert result.meta.total_count == nil
+  end
+end


### PR DESCRIPTION
Closes #263.

`window: [count: :exact]` runs a second statement, derived from the page statement, to compute `meta.total_count`. That run went through the full pipeline with almost none of the caller's options: preflight ran with `scope: nil`, so a scoped table deny that blocked the page did not apply to the count beside it, and middleware saw `context: nil` and `vars: %{}`.

## What changes

- The count run carries the caller's `:context`, `:scope`, `:vars` and read-only setting. They travel in the pagination metadata, which is built where the runner options are in scope.
- The count run calls `Runner.execute_statement/3` instead of `run_statement/3`: sanitization, scoped preflight, `:before_execute` and column policies. It does not re-fire `:before_query`, because the count statement is derived from the statement that hook already returned and a rewriting plug would apply twice. It does not fire `:after_query`, because that hook shapes a result the caller reads and the count has none.
- A halted or failed count keeps the documented `total_count: nil`. With the same context and scope, a count that the page's own preflight and `:before_execute` just admitted cannot be refused by the same rules; what remains is adapter errors, already documented as `nil`.
- The middleware moduledoc and guide state which events the derived count run fires.

## Tests

`test/lotus/middleware_count_run_test.exs`, written first and watched fail on the current behaviour:

- `:before_query` fires once per paginated call, with the caller's context.
- `:before_execute` fires for the page and for the count, both with the caller's context; the count's relations name the same table.
- `:before_execute` for the count carries the caller's vars (saved query with a variable).
- `:after_query` fires once, for the page result only.
- A recording visibility resolver sees the caller's scope on both preflights and never `nil`.
- A plug that halts the count leaves `total_count` nil and the page intact.

Full suite 1979 tests green, `mix format --check-formatted`, `mix credo --strict` and `mix compile --warnings-as-errors` clean.