### PR TITLE
feat(middleware): settle the query middleware contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,42 @@
   after sanitization and preflight pass and before the statement executes,
   and its payload carries `:relations` — the `{schema, table}` pairs preflight
   proved the statement touches — alongside `:statement`, `:source`,
-  `:context` and `:vars`. A halt returns `{:error, reason}` to the caller, as
-  the other events do. `:relations` is `[]` when the adapter needs no
-  preflight, and `{:unrestricted, reason}` when the adapter cannot name the
-  relations a statement touches; both mean "unknown", not "touches nothing",
-  and a plug that gates on the list must refuse rather than read them as an
-  empty set. The event fires on a result served from the result cache too: the
-  relations are stored with the result, so a plug that authorizes a statement
-  against its tables is not skipped once the cache is warm.
+  `:origin`, `:context` and `:vars`. A halt returns `{:error, reason}` to the
+  caller, as the other events do. `:relations` is a list when preflight
+  proved the set — an empty list means the statement touches no relation —
+  and a tuple when nothing is known: `{:unrestricted, reason}` when the
+  adapter cannot name the relations a statement touches, `{:skipped, reason}`
+  when the adapter does not preflight the statement. A plug that gates on the
+  list matches `when is_list/1` and refuses any tuple. The event fires on a
+  result served from the result cache too: the relations are stored with the
+  result, so a plug that authorizes a statement against its tables is not
+  skipped once the cache is warm.
+
+- **`[:lotus, :run, :start | :stop | :exception]` telemetry.** The query
+  events cover only the execute step, so a result served from the cache and a
+  run a plug halted before execution emitted nothing — an audit consumer
+  could see neither a cache-served read nor a refusal unless it was the plug
+  that refused. The run events bracket the whole run, from `:before_query` to
+  `:after_query`, on every path. `:stop` carries the statement that ran, the
+  result, the relations and the origin (`:executed` or `:cached`);
+  `:exception` carries the phase that failed and the reason. All three carry
+  the caller's `:context` and `:vars`.
+
+- **`Lotus.Runner.run/4`** composes the phases of a run around an execute
+  step, so the cached and the uncached paths share one phase order, one set of
+  payloads and one telemetry span. **`Lotus.Preflight.analyze/4`** returns
+  what preflight learned as a value — the relations, or why they are unknown
+  — and the runner carries it down the pipeline; nothing crosses a phase
+  through the process dictionary any more.
+
+### Changed
+
+- **`:after_query` carries `:relations` and `:origin`.** The same relations
+  `:before_execute` received, and whether the result was executed or served
+  from the cache. A plug that shapes a result by table no longer needs a
+  second analysis or a hand-off from an earlier hook. `:before_execute`
+  carries `:origin` too. `Lotus.Runner.before_execute/5` takes the origin and
+  `after_query/3` takes the outcome map; both were unreleased.
 
 ### Fixed
 

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -26,8 +26,8 @@ Each middleware receives a payload map whose contents depend on the pipeline eve
 | Event | Triggered | Payload keys |
 |-------|-----------|--------------|
 | `:before_query` | Before sanitization, preflight and execution | `:statement`, `:source`, `:context`, `:vars` |
-| `:before_execute` | After sanitization and preflight pass, before execution | `:statement`, `:relations`, `:source`, `:context`, `:vars` |
-| `:after_query` | After execution, before result returned to caller | `:result`, `:statement`, `:source`, `:context`, `:vars` |
+| `:before_execute` | After sanitization and preflight pass, before execution — or, on a cache hit, before the stored result is returned | `:statement`, `:relations`, `:origin`, `:source`, `:context`, `:vars` |
+| `:after_query` | After execution, before result returned to caller | `:result`, `:statement`, `:relations`, `:origin`, `:source`, `:context`, `:vars` |
 | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
 | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |
 | `:after_describe_table` | After table schema introspection and column visibility | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
@@ -35,6 +35,17 @@ Each middleware receives a payload map whose contents depend on the pipeline eve
 | `:after_discover` | After any discovery call, following the kind-specific `:after_list_*` event | `:kind`, `:result`, `:source`, `:scope`, `:context` |
 
 `:vars` is the map of bound query variables by name, after defaults and caller-supplied values are merged. It is `%{}` for a raw statement run through `Lotus.run_statement/3`.
+
+### The contract
+
+What a plug can rely on, release to release:
+
+- **Phase order is fixed.** `:before_query`, then sanitization, preflight and `:before_execute`, then execution, then `:after_query`. The order lives in one place, `Lotus.Runner.run/4`, whether or not the result cache is involved.
+- **Every query event fires on a cache hit.** See [Caching](#caching). `:before_execute` gets the relations stored with the entry; `:after_query` gets the stored result.
+- **Payload keys are additive.** A release may add a key to a payload; it does not remove or rename one. Match on the keys you use, not on the whole map.
+- **`:relations` follows one rule.** A list is proven, an empty list means "touches nothing", a tuple means "unknown". `:before_execute` and `:after_query` carry the same value.
+- **Halting is final.** A halt returns `{:error, reason}` to the caller and later events for that run do not fire.
+- **Observation is telemetry's job.** A plug sees only its own event. To record every run, including refusals and cache-served reads, attach to `[:lotus, :run, :start | :stop | :exception]` — see `Lotus.Telemetry`.
 
 ### The exact-count run
 
@@ -107,7 +118,7 @@ defmodule MyApp.TableAuthz do
   def init(opts), do: opts
 
   def call(%{relations: relations, context: %{user: user}} = payload, _opts)
-      when is_list(relations) and relations != [] do
+      when is_list(relations) do
     if Enum.all?(relations, &MyApp.Authz.may_read?(user, &1)) do
       {:cont, payload}
     else
@@ -115,20 +126,28 @@ defmodule MyApp.TableAuthz do
     end
   end
 
-  # `[]` and `{:unrestricted, reason}` both mean Lotus could not name the
-  # tables, not that the statement touches none. A plug that gates on the
-  # list must refuse rather than read either as an empty set.
+  # A tuple — `{:unrestricted, reason}` or `{:skipped, reason}` — means Lotus
+  # could not name the tables. A plug that gates on the list refuses rather
+  # than read it as an empty set.
   def call(_payload, _opts), do: {:halt, "cannot determine which tables this query reads"}
 end
 ```
 
 Halting returns `{:error, reason}` to the caller and the statement never runs.
 
-`:relations` is `[]` when the adapter's `needs_preflight?/2` returns false for
-the statement — no analysis ran. It is `{:unrestricted, reason}` when the
-adapter cannot name the relations a statement touches (Elasticsearch, for one)
-and the host opted in via `:allow_unrestricted_resources`. The two forms are
-distinct so a plug can log which case it hit.
+`:relations` is a list when preflight proved the set, and an empty list means
+the statement touches no relation (`SELECT 1` passes the plug above with
+`Enum.all?` over nothing). It is `{:unrestricted, reason}` when the adapter
+cannot name the relations a statement touches (Elasticsearch, for one) and the
+host opted in via `:allow_unrestricted_resources`, and `{:skipped, reason}`
+when the adapter does not preflight the statement at all — the SQL adapters
+skip `EXPLAIN`, `SHOW` and `PRAGMA`. The two tuples are distinct so a plug can
+log which case it hit, and both mean "unknown".
+
+`:after_query` carries the same `:relations`, so a plug that shapes a result
+by table — drop or mask columns of one relation, annotate another — does so
+without a second analysis. Both events also carry `:origin`, `:executed` or
+`:cached`.
 
 The two query hooks answer different questions, and both can be registered:
 
@@ -404,7 +423,9 @@ from the cache:
 - **`:before_execute` gets its relations either way.** The relations preflight
   named are stored with the result, so the event carries them on a hit as well
   as on a miss — a plug that authorizes a statement against its tables is an
-  access control, and one a warm cache skips would be no control at all.
+  access control, and one a warm cache skips would be no control at all. The
+  payload says which case it is: `origin: :cached` on a hit, `:executed` on a
+  miss.
 - **The stored entry keeps the raw result.** `:after_query` runs on the way out,
   so what a plug makes of the result is returned to that caller and never
   written back. A halt there withholds the result from that caller; the rows

--- a/lib/lotus.ex
+++ b/lib/lotus.ex
@@ -504,31 +504,26 @@ defmodule Lotus do
     # count are both built from the statement the plug returned. Everything that
     # keys the entry — the body, the bound values, the window — therefore
     # describes what will actually execute.
-    with {:ok, %Statement{} = statement} <- Runner.before_query(adapter, statement, runner_opts),
-         {statement, pagination_meta, cache_bound} =
-           maybe_paginate(statement, adapter, runner_opts, Keyword.get(opts, :window)),
-         {:ok, %Result{} = res} <-
-           exec_cached_statement(
-             adapter,
-             statement,
-             runner_opts,
-             [
-               mode: opts[:cache],
-               key:
-                 result_key(
-                   statement.body,
-                   bound_identity(cache_bound || cache_identity, statement.params),
-                   adapter.name,
-                   search_path,
-                   Keyword.get(opts, :scope)
-                 ),
-               tags: build_cache_tags(query_id, adapter.name, opts),
-               profile: determine_cache_profile(opts)
-             ],
-             pagination_meta
-           ) do
-      Runner.after_query(adapter, statement, res, runner_opts)
-    end
+    Runner.run(adapter, statement, runner_opts, fn %Statement{} = statement ->
+      {statement, pagination_meta, cache_bound} =
+        maybe_paginate(statement, adapter, runner_opts, Keyword.get(opts, :window))
+
+      cache = [
+        mode: opts[:cache],
+        key:
+          result_key(
+            statement.body,
+            bound_identity(cache_bound || cache_identity, statement.params),
+            adapter.name,
+            search_path,
+            Keyword.get(opts, :scope)
+          ),
+        tags: build_cache_tags(query_id, adapter.name, opts),
+        profile: determine_cache_profile(opts)
+      ]
+
+      exec_cached_statement(adapter, statement, runner_opts, cache, pagination_meta)
+    end)
   end
 
   # The bound values in the key come from the statement that will execute. A
@@ -539,33 +534,34 @@ defmodule Lotus do
 
   defp bound_identity(_identity, params), do: %{__params__: params}
 
-  # Only the execution is cached, and it is stored with the relations preflight
-  # found, so `:before_execute` can run on a hit as well. On a miss it runs
-  # inside the callback, where it still gates execution.
+  # The execute step of a cached run. Only the execution is cached, and it is
+  # stored with the relations preflight found, so the runner can fire
+  # `:before_execute` on a hit as well: the step reports `:cached`, and
+  # `Lotus.Runner.run/4` runs the gate with the stored relations. On a miss the
+  # gate runs inside the callback, where it still gates execution. Errors keep
+  # the phase the runner tagged them with, so the run span can report it.
   defp exec_cached_statement(adapter, statement, runner_opts, cache, pagination_meta) do
     fetch = fn ->
       with {:ok, %{result: res, relations: relations}} <-
-             Runner.execute_statement(adapter, statement, runner_opts) do
+             Runner.execute_phases(adapter, statement, runner_opts) do
         {:ok, %{result: merge_pagination_meta(res, pagination_meta), relations: relations}}
       end
     end
 
     case exec_with_cache_origin(cache, fetch) do
       {:ok, %{result: %Result{} = res, relations: relations}, :hit} ->
-        with :ok <- Runner.before_execute(adapter, statement, relations, runner_opts) do
-          {:ok, res}
-        end
+        {:ok, %{statement: statement, result: res, relations: relations, origin: :cached}}
 
-      {:ok, %{result: %Result{} = res}, _executed} ->
-        {:ok, res}
+      {:ok, %{result: %Result{} = res, relations: relations}, _executed} ->
+        {:ok, %{statement: statement, result: res, relations: relations, origin: :executed}}
 
       # An entry stored before results carried their relations. `:before_execute`
       # has nothing to gate on, so the entry is of no use: execute, and replace
       # it with one that carries them.
       {:ok, _stale, :hit} ->
-        with {:ok, %{result: %Result{} = res}} = fresh <- fetch.() do
-          put_cache_entry(cache, elem(fresh, 1))
-          {:ok, res}
+        with {:ok, %{result: %Result{} = res, relations: relations} = fresh} <- fetch.() do
+          put_cache_entry(cache, fresh)
+          {:ok, %{statement: statement, result: res, relations: relations, origin: :executed}}
         end
 
       {:error, _} = error ->

--- a/lib/lotus/middleware.ex
+++ b/lib/lotus/middleware.ex
@@ -20,8 +20,8 @@ defmodule Lotus.Middleware do
   | Event | Triggered | Payload keys |
   |-------|-----------|--------------|
   | `:before_query` | First, before sanitization, preflight and execution | `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
-  | `:before_execute` | After sanitization and preflight pass, before execution | `:statement` (`%Lotus.Query.Statement{}`), `:relations`, `:source`, `:context`, `:vars` |
-  | `:after_query` | After execution, before result returned to caller | `:result`, `:statement` (`%Lotus.Query.Statement{}`), `:source`, `:context`, `:vars` |
+  | `:before_execute` | After sanitization and preflight pass, before execution — or, on a cache hit, before the stored result is returned | `:statement` (`%Lotus.Query.Statement{}`), `:relations`, `:origin`, `:source`, `:context`, `:vars` |
+  | `:after_query` | After execution, before result returned to caller | `:result`, `:statement` (`%Lotus.Query.Statement{}`), `:relations`, `:origin`, `:source`, `:context`, `:vars` |
   | `:after_list_schemas` | After schema discovery and visibility filtering | `:schemas`, `:source`, `:scope`, `:context` |
   | `:after_list_tables` | After table discovery and visibility filtering | `:tables`, `:source`, `:scope`, `:context` |
   | `:after_describe_table` | After table schema introspection and column visibility | `:columns`, `:table_name`, `:schema`, `:source`, `:scope`, `:context` |
@@ -45,18 +45,28 @@ defmodule Lotus.Middleware do
 
   #### The `:relations` payload
 
-  `:relations` is a list of `{schema, table}` tuples, where `schema` is `nil`
-  for a source that has no schemas. Two values mean "Lotus cannot name the
-  tables", not "the statement touches none":
+  `:relations` is what preflight knows about the statement. `:before_execute`
+  and `:after_query` carry the same value.
 
-    * `[]` — the adapter's `needs_preflight?/2` returned false for this
-      statement, so no analysis ran.
+    * A list of `{schema, table}` tuples, where `schema` is `nil` for a
+      source that has no schemas, is the set preflight proved the statement
+      touches. An empty list means it touches no relation — `SELECT 1`.
     * `{:unrestricted, reason}` — the adapter cannot name the relations a
       statement touches (Elasticsearch, for one), and the host opted in via
       `:allow_unrestricted_resources`.
+    * `{:skipped, reason}` — the adapter does not preflight this statement
+      (the SQL adapters skip `EXPLAIN`, `SHOW` and `PRAGMA`), so nothing was
+      analysed.
 
-  A plug that authorizes on the table list must treat both as unknown and
-  halt, rather than read them as an empty set of tables.
+  The two tuples mean "unknown". A plug that authorizes on the table list
+  matches `when is_list(relations)` and halts on anything else, rather than
+  read a tuple as an empty set of tables.
+
+  #### The `:origin` payload
+
+  `:origin` is `:executed` when the result came from the source on this call
+  and `:cached` when it was served from the result cache. Both events carry
+  it, so a plug that meters usage or cost can tell a read from an execution.
 
   #### Derived statements
 
@@ -96,6 +106,17 @@ defmodule Lotus.Middleware do
   `:scope`, which is part of the cache key — so a visibility resolver must
   decide from `(source, relations, column, scope)` alone. Per-actor logic that
   cannot be expressed that way belongs in middleware.
+
+  ### Observing a run
+
+  Middleware decides; it does not observe. A halt in `:before_query` or
+  `:before_execute` means `:after_query` never fires, so a plug there cannot
+  see a refusal, and a plug sees only the calls its own event covers. The
+  `[:lotus, :run, :start | :stop | :exception]` telemetry events bracket the
+  whole run instead — every phase, on a cache hit and on a halt alike — and
+  carry the caller's `:context`, the relations, the origin and, on failure,
+  the phase that failed. An audit or usage consumer attaches to those. See
+  `Lotus.Telemetry`.
 
   ### Discovery event ordering
 

--- a/lib/lotus/preflight.ex
+++ b/lib/lotus/preflight.ex
@@ -38,6 +38,21 @@ defmodule Lotus.Preflight do
   @spec authorize(Adapter.t(), Statement.t(), String.t() | nil, term()) ::
           :ok | {:error, String.t()}
   def authorize(%Adapter{} = adapter, %Statement{} = statement, search_path \\ nil, scope \\ nil) do
+    with {:ok, _relations} <- analyze(adapter, statement, search_path, scope), do: :ok
+  end
+
+  @doc """
+  Authorizes a statement and returns what preflight learned about it.
+
+  The same check as `authorize/4`, returning the outcome as a value: the list
+  of `{schema, table}` relations the statement touches — empty when it touches
+  none — or `{:unrestricted, reason}` when the adapter cannot name them and the
+  host opted in. `Lotus.Runner` carries this value down the pipeline and into
+  the `:before_execute` and `:after_query` payloads.
+  """
+  @spec analyze(Adapter.t(), Statement.t(), String.t() | nil, term()) ::
+          {:ok, Relations.outcome()} | {:error, String.t()}
+  def analyze(%Adapter{} = adapter, %Statement{} = statement, search_path \\ nil, scope \\ nil) do
     statement =
       if search_path,
         do: %{statement | meta: Map.put(statement.meta, :search_path, search_path)},
@@ -58,8 +73,7 @@ defmodule Lotus.Preflight do
 
   defp handle_unrestricted(%Adapter{name: name}, reason) do
     if Config.allow_unrestricted_resources?(name) do
-      Relations.put({:unrestricted, reason})
-      :ok
+      {:ok, {:unrestricted, reason}}
     else
       {:error,
        "Preflight blocked: source #{inspect(name)} cannot enforce visibility at the " <>
@@ -74,8 +88,7 @@ defmodule Lotus.Preflight do
       Enum.split_with(rels, &Visibility.allowed_relation?(source_name, &1, scope))
 
     if blocked == [] do
-      Relations.put(allowed)
-      :ok
+      {:ok, allowed}
     else
       {:error, "Query touches blocked table(s): #{format_relations(blocked)}"}
     end

--- a/lib/lotus/preflight/relations.ex
+++ b/lib/lotus/preflight/relations.ex
@@ -1,32 +1,39 @@
 defmodule Lotus.Preflight.Relations do
   @moduledoc """
-  Manages the preflight outcome stored in the process dictionary.
+  The preflight outcome: what Lotus knows about the relations a statement
+  touches.
 
-  This module provides a clean interface for storing and retrieving
-  the relations discovered during SQL preflight authorization, which are
-  later used for column-level visibility policies and handed to
-  `:before_execute` middleware.
+  The outcome is one of:
 
-  The stored value is either a list of `{schema, table}` relations or
-  `{:unrestricted, reason}` for an adapter that cannot name the relations a
-  statement touches. The second form lets a caller tell "this statement
-  touches no table" apart from "this adapter cannot say".
+    * a list of `{schema, table}` relations preflight proved the statement
+      touches — an empty list means it touches none;
+    * `{:unrestricted, reason}` for an adapter that cannot name the relations
+      a statement touches, when the host opted in;
+    * `{:skipped, reason}` for a statement the adapter does not preflight.
+
+  The two tuples both mean "unknown". A consumer that gates on the list
+  matches `when is_list/1` and refuses any tuple rather than reading it as an
+  empty set.
+
+  `Lotus.Preflight.analyze/4` returns the outcome as a value, and
+  `Lotus.Runner` carries it down the pipeline explicitly. The process
+  dictionary functions below are kept for callers that still store an outcome
+  themselves; the runner neither writes nor reads them.
   """
 
   @process_key :lotus_preflight_relations
 
   @type relation :: {String.t() | nil, String.t()}
-  @type outcome :: [relation()] | {:unrestricted, String.t()}
+  @type outcome :: [relation()] | {:unrestricted, String.t()} | {:skipped, String.t()}
 
   @doc """
-  Stores the preflight outcome in the process dictionary.
-
-  Accepts the list of relations discovered during preflight authorization,
-  or `{:unrestricted, reason}` when the adapter cannot name them.
+  Stores a preflight outcome in the process dictionary.
   """
   @spec put(outcome()) :: :ok
   def put(relations) when is_list(relations), do: store(relations)
-  def put({:unrestricted, reason} = outcome) when is_binary(reason), do: store(outcome)
+
+  def put({tag, reason} = outcome) when tag in [:unrestricted, :skipped] and is_binary(reason),
+    do: store(outcome)
 
   defp store(outcome) do
     Process.put(@process_key, outcome)
@@ -34,9 +41,7 @@ defmodule Lotus.Preflight.Relations do
   end
 
   @doc """
-  Retrieves the preflight outcome from the process dictionary.
-
-  Returns an empty list if no outcome has been stored.
+  Retrieves the stored preflight outcome, or an empty list.
   """
   @spec get() :: outcome()
   def get do
@@ -44,10 +49,7 @@ defmodule Lotus.Preflight.Relations do
   end
 
   @doc """
-  Retrieves and clears the preflight outcome from the process dictionary.
-
-  This is typically called after the outcome has been consumed
-  to ensure it doesn't leak to subsequent operations.
+  Retrieves and clears the stored preflight outcome.
   """
   @spec take() :: outcome()
   def take do
@@ -59,16 +61,16 @@ defmodule Lotus.Preflight.Relations do
   @doc """
   Narrows a preflight outcome to the list of relations it names.
 
-  An `{:unrestricted, reason}` outcome names none, so it narrows to `[]`.
-  Column visibility policies use this: a relation Lotus cannot name is a
-  relation it cannot write a policy for.
+  An unknown outcome names none, so it narrows to `[]`. Column visibility
+  policies use this: a relation Lotus cannot name is a relation it cannot
+  write a policy for.
   """
   @spec to_list(outcome()) :: [relation()]
   def to_list(relations) when is_list(relations), do: relations
-  def to_list({:unrestricted, _reason}), do: []
+  def to_list({tag, _reason}) when tag in [:unrestricted, :skipped], do: []
 
   @doc """
-  Clears the stored outcome from the process dictionary.
+  Clears the stored preflight outcome.
   """
   @spec clear() :: :ok
   def clear do

--- a/lib/lotus/runner.ex
+++ b/lib/lotus/runner.ex
@@ -29,32 +29,206 @@ defmodule Lotus.Runner do
         ]
 
   @typedoc """
+  What preflight knows about the relations a statement touches.
+
+  A list is a proven set of `{schema, table}` pairs, and an empty list means
+  the statement touches no relation (`SELECT 1`). A tuple means nothing is
+  known: `{:unrestricted, reason}` when the adapter cannot name relations and
+  the host opted in, `{:skipped, reason}` when the adapter does not preflight
+  the statement at all. A plug that gates on tables matches `when is_list/1`
+  and treats any tuple as unknown.
+  """
+  @type relations :: Relations.outcome()
+
+  @typedoc """
+  Where a result came from: executed against the source, or served from the
+  result cache.
+  """
+  @type origin :: :executed | :cached
+
+  @typedoc """
   What executing a statement produced: the result, and the relations preflight
   proved the statement touches.
 
   This is the unit the result cache stores, so that a caller serving a result
   from the cache can still hand the relations to `:before_execute`.
   """
-  @type execution :: %{result: query_result(), relations: term()}
+  @type execution :: %{result: query_result(), relations: relations()}
+
+  @typedoc """
+  What a run produced, as `:after_query` sees it: the statement that ran, its
+  result, the relations, and where the result came from.
+  """
+  @type outcome :: %{
+          statement: Statement.t(),
+          result: query_result(),
+          relations: relations(),
+          origin: origin()
+        }
+
+  @typedoc """
+  The execute step of a run: takes the statement `:before_query` returned and
+  produces the outcome. `run/4` supplies one that executes against the source;
+  a caller that caches executions supplies one that consults the cache first.
+  """
+  @type executor :: (Statement.t() -> {:ok, outcome()} | {:error, term()})
+
+  @phases [:before_query, :sanitize, :preflight, :before_execute, :execute, :after_query]
 
   @doc """
   Runs a statement through the full pipeline: `:before_query`, sanitization,
   preflight, `:before_execute`, execution, column policy enforcement and
-  `:after_query`.
-
-  A caller that wraps execution in the result cache composes the phases itself
-  — `before_query/3`, `execute_statement/3` or a cached result plus
-  `before_execute/4`, then `after_query/4` — so that the middleware runs on a
-  cache hit as well.
+  `:after_query`. See `run/4`.
   """
   @spec run_statement(Adapter.t(), Statement.t(), opts()) ::
           {:ok, query_result()} | {:error, term()}
   def run_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
-    with {:ok, %Statement{} = statement} <- before_query(adapter, statement, opts),
-         {:ok, %{result: %Result{} = res}} <- execute_statement(adapter, statement, opts) do
-      after_query(adapter, statement, res, opts)
+    run(adapter, statement, opts, nil)
+  end
+
+  @doc """
+  Runs the phases of a statement run around an execute step.
+
+  This is the one place the phase order lives. `run_statement/3` uses it with
+  the default step, which executes against the source; `Lotus` uses it with a
+  step that consults the result cache. Both get the same phases, the same
+  payloads and the same telemetry:
+
+  1. `:before_query`, which may rewrite the statement.
+  2. The execute step, with the statement `:before_query` returned. The default
+     step is `execute_statement/3`, which runs sanitization, preflight and
+     `:before_execute` itself.
+  3. `:before_execute`, when the step served a cached result — the relations
+     stored with the entry stand in for preflight, so the gate fires on a hit
+     as it does on a miss.
+  4. `:after_query`.
+
+  `[:lotus, :run, *]` telemetry brackets all of it: `:start` before the first
+  phase, `:stop` after `:after_query` with the origin and the relations, and
+  `:exception` when any phase fails, with the `:phase` that failed. It fires on
+  a cache hit and on a halt alike, so a consumer that records who ran what and
+  whether it was refused attaches to these three events and nothing else.
+
+  A step may return `{:error, {Lotus.Runner, phase, reason}}` to name the phase
+  that failed; the caller receives `{:error, reason}`.
+  """
+  @spec run(Adapter.t(), Statement.t(), opts(), executor() | nil) ::
+          {:ok, query_result()} | {:error, term()}
+  def run(%Adapter{} = adapter, %Statement{} = statement, opts, executor \\ nil) do
+    executor = executor || default_executor(adapter, opts)
+
+    meta = %{
+      source: adapter.name,
+      statement: statement,
+      context: Keyword.get(opts, :context),
+      vars: vars(opts)
+    }
+
+    start_time = Telemetry.run_start(meta)
+
+    try do
+      case tag(:before_query, before_query(adapter, statement, opts)) do
+        {:ok, %Statement{} = statement} ->
+          case executor.(statement) do
+            {:ok, %{statement: %Statement{}, result: %Result{}} = outcome} ->
+              with :ok <- gate_cached(adapter, outcome, opts),
+                   {:ok, %Result{} = res} <-
+                     tag(:after_query, after_query(adapter, outcome, opts)) do
+                {:ok, res}
+              end
+              |> finish(start_time, meta, outcome)
+
+            {:error, _} = error ->
+              finish(error, start_time, meta, nil)
+          end
+
+        {:error, _} = error ->
+          finish(error, start_time, meta, nil)
+      end
+    rescue
+      e ->
+        # Plugs that raise become halts inside `Middleware.run/2`, and the
+        # execute step rescues adapter errors, so a raise here is exceptional.
+        # The span still closes, so a consumer never sees a start without an
+        # end, and the raise reaches the caller as it would have.
+        Telemetry.run_exception(
+          start_time,
+          Map.merge(meta, %{phase: :unknown, reason: e, kind: :error, stacktrace: __STACKTRACE__})
+        )
+
+        reraise e, __STACKTRACE__
     end
   end
+
+  defp default_executor(%Adapter{} = adapter, opts) do
+    fn %Statement{} = statement ->
+      with {:ok, execution} <- execute_phases(adapter, statement, opts) do
+        {:ok, Map.merge(execution, %{statement: statement, origin: :executed})}
+      end
+    end
+  end
+
+  # A step that served a cached result skipped preflight and, with it, the
+  # gate. The relations stored with the entry make the gate possible here.
+  defp gate_cached(%Adapter{} = adapter, %{origin: :cached} = outcome, opts) do
+    tag(
+      :before_execute,
+      before_execute(adapter, outcome.statement, outcome.relations, :cached, opts)
+    )
+  end
+
+  defp gate_cached(_adapter, _outcome, _opts), do: :ok
+
+  defp finish({:ok, %Result{} = res}, start_time, meta, outcome) do
+    Telemetry.run_stop(
+      start_time,
+      Map.merge(meta, %{
+        statement: outcome.statement,
+        result: res,
+        row_count: res.num_rows,
+        relations: outcome.relations,
+        origin: outcome.origin
+      })
+    )
+
+    {:ok, res}
+  end
+
+  defp finish({:error, {__MODULE__, phase, reason}}, start_time, meta, outcome) do
+    Telemetry.run_exception(start_time, exception_meta(meta, phase, reason, outcome))
+    {:error, reason}
+  end
+
+  defp finish({:error, reason}, start_time, meta, outcome) do
+    Telemetry.run_exception(start_time, exception_meta(meta, :execute, reason, outcome))
+    {:error, reason}
+  end
+
+  defp exception_meta(meta, phase, reason, nil),
+    do: Map.merge(meta, %{phase: phase, reason: reason})
+
+  defp exception_meta(meta, phase, reason, outcome) do
+    Map.merge(meta, %{
+      phase: phase,
+      reason: reason,
+      statement: outcome.statement,
+      relations: outcome.relations,
+      origin: outcome.origin
+    })
+  end
+
+  # Names the phase an error came from, so the run span can report it. The
+  # wrapper is unwrapped before anything reaches the caller.
+  defp tag(phase, {:error, {__MODULE__, _phase, _reason}} = tagged) when phase in @phases,
+    do: tagged
+
+  defp tag(phase, {:error, reason}) when phase in @phases,
+    do: {:error, {__MODULE__, phase, reason}}
+
+  defp tag(_phase, other), do: other
+
+  defp untag({:error, {__MODULE__, phase, reason}}) when phase in @phases, do: {:error, reason}
+  defp untag(other), do: other
 
   @doc """
   Runs the `:before_query` pipeline and returns the statement to execute.
@@ -72,13 +246,6 @@ defmodule Lotus.Runner do
   @spec before_query(Adapter.t(), Statement.t(), opts()) ::
           {:ok, Statement.t()} | {:error, term()}
   def before_query(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
-    # The first phase of a run clears the relations, so a plug cannot read a
-    # value another statement left in the process dictionary. `Preflight.
-    # authorize/4` is public, and `execute_statement/3` clears on entry and on
-    # every exit — but on a cache hit it never runs at all, and it is the phases
-    # around it that would then carry a stale value forward.
-    Relations.clear()
-
     payload = %{
       source: adapter.name,
       statement: statement,
@@ -97,20 +264,23 @@ defmodule Lotus.Runner do
   end
 
   @doc """
-  Runs the `:after_query` pipeline on a result and returns what it yields.
+  Runs the `:after_query` pipeline on an outcome and returns the result it
+  yields.
 
-  A caller that caches the execution runs this phase on the returned result,
-  whether that result came from the cache or from the source. A plug that
-  changes the result changes what this call returns; the stored entry keeps the
-  raw execution.
+  The payload carries the statement that ran, the result, the relations
+  preflight found for it — the same value `:before_execute` received — and the
+  origin, `:executed` or `:cached`. It runs whether the result came from the
+  cache or from the source. A plug that changes the result changes what this
+  call returns; the stored entry keeps the raw execution.
   """
-  @spec after_query(Adapter.t(), Statement.t(), query_result(), opts()) ::
-          {:ok, query_result()} | {:error, term()}
-  def after_query(%Adapter{} = adapter, %Statement{} = statement, %Result{} = result, opts \\ []) do
+  @spec after_query(Adapter.t(), outcome(), opts()) :: {:ok, query_result()} | {:error, term()}
+  def after_query(%Adapter{} = adapter, %{result: %Result{} = result} = outcome, opts \\ []) do
     payload = %{
       source: adapter.name,
-      statement: statement,
+      statement: outcome.statement,
       result: result,
+      relations: outcome.relations,
+      origin: outcome.origin,
       context: Keyword.get(opts, :context),
       vars: vars(opts)
     }
@@ -130,17 +300,26 @@ defmodule Lotus.Runner do
   touches.
 
   `execute_statement/3` runs this itself, with the relations preflight just
-  found. A caller that serves a result from the cache runs it with the
-  relations stored alongside that result, so the gate fires on every call: a
-  plug that authorizes a statement against its tables is an access control,
-  and an access control that a warm cache skips is no control at all.
+  found and origin `:executed`. `run/4` runs it with the relations stored
+  alongside a cached result and origin `:cached`, so the gate fires on every
+  call: a plug that authorizes a statement against its tables is an access
+  control, and an access control that a warm cache skips is no control at all.
   """
-  @spec before_execute(Adapter.t(), Statement.t(), term(), opts()) :: :ok | {:error, term()}
-  def before_execute(%Adapter{} = adapter, %Statement{} = statement, relations, opts \\ []) do
+  @spec before_execute(Adapter.t(), Statement.t(), relations(), origin(), opts()) ::
+          :ok | {:error, term()}
+  def before_execute(
+        %Adapter{} = adapter,
+        %Statement{} = statement,
+        relations,
+        origin,
+        opts \\ []
+      )
+      when origin in [:executed, :cached] do
     payload = %{
       source: adapter.name,
       statement: statement,
       relations: relations,
+      origin: origin,
       context: Keyword.get(opts, :context),
       vars: vars(opts)
     }
@@ -164,6 +343,18 @@ defmodule Lotus.Runner do
   @spec execute_statement(Adapter.t(), Statement.t(), opts()) ::
           {:ok, execution()} | {:error, term()}
   def execute_statement(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
+    adapter
+    |> execute_phases(statement, opts)
+    |> untag()
+  end
+
+  @doc false
+  # `execute_statement/3` with the failing phase named in the error, for
+  # `run/4` and for an execute step that wraps this in the result cache. The
+  # phase travels as `{:error, {Lotus.Runner, phase, reason}}`.
+  @spec execute_phases(Adapter.t(), Statement.t(), opts()) ::
+          {:ok, execution()} | {:error, {module(), atom(), term()}}
+  def execute_phases(%Adapter{} = adapter, %Statement{} = statement, opts \\ []) do
     telemetry_meta = %{
       source: adapter.name,
       statement: statement,
@@ -172,25 +363,17 @@ defmodule Lotus.Runner do
 
     start_time = Telemetry.query_start(telemetry_meta)
 
-    # Preflight records its relations in the process dictionary, and
-    # `preflight_visibility/3` reads them out once and carries them down the
-    # pipeline explicitly. Clearing on both sides keeps them from crossing a
-    # statement boundary: on entry, because `Preflight.authorize/4` is public
-    # and a caller may have left its own behind, and in `after` on every exit,
-    # raises included, so a statement that fails cannot hand its tables to the
-    # next one in the same process.
+    # Preflight hands its relations back as a value, and they travel down the
+    # pipeline explicitly. Nothing crosses a statement boundary through the
+    # process dictionary.
     result =
-      try do
-        Relations.clear()
-
-        with :ok <- Adapter.sanitize_query(adapter, statement, sanitize_opts(opts)),
-             {:ok, relations} <- preflight_visibility(adapter, statement, opts),
-             :ok <- before_execute(adapter, statement, relations, opts),
-             {:ok, %Result{} = res} <- exec_read_only(adapter, statement, relations, opts) do
-          {:ok, %{result: res, relations: relations}}
-        end
-      after
-        Relations.clear()
+      with :ok <- tag(:sanitize, Adapter.sanitize_query(adapter, statement, sanitize_opts(opts))),
+           {:ok, relations} <- tag(:preflight, preflight_visibility(adapter, statement, opts)),
+           :ok <-
+             tag(:before_execute, before_execute(adapter, statement, relations, :executed, opts)),
+           {:ok, %Result{} = res} <-
+             tag(:execute, exec_read_only(adapter, statement, relations, opts)) do
+        {:ok, %{result: res, relations: relations}}
       end
 
     case result do
@@ -203,7 +386,7 @@ defmodule Lotus.Runner do
         result
 
       {:error, _} = error ->
-        Telemetry.query_exception(start_time, :error, error, [], telemetry_meta)
+        Telemetry.query_exception(start_time, :error, untag(error), [], telemetry_meta)
         error
     end
   end
@@ -397,21 +580,19 @@ defmodule Lotus.Runner do
     Keyword.take(opts, [:read_only])
   end
 
-  # Returns what preflight proved the statement touches: a list of
-  # `{schema, table}`, or `{:unrestricted, reason}` for an adapter that cannot
-  # name them. An adapter that needs no preflight yields `[]` — nothing was
-  # analysed, so nothing is known.
+  # Returns what preflight knows about the statement: a list of
+  # `{schema, table}`, `{:unrestricted, reason}` for an adapter that cannot
+  # name them, or `{:skipped, reason}` for a statement the adapter does not
+  # preflight — nothing was analysed, so nothing is known, and that is not the
+  # same as an empty list.
   defp preflight_visibility(%Adapter{} = adapter, %Statement{} = statement, opts) do
     if Adapter.needs_preflight?(adapter, statement) do
       search_path = Keyword.get(opts, :search_path)
       scope = Keyword.get(opts, :scope)
 
-      case Preflight.authorize(adapter, statement, search_path, scope) do
-        :ok -> {:ok, Relations.get()}
-        {:error, msg} -> {:error, msg}
-      end
+      Preflight.analyze(adapter, statement, search_path, scope)
     else
-      {:ok, []}
+      {:ok, {:skipped, "the adapter does not preflight this statement"}}
     end
   rescue
     e -> {:error, Exception.message(e)}

--- a/lib/lotus/telemetry.ex
+++ b/lib/lotus/telemetry.ex
@@ -6,6 +6,61 @@ defmodule Lotus.Telemetry do
   and schema introspection. You can attach handlers to these events for monitoring,
   logging, or integration with tools like Phoenix LiveDashboard or AppSignal.
 
+  ## Run Events
+
+  A run is one call to `Lotus.run_query/2`, `Lotus.run_statement/3` or
+  `Lotus.Runner.run_statement/3`: `:before_query`, the execute step (or the
+  result cache), `:before_execute`, `:after_query`. The run events bracket all
+  of it, on every path — a result served from the cache, a statement a plug
+  halted in any phase — and always carry the caller's `:context`. A consumer
+  that records who ran what, whether it was served from the cache and whether
+  it was refused attaches to these three events.
+
+  The query events below cover only the execute step: a result served from
+  the cache emits no query event, and neither does a run a plug halted before
+  execution.
+
+  ### `[:lotus, :run, :start]`
+
+  **Measurements:** `:system_time`.
+
+  **Metadata:**
+
+    * `:source` - The data source name
+    * `:statement` - The `Lotus.Query.Statement` the caller supplied, before
+      any `:before_query` rewrite
+    * `:context` - The caller-supplied context (or `nil`)
+    * `:vars` - The bound query variables, by name
+
+  ### `[:lotus, :run, :stop]`
+
+  Emitted when a run completes and its result is returned to the caller.
+
+  **Measurements:** `:duration` (native units), `:row_count`.
+
+  **Metadata:** the start metadata, with `:statement` now the statement that
+  ran, plus:
+
+    * `:result` - The `Lotus.Result` returned to the caller
+    * `:relations` - What preflight knew about the statement: a list of
+      `{schema, table}`, `{:unrestricted, reason}` or `{:skipped, reason}`
+    * `:origin` - `:executed` or `:cached`
+
+  ### `[:lotus, :run, :exception]`
+
+  Emitted when any phase of a run fails, including a middleware halt.
+
+  **Measurements:** `:duration`.
+
+  **Metadata:** the start metadata plus:
+
+    * `:phase` - `:before_query`, `:sanitize`, `:preflight`,
+      `:before_execute`, `:execute` or `:after_query`
+    * `:reason` - The error or halt reason the caller receives
+    * `:kind` - `:error`
+    * `:statement`, `:relations`, `:origin` - Present when the failure came
+      after the execute step, describing what ran
+
   ## Query Events
 
   ### `[:lotus, :query, :start]`
@@ -166,6 +221,10 @@ defmodule Lotus.Telemetry do
       end
   """
 
+  @run_start [:lotus, :run, :start]
+  @run_stop [:lotus, :run, :stop]
+  @run_exception [:lotus, :run, :exception]
+
   @query_start [:lotus, :query, :start]
   @query_stop [:lotus, :query, :stop]
   @query_exception [:lotus, :query, :exception]
@@ -180,6 +239,9 @@ defmodule Lotus.Telemetry do
   @doc false
   def events do
     [
+      @run_start,
+      @run_stop,
+      @run_exception,
       @query_start,
       @query_stop,
       @query_exception,
@@ -189,6 +251,35 @@ defmodule Lotus.Telemetry do
       @schema_start,
       @schema_stop
     ]
+  end
+
+  @doc false
+  def run_start(metadata) do
+    start_time = System.monotonic_time()
+    :telemetry.execute(@run_start, %{system_time: System.system_time()}, metadata)
+    start_time
+  end
+
+  @doc false
+  def run_stop(start_time, metadata) do
+    duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(
+      @run_stop,
+      %{duration: duration, row_count: metadata[:row_count] || 0},
+      metadata
+    )
+  end
+
+  @doc false
+  def run_exception(start_time, metadata) do
+    duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(
+      @run_exception,
+      %{duration: duration},
+      Map.put_new(metadata, :kind, :error)
+    )
   end
 
   @doc false

--- a/test/lotus/middleware_cache_hit_test.exs
+++ b/test/lotus/middleware_cache_hit_test.exs
@@ -60,16 +60,6 @@ defmodule Lotus.MiddlewareCacheHitTest do
     def call(_payload, _opts), do: {:halt, "withheld"}
   end
 
-  defmodule ReadRelationsPlug do
-    @moduledoc false
-    def init(opts), do: opts
-
-    def call(payload, _opts) do
-      send(self(), {:relations_at_before_query, Relations.get()})
-      {:cont, payload}
-    end
-  end
-
   defmodule DenyRelationPlug do
     @moduledoc false
     def init(opts), do: opts
@@ -349,22 +339,29 @@ defmodule Lotus.MiddlewareCacheHitTest do
   end
 
   describe "preflight relations across a cached call" do
-    test "a call served from the cache leaves no relations behind" do
+    # The process dictionary is not a source of relations for any phase: a
+    # value another statement left there never reaches a payload, on a hit or
+    # on a miss.
+    test "a call served from the cache carries the stored relations, not stranded ones" do
+      Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
+
       assert {:ok, _} = run(nil)
+      assert_received {:before_execute, %{origin: :executed}}
 
       Relations.put([{"public", "decoy"}])
 
       assert {:ok, _} = run(nil)
-      assert Relations.get() == []
+      assert_received {:before_execute, %{origin: :cached, relations: [{"public", "test_users"}]}}
     end
 
-    test "a :before_query plug never sees relations another statement left behind" do
-      Middleware.compile(%{before_query: [{ReadRelationsPlug, []}]})
+    test "a :before_query payload carries no relations at all" do
+      Middleware.compile(%{before_query: [{CapturePlug, [event: :before_query]}]})
 
       Relations.put([{"public", "test_users"}])
 
       assert {:ok, _} = run(nil)
-      assert_received {:relations_at_before_query, []}
+      assert_received {:before_query, payload}
+      refute Map.has_key?(payload, :relations)
     end
 
     # `CAST(email AS integer)` plans fine and fails only once a row is

--- a/test/lotus/middleware_contract_test.exs
+++ b/test/lotus/middleware_contract_test.exs
@@ -1,0 +1,284 @@
+defmodule Lotus.MiddlewareContractTest do
+  @moduledoc """
+  The query middleware contract, as a whole:
+
+    * `:relations` is a list when preflight proved the set — `[]` means the
+      statement touches no relation — and a tagged tuple when nothing is
+      known: `{:unrestricted, reason}` or `{:skipped, reason}`.
+    * `:after_query` carries the same `:relations` as `:before_execute`, and
+      both carry `:origin`, `:executed` or `:cached`.
+    * `[:lotus, :run, *]` telemetry brackets the whole run on every path —
+      a cache hit, a halt in any phase — with the caller's context.
+    * Preflight hands its relations back as a value. Nothing crosses phases
+      through the process dictionary.
+  """
+
+  use Lotus.Case, async: false
+  use Mimic
+
+  alias Lotus.Cache.ETS
+  alias Lotus.{Config, Middleware, Preflight, Runner}
+  alias Lotus.Query.Statement
+  alias Lotus.Source.Adapters.Ecto, as: EctoAdapter
+  alias Lotus.Test.Schemas.User
+
+  defmodule CapturePlug do
+    @moduledoc false
+    def init(opts), do: opts
+
+    def call(payload, event: event) do
+      send(self(), {event, payload})
+      {:cont, payload}
+    end
+  end
+
+  defmodule DenyUserPlug do
+    @moduledoc false
+    def init(opts), do: opts
+    def call(%{context: %{user: "b"}}, _opts), do: {:halt, "denied"}
+    def call(payload, _opts), do: {:cont, payload}
+  end
+
+  defmodule DenyingResolver do
+    @moduledoc false
+    @behaviour Lotus.Visibility.Resolver
+
+    @impl true
+    def schema_rules_for(_source, _scope), do: []
+
+    @impl true
+    def table_rules_for(_source, _scope), do: [deny: [{"public", "test_users"}]]
+
+    @impl true
+    def column_rules_for(_source, _scope), do: []
+  end
+
+  @statement "SELECT id FROM test_users ORDER BY id"
+  @pg_adapter EctoAdapter.wrap("postgres", Lotus.Test.Repo)
+  @run_events [[:lotus, :run, :start], [:lotus, :run, :stop], [:lotus, :run, :exception]]
+
+  setup :set_mimic_from_context
+
+  setup do
+    Mimic.copy(Config)
+
+    clear_cache_tables()
+
+    on_exit(fn ->
+      :persistent_term.erase({Lotus.Middleware, :compiled})
+      clear_cache_tables()
+    end)
+
+    Config
+    |> stub(:cache_adapter, fn -> {:ok, ETS} end)
+    |> stub(:cache_namespace, fn -> "middleware_contract_test" end)
+    |> stub(:default_cache_profile, fn -> :results end)
+    |> stub(:cache_profile_settings, fn _profile -> [ttl_ms: 30_000] end)
+
+    Repo.insert!(%User{id: 1, name: "Ada", email: "ada@example.test", age: 36})
+    Repo.insert!(%User{id: 2, name: "Grace", email: "grace@example.test", age: 85})
+
+    :ok
+  end
+
+  defp clear_cache_tables do
+    for table <- [:lotus_cache, :lotus_cache_tags] do
+      if :ets.whereis(table) != :undefined, do: :ets.delete_all_objects(table)
+    end
+
+    :ok
+  end
+
+  defp run(statement \\ @statement, opts) do
+    Lotus.run_statement(statement, [], Keyword.merge([repo: "postgres"], opts))
+  end
+
+  defp attach_run_events do
+    ref = make_ref()
+    pid = self()
+
+    for event <- @run_events do
+      id = {ref, event}
+
+      :telemetry.attach(
+        id,
+        event,
+        fn ev, measurements, metadata, _config ->
+          send(pid, {:run_event, ev, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(id) end)
+    end
+
+    :ok
+  end
+
+  defp drain(acc \\ []) do
+    receive do
+      message -> drain([message | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  describe ":relations" do
+    test "an empty list means the statement touches no relation" do
+      Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
+
+      assert {:ok, _} = run("SELECT 1", [])
+
+      assert_received {:before_execute, %{relations: []}}
+    end
+
+    test "a statement the adapter does not preflight yields {:skipped, reason}" do
+      Middleware.compile(%{before_execute: [{CapturePlug, [event: :before_execute]}]})
+
+      assert {:ok, _} = run("EXPLAIN SELECT 1", [])
+
+      assert_received {:before_execute, %{relations: {:skipped, reason}}}
+      assert is_binary(reason)
+    end
+  end
+
+  describe ":after_query" do
+    test "carries the relations :before_execute saw, and origin :executed on a miss" do
+      Middleware.compile(%{
+        before_execute: [{CapturePlug, [event: :before_execute]}],
+        after_query: [{CapturePlug, [event: :after_query]}]
+      })
+
+      assert {:ok, _} = run(context: %{user: "a"})
+
+      assert_received {:before_execute, %{relations: relations, origin: :executed}}
+      assert relations == [{"public", "test_users"}]
+      assert_received {:after_query, %{relations: ^relations, origin: :executed}}
+    end
+
+    test "on a cache hit both events carry the stored relations and origin :cached" do
+      Middleware.compile(%{
+        before_execute: [{CapturePlug, [event: :before_execute]}],
+        after_query: [{CapturePlug, [event: :after_query]}]
+      })
+
+      assert {:ok, _} = run(context: %{user: "a"})
+      drain()
+
+      assert {:ok, _} = run(context: %{user: "a"})
+
+      assert_received {:before_execute, %{relations: [{"public", "test_users"}], origin: :cached}}
+      assert_received {:after_query, %{relations: [{"public", "test_users"}], origin: :cached}}
+    end
+
+    test "the uncached runner path carries the same keys" do
+      Middleware.compile(%{after_query: [{CapturePlug, [event: :after_query]}]})
+
+      assert {:ok, _} =
+               Runner.run_statement(@pg_adapter, Statement.new(@statement, []),
+                 context: %{user: "a"}
+               )
+
+      assert_received {:after_query,
+                       %{
+                         relations: [{"public", "test_users"}],
+                         origin: :executed,
+                         context: %{user: "a"}
+                       }}
+    end
+  end
+
+  describe "[:lotus, :run, *] telemetry" do
+    setup do
+      attach_run_events()
+    end
+
+    test "brackets the run from :before_query to :after_query" do
+      Middleware.compile(%{
+        before_query: [{CapturePlug, [event: :before_query]}],
+        after_query: [{CapturePlug, [event: :after_query]}]
+      })
+
+      assert {:ok, _} = run(context: %{user: "a"})
+
+      order =
+        drain()
+        |> Enum.map(fn
+          {:run_event, [:lotus, :run, phase], _, _} -> {:run, phase}
+          {event, _payload} -> event
+        end)
+
+      assert order == [{:run, :start}, :before_query, :after_query, {:run, :stop}]
+    end
+
+    test ":stop fires on a cache hit with the caller's context and origin :cached" do
+      assert {:ok, _} = run(context: %{user: "a"})
+      drain()
+
+      assert {:ok, _} = run(context: %{user: "b"})
+
+      assert_received {:run_event, [:lotus, :run, :stop], %{duration: _, row_count: 2}, metadata}
+      assert metadata.context == %{user: "b"}
+      assert metadata.origin == :cached
+      assert metadata.relations == [{"public", "test_users"}]
+      assert metadata.source == "postgres"
+    end
+
+    test ":exception fires on a :before_query halt with the phase and the caller's context" do
+      Middleware.compile(%{before_query: [{DenyUserPlug, []}]})
+
+      assert {:error, "denied"} = run(context: %{user: "b"})
+
+      assert_received {:run_event, [:lotus, :run, :exception], %{duration: _}, metadata}
+      assert metadata.phase == :before_query
+      assert metadata.reason == "denied"
+      assert metadata.context == %{user: "b"}
+      refute_received {:run_event, [:lotus, :run, :stop], _, _}
+    end
+
+    test ":exception fires on a :before_execute halt on a cache hit" do
+      Middleware.compile(%{before_execute: [{DenyUserPlug, []}]})
+
+      assert {:ok, _} = run(context: %{user: "a"})
+      drain()
+
+      assert {:error, "denied"} = run(context: %{user: "b"})
+
+      assert_received {:run_event, [:lotus, :run, :exception], _, metadata}
+      assert metadata.phase == :before_execute
+      assert metadata.origin == :cached
+      assert metadata.context == %{user: "b"}
+    end
+
+    test "the run events are listed" do
+      for event <- @run_events, do: assert(event in Lotus.Telemetry.events())
+    end
+  end
+
+  describe "preflight" do
+    test "analyze/4 returns the relations a statement touches" do
+      assert {:ok, [{"public", "test_users"}]} =
+               Preflight.analyze(@pg_adapter, Statement.new(@statement, []))
+    end
+
+    test "analyze/4 returns an empty list for a statement that touches nothing" do
+      assert {:ok, []} = Preflight.analyze(@pg_adapter, Statement.new("SELECT 1", []))
+    end
+
+    test "analyze/4 returns the error for a blocked relation" do
+      stub(Config, :visibility_resolver, fn -> DenyingResolver end)
+
+      assert {:error, message} = Preflight.analyze(@pg_adapter, Statement.new(@statement, []))
+      assert message =~ "blocked"
+    end
+
+    test "a run leaves nothing in the process dictionary, on success and on a halt" do
+      assert {:ok, _} = run(context: %{user: "a"})
+      assert Process.get(:lotus_preflight_relations) == nil
+
+      Middleware.compile(%{before_execute: [{DenyUserPlug, []}]})
+      assert {:error, "denied"} = run(context: %{user: "b"})
+      assert Process.get(:lotus_preflight_relations) == nil
+    end
+  end
+end

--- a/test/lotus/runner_test.exs
+++ b/test/lotus/runner_test.exs
@@ -1265,10 +1265,10 @@ defmodule Lotus.RunnerTest do
 
     # `exec_read_only/3` rescues, and `Middleware.run/2` turns a raising plug
     # into `{:halt, _}`, so no exception escapes `run_statement/3` as the code
-    # stands — the `try/after` is defence in depth. Stubbing both boundaries
-    # forces the raise this pins: whatever else changes, an exception must not
-    # strand relations for the next statement.
-    test "a raise does not strand relations for the next statement" do
+    # stands. Stubbing both boundaries forces the raise this pins: whatever a
+    # raising run leaves in the process dictionary, the next statement's column
+    # policies come from its own preflight and nothing else.
+    test "a raise does not lend relations to the next statement" do
       Lotus.Middleware
       |> stub(:run, fn
         :before_query, payload ->
@@ -1286,7 +1286,20 @@ defmodule Lotus.RunnerTest do
         Runner.run_statement(@pg_adapter, Statement.new("SELECT 1"))
       end
 
-      assert Relations.get() == []
+      Lotus.Source.Adapter
+      |> stub(:sanitize_query, fn _adapter, _statement, _opts -> :ok end)
+
+      Lotus.Config
+      |> stub(:column_rules_for_source_name, fn _source ->
+        [{"test_users", "search_path", [mask: {:fixed, "REDACTED"}]}]
+      end)
+
+      # `SHOW` skips preflight, so the stranded value is the only candidate
+      # for its column policy — and it must not be used.
+      assert {:ok, %{columns: ["search_path"], rows: [[path]]}} =
+               Runner.run_statement(@pg_adapter, Statement.new("SHOW search_path"))
+
+      assert path != "REDACTED"
     end
   end
 end


### PR DESCRIPTION
Closes #268 and #264. Everything here touches the `[Unreleased]` middleware events, so the contract is set once, before it ships.

## The contract

- **`:relations` follows one rule** (#268). A list is the set preflight proved; an empty list means the statement touches no relation (`SELECT 1`). A tuple means unknown: `{:unrestricted, reason}` when the adapter cannot name relations and the host opted in, `{:skipped, reason}` when the adapter does not preflight the statement (the SQL adapters skip `EXPLAIN`, `SHOW`, `PRAGMA`). A gate writes `when is_list(relations)` and refuses any tuple. Until now a skipped preflight was indistinguishable from an empty set, so a gate that followed the documented rule refused every constant query.
- **`:after_query` carries `:relations` and `:origin`** (#264), the same relations `:before_execute` received, on every path. `:before_execute` carries `:origin` too: `:executed` or `:cached`.
- **One composition point.** `Lotus.Runner.run/4` runs the phases around an execute step. `run_statement/3` uses the default step; `Lotus` supplies a step that consults the result cache. Both paths share the phase order, the payloads and the telemetry, and the gate on a cache hit now lives in the runner rather than in the cache code.
- **A run-level telemetry span.** `[:lotus, :run, :start | :stop | :exception]` bracket the whole run, from `:before_query` to `:after_query`, on every path. The query events cover only the execute step, so a cache-served read and a run halted before execution emitted nothing; an audit consumer could see neither unless it was the plug that refused. `:stop` carries the statement that ran, the result, relations and origin; `:exception` carries the phase that failed and the reason; all carry the caller's context. A raise inside a run closes the span before it propagates. The existing `[:lotus, :query, *]` events are unchanged.
- **Preflight returns its relations.** `Lotus.Preflight.analyze/4` returns `{:ok, relations} | {:error, reason}`; `authorize/4` stays as a thin wrapper. The runner carries the value explicitly and no longer reads or writes the process dictionary, which is where both #258 bugs came from. The `Relations` module keeps its functions for callers that use them; the runner does not.
- The middleware guide gains a "contract" section: phase order, cache-hit guarantees, additive payload keys, the relations rule, halting, and where observation belongs.

## Tests

`test/lotus/middleware_contract_test.exs`, written first and watched fail (12 of 14 on the current code):

- `[]` for `SELECT 1`; `{:skipped, _}` for `EXPLAIN SELECT 1`.
- `:after_query` carries the relations `:before_execute` saw and `origin: :executed` on a miss; both carry the stored relations and `origin: :cached` on a hit; the uncached runner path carries the same keys.
- The run span brackets `:before_query` through `:after_query`; `:stop` fires on a cache hit with the caller's context and `origin: :cached`; `:exception` fires on a `:before_query` halt and on a `:before_execute` halt on a cache hit, with the phase and context; the events are listed.
- `Preflight.analyze/4` returns the relations, an empty list, or the blocked error; a run leaves nothing in the process dictionary on success or on a halt.

Three existing tests pinned the process-dictionary mechanism (they seeded it and expected the runner to clear it). They now pin the behaviour instead: a stranded value never reaches a payload or a column policy, on a hit or on a miss, and after a raise.

Full suite 1998 tests green; `mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` and `mix docs` clean.